### PR TITLE
Use helper to extract reservation ID in polling update handler

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -1010,8 +1010,8 @@ function hic_process_update(array $u){
     }
     
     // Get reservation ID with proper validation
-    $id = isset($u['id']) ? $u['id'] : null;
-    if (empty($id) || !is_scalar($id)) {
+    $id = hic_extract_reservation_id($u);
+    if (empty($id)) {
         hic_log('hic_process_update: missing or invalid reservation id');
         return;
     }


### PR DESCRIPTION
## Summary
- Use `hic_extract_reservation_id()` to read reservation ID in `hic_process_update`
- Log and return early if ID missing, ensuring subsequent calls use the extracted ID

## Testing
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb39d79758832f96d7819f96846327