### PR TITLE
Add checkin/checkout fallback for Brevo webhook

### DIFF
--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -624,8 +624,8 @@ function hic_transform_webhook_data_for_brevo($webhook_data) {
     'phone' => isset($webhook_data['whatsapp']) ? $webhook_data['whatsapp'] : (isset($webhook_data['phone']) ? $webhook_data['phone'] : ''),
     'original_price' => isset($webhook_data['amount']) ? hic_normalize_price($webhook_data['amount']) : 0,
     'currency' => isset($webhook_data['currency']) ? $webhook_data['currency'] : 'EUR',
-    'from_date' => isset($webhook_data['date']) ? $webhook_data['date'] : '',
-    'to_date' => isset($webhook_data['to_date']) ? $webhook_data['to_date'] : '',
+    'from_date' => $webhook_data['date'] ?? $webhook_data['checkin'] ?? '',
+    'to_date'   => $webhook_data['to_date'] ?? $webhook_data['checkout'] ?? '',
     'accommodation_name' => isset($webhook_data['room']) ? $webhook_data['room'] : '',
     'guests' => isset($webhook_data['guests']) ? $webhook_data['guests'] : 1,
     'language' => isset($webhook_data['lingua']) ? $webhook_data['lingua'] : (isset($webhook_data['lang']) ? $webhook_data['lang'] : '')


### PR DESCRIPTION
## Summary
- Ensure Brevo webhook transformation supports `checkin`/`checkout` when `date`/`to_date` are missing

## Testing
- `php tests/test-functions.php`
- `php -r 'require "tests/bootstrap.php"; require "includes/integrations/brevo.php"; $payload=["checkin"=>"2024-06-01","checkout"=>"2024-06-07","amount"=>"100"]; var_export(hic_transform_webhook_data_for_brevo($payload)); echo "\n";'`


------
https://chatgpt.com/codex/tasks/task_e_68bbd7741e1c832f9744922b267e504a