### PR TITLE
Handle phone fallback in reservations

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -394,7 +394,7 @@ function hic_transform_reservation($reservation) {
         'guest_first_name' => $first,
         'guest_last_name' => $last,
         'email' => $email,
-        'phone' => isset($reservation['phone']) ? $reservation['phone'] : '',
+        'phone' => $reservation['phone'] ?? $reservation['whatsapp'] ?? '',
         'language' => $language,
         'original_price' => $price
     );
@@ -495,6 +495,7 @@ function hic_dispatch_reservation($transformed, $original) {
                 'first_name'    => isset($transformed['guest_first_name']) ? $transformed['guest_first_name'] : '',
                 'last_name'     => isset($transformed['guest_last_name']) ? $transformed['guest_last_name'] : '',
                 'email'         => isset($transformed['email']) ? $transformed['email'] : '',
+                'phone'         => isset($transformed['phone']) ? $transformed['phone'] : '',
                 'lingua'        => isset($transformed['language']) ? $transformed['language'] : '',
                 'room'          => isset($transformed['accommodation_name']) ? $transformed['accommodation_name'] : (isset($transformed['room_name']) ? $transformed['room_name'] : ''),
                 'checkin'       => isset($transformed['from_date']) ? $transformed['from_date'] : '',

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -403,6 +403,7 @@ function hic_send_admin_email($data, $gclid, $fbclid, $sid){
   $body .= "Importo: " . (isset($data['amount']) ? hic_normalize_price($data['amount']) : '0') . " " . ($data['currency'] ?? 'EUR') . "\n";
   $body .= "Nome: " . trim(($data['first_name'] ?? '') . ' ' . ($data['last_name'] ?? '')) . "\n";
   $body .= "Email: " . ($data['email'] ?? 'n/a') . "\n";
+  $body .= "Telefono: " . ($data['phone'] ?? 'n/a') . "\n";
   $body .= "Lingua: " . ($data['lingua'] ?? ($data['lang'] ?? 'n/a')) . "\n";
   $body .= "Camera: " . ($data['room'] ?? 'n/a') . "\n";
   $body .= "Check-in: " . ($data['checkin'] ?? 'n/a') . "\n";

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -94,8 +94,23 @@ class HICFunctionsTest {
         assert(is_string(hic_get_api_secret()), 'API Secret should return string');
         assert(is_bool(hic_is_brevo_enabled()), 'Brevo enabled should return boolean');
         assert(is_bool(hic_is_debug_verbose()), 'Debug verbose should return boolean');
-        
+
         echo "✅ Configuration helper tests passed\n";
+    }
+
+    public function testReservationPhoneFallback() {
+        if (!function_exists('add_action')) {
+            function add_action(...$args) {}
+        }
+        require_once dirname(__DIR__) . '/includes/api/polling.php';
+
+        $res = hic_transform_reservation(['whatsapp' => '12345']);
+        assert($res['phone'] === '12345', 'Should use whatsapp when phone is missing');
+
+        $res2 = hic_transform_reservation(['phone' => '67890', 'whatsapp' => '12345']);
+        assert($res2['phone'] === '67890', 'Should prioritize phone over whatsapp');
+
+        echo "✅ Reservation phone fallback tests passed\n";
     }
     
     public function runAll() {
@@ -108,7 +123,8 @@ class HICFunctionsTest {
             $this->testPriceNormalization();
             $this->testOTAEmailDetection();
             $this->testConfigurationHelpers();
-            
+            $this->testReservationPhoneFallback();
+
             echo "\n🎉 All tests passed successfully!\n";
         } catch (AssertionError $e) {
             echo "\n❌ Test failed: " . $e->getMessage() . "\n";


### PR DESCRIPTION
## Summary
- Capture guest phone from `phone` or `whatsapp` fields when transforming reservations
- Include guest phone in admin notification emails
- Add tests for phone fallback in reservations

## Testing
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbd6cf4580832fb90de9506e2a20d4