### PR TITLE
Secure monitor AJAX endpoints with nonce checks

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -1,12 +1,30 @@
 jQuery(document).ready(function($) {
-        
+
     // Ensure ajaxurl is defined for AJAX calls
     if (typeof ajaxurl === 'undefined') {
         var ajaxurl = hicDiagnostics.ajax_url;
     }
-        
+
+    // Helper functions for monitoring endpoints with security nonce
+    window.hicRunHealthCheck = function(level, callback) {
+        $.post(ajaxurl, {
+            action: 'hic_health_check',
+            nonce: hicDiagnostics.monitor_nonce,
+            level: level || 'basic'
+        }, callback, 'json');
+    };
+
+    window.hicGetPerformanceMetrics = function(type, days, callback) {
+        $.post(ajaxurl, {
+            action: 'hic_performance_metrics',
+            nonce: hicDiagnostics.monitor_nonce,
+            type: type || 'summary',
+            days: days || 7
+        }, callback, 'json');
+    };
+
         // Enhanced UI functionality
-        
+
         // Toast notification system
         function showToast(message, type = 'info', duration = 5000) {
             var toastContainer = $('#hic-toast-container');

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -235,6 +235,7 @@ function hic_admin_enqueue_scripts($hook) {
             'ajax_url' => admin_url('admin-ajax.php'),
             'diagnostics_nonce' => wp_create_nonce('hic_diagnostics_nonce'),
             'admin_nonce' => wp_create_nonce('hic_admin_action'),
+            'monitor_nonce' => wp_create_nonce('hic_monitor_nonce'),
             'is_api_connection' => (hic_get_connection_type() === 'api'),
             'has_basic_auth' => hic_has_basic_auth_credentials(),
             'has_property_id' => (bool) hic_get_property_id(),

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -440,14 +440,18 @@ class HIC_Health_Monitor {
      * AJAX health check handler
      */
     public function ajax_health_check() {
-        if (!current_user_can('manage_options')) {
-            wp_die(json_encode(['error' => 'Insufficient permissions']));
+        if (!check_ajax_referer('hic_monitor_nonce', 'nonce', false)) {
+            wp_send_json(['error' => 'Invalid nonce'], 403);
         }
-        
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json(['error' => 'Insufficient permissions'], 403);
+        }
+
         $level = sanitize_text_field($_GET['level'] ?? HIC_DIAGNOSTIC_BASIC);
         $health_data = $this->check_health($level);
-        
-        wp_die(json_encode($health_data));
+
+        wp_send_json($health_data);
     }
     
     /**
@@ -459,8 +463,8 @@ class HIC_Health_Monitor {
             'timestamp' => current_time('mysql'),
             'version' => HIC_PLUGIN_VERSION
         ];
-        
-        wp_die(json_encode($health_data));
+
+        wp_send_json($health_data);
     }
     
     /**

--- a/includes/performance-monitor.php
+++ b/includes/performance-monitor.php
@@ -447,13 +447,17 @@ class HIC_Performance_Monitor {
      * AJAX handler for getting metrics
      */
     public function ajax_get_metrics() {
-        if (!current_user_can('manage_options')) {
-            wp_die(json_encode(['error' => 'Insufficient permissions']));
+        if (!check_ajax_referer('hic_monitor_nonce', 'nonce', false)) {
+            wp_send_json(['error' => 'Invalid nonce'], 403);
         }
-        
+
+        if (!current_user_can('manage_options')) {
+            wp_send_json(['error' => 'Insufficient permissions'], 403);
+        }
+
         $type = sanitize_text_field($_GET['type'] ?? 'summary');
         $days = absint($_GET['days'] ?? 7);
-        
+
         switch ($type) {
             case 'summary':
                 $data = $this->get_performance_summary($days);
@@ -467,8 +471,8 @@ class HIC_Performance_Monitor {
             default:
                 $data = ['error' => 'Invalid type'];
         }
-        
-        wp_die(json_encode($data));
+
+        wp_send_json($data);
     }
     
     /**


### PR DESCRIPTION
## Summary
- validate health check and performance metrics AJAX handlers via nonce
- standardize responses with `wp_send_json`
- expose `hic_monitor_nonce` to admin scripts and send it in monitoring requests

## Testing
- `php tests/test-functions.php`
- `php -r 'require "tests/bootstrap.php"; function add_action(){} function check_ajax_referer($a,$b,$c=false){return isset($_REQUEST[$b]) && $_REQUEST[$b]=="valid";} function wp_send_json($data,$code=200){echo json_encode($data);exit;} function current_user_can($cap){return true;} require "includes/health-monitor.php"; class HM_Test extends HIC_Health_Monitor{public function __construct(){} public function check_health($level=HIC_DIAGNOSTIC_BASIC){return ["ok"=>true];}} $hm=new HM_Test(); $hm->ajax_health_check();'`
- `php -r 'require "tests/bootstrap.php"; $_REQUEST["nonce"]="valid"; function add_action(){} function check_ajax_referer($a,$b,$c=false){return isset($_REQUEST[$b]) && $_REQUEST[$b]=="valid";} function wp_send_json($data,$code=200){echo json_encode($data);exit;} function current_user_can($cap){return true;} require "includes/health-monitor.php"; class HM_Test extends HIC_Health_Monitor{public function __construct(){} public function check_health($level=HIC_DIAGNOSTIC_BASIC){return ["ok"=>true];}} $hm=new HM_Test(); $hm->ajax_health_check();'`
- `php -r 'require "tests/bootstrap.php"; function add_action(){} function check_ajax_referer($a,$b,$c=false){return isset($_REQUEST[$b]) && $_REQUEST[$b]=="valid";} function wp_send_json($data,$code=200){echo json_encode($data);exit;} function current_user_can($cap){return true;} require "includes/performance-monitor.php"; class PM_Test extends HIC_Performance_Monitor{public function __construct(){} public function get_performance_summary($days = 7){return ["summary"=>$days];} public function get_api_stats($days = 7){return ["api"=>$days];} public function get_system_resources(){return ["resources"=>true];}} $pm=new PM_Test(); $_GET["type"]="summary"; $_GET["days"]=1; $pm->ajax_get_metrics();'`
- `php -r 'require "tests/bootstrap.php"; $_REQUEST["nonce"]="valid"; function add_action(){} function check_ajax_referer($a,$b,$c=false){return isset($_REQUEST[$b]) && $_REQUEST[$b]=="valid";} function wp_send_json($data,$code=200){echo json_encode($data);exit;} function current_user_can($cap){return true;} require "includes/performance-monitor.php"; class PM_Test extends HIC_Performance_Monitor{public function __construct(){} public function get_performance_summary($days = 7){return ["summary"=>$days];} public function get_api_stats($days = 7){return ["api"=>$days];} public function get_system_resources(){return ["resources"=>true];}} $pm=new PM_Test(); $_GET["type"]="summary"; $_GET["days"]=1; $pm->ajax_get_metrics();'`


------
https://chatgpt.com/codex/tasks/task_e_68bb31d6d334832f8117fadefbc9c676