### PR TITLE
Use booking UID in reservation transformation errors

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -785,7 +785,8 @@ function hic_process_single_reservation($reservation) {
     if ($transformed !== false && is_array($transformed)) {
         hic_dispatch_reservation($transformed, $reservation);
     } else {
-        throw new Exception("Failed to transform reservation " . ($reservation['id'] ?? 'unknown'));
+        $uid = hic_booking_uid($reservation);
+        throw new Exception('Failed to transform reservation ' . ($uid ?: 'unknown'));
     }
 }
 


### PR DESCRIPTION
## Summary
- Use `hic_booking_uid` when throwing reservation transformation exceptions to include reliable booking identifier

## Testing
- `php tests/test-functions.php`
- `php -r 'require "tests/bootstrap.php"; function hic_transform_reservation($r){ return false; } function hic_dispatch_reservation($t,$r){} function hic_process_single_reservation($reservation){ $transformed = hic_transform_reservation($reservation); if ($transformed !== false && is_array($transformed)) { hic_dispatch_reservation($transformed, $reservation); } else { $uid = hic_booking_uid($reservation); throw new Exception("Failed to transform reservation " . ($uid ?: "unknown")); } } $reservation=["id"=>"ABC123"]; try { hic_process_single_reservation($reservation); } catch (Exception $e) { hic_log("Process reservation error: ".$e->getMessage()); } echo file_get_contents(sys_get_temp_dir()."/hic-log.txt");'`

------
https://chatgpt.com/codex/tasks/task_e_68bb3d1dd420832fae01b984e6127f54