### PR TITLE
Use accommodation fallback for event item names

### DIFF
--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -66,7 +66,7 @@ function hic_send_to_fb($data, $gclid, $fbclid){
         'value'        => $amount,
         'order_id'     => $event_id,
         'bucket'       => $bucket,           // per creare custom conversions per fbads/organic/gads
-        'content_name' => sanitize_text_field($data['room'] ?? 'Prenotazione'),
+        'content_name' => sanitize_text_field($data['room'] ?? $data['accommodation_name'] ?? 'Prenotazione'),
         'vertical'     => 'hotel'
       ]
     ]]

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -42,7 +42,7 @@ function hic_send_to_ga4($data, $gclid, $fbclid) {
     'currency'       => sanitize_text_field($data['currency'] ?? 'EUR'),
     'value'          => $amount,
     'items'          => [[
-      'item_name' => sanitize_text_field($data['room'] ?? 'Prenotazione'),
+      'item_name' => sanitize_text_field($data['room'] ?? $data['accommodation_name'] ?? 'Prenotazione'),
       'quantity'  => 1,
       'price'     => $amount
     ]],


### PR DESCRIPTION
## Summary
- ensure GA4 purchase events fall back to `accommodation_name` when room is missing
- align Facebook custom data `content_name` with the same fallback
- test GA4/Facebook event payloads for room/accommodation defaults

## Testing
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbdc626ec4832f98f9ab21b235851e