### PR TITLE
Include phone number in Meta CAPI events

### DIFF
--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -48,8 +48,9 @@ function hic_send_to_fb($data, $gclid, $fbclid){
   if (!empty($data['last_name']) && is_string($data['last_name'])) {
     $user_data['ln'] = [ hash('sha256', strtolower(trim($data['last_name']))) ];
   }
-  if (!empty($data['whatsapp']) && is_string($data['whatsapp'])) {
-    $user_data['ph'] = [ hash('sha256', preg_replace('/\D/','', $data['whatsapp'])) ];
+  $phone = $data['whatsapp'] ?? $data['phone'] ?? '';
+  if (!empty($phone) && is_string($phone)) {
+    $user_data['ph'] = [ hash('sha256', preg_replace('/\D/','', $phone)) ];
   }
 
   $payload = [


### PR DESCRIPTION
## Summary
- include `whatsapp` or `phone` value in Facebook CAPI user data

## Testing
- `php -l includes/integrations/facebook.php`
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbda2a4d28832f8f739c05b97a902f