### PR TITLE
fix: remove custom width and margin from diagnostics wrap

### DIFF
--- a/assets/css/diagnostics.css
+++ b/assets/css/diagnostics.css
@@ -1,8 +1,6 @@
 /* Modern, Clean Diagnostic Interface */
         .wrap {
             max-width: none !important;
-            margin: 0 20px 0 0;
-            width: calc(100% - 20px) !important;
         }
         
         .wrap h1 {
@@ -626,11 +624,6 @@
         }
         
         @media (max-width: 782px) {
-            .wrap {
-                width: 100% !important;
-                margin-right: 0;
-            }
-            
             .hic-diagnostics-container .card {
                 padding: 16px;
                 margin-bottom: 12px;


### PR DESCRIPTION
## Summary
- rely on standard WordPress layout by dropping custom width and margin from diagnostics wrapper

## Testing
- `php -l includes/admin/diagnostics.php`
- `php tests/test-functions.php` *(fails: GTM should be enabled when option is "1")*


------
https://chatgpt.com/codex/tasks/task_e_68bb2ffbaee8832fa94c05ebbd6bb1ed