### PR TITLE
fix: use reservation ID extraction helper

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -1075,8 +1075,8 @@ function hic_process_new_reservation_for_realtime($reservation_data) {
         return;
     }
 
-    $reservation_id = isset($reservation_data['id']) ? $reservation_data['id'] : null;
-    if (empty($reservation_id)) {
+    $reservation_id = hic_extract_reservation_id($reservation_data);
+    if (!$reservation_id) {
         hic_log('Cannot process new reservation: missing reservation ID');
         return;
     }


### PR DESCRIPTION
## Summary
- replace raw reservation ID access with `hic_extract_reservation_id`
- guard real-time notification logic behind populated reservation IDs

## Testing
- `php tests/test-functions.php`
- `php -l includes/api/polling.php`


------
https://chatgpt.com/codex/tasks/task_e_68bb3fba6074832f8f8cd46124262453