### PR TITLE
refactor: use global polling constants

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -6,10 +6,6 @@
 
 if (!defined('ABSPATH')) exit;
 
-// Define constants for better maintainability
-define('HIC_POLL_INTERVAL_SECONDS', 300);  // 5 minutes
-define('HIC_RETRY_INTERVAL_SECONDS', 900); // 15 minutes
-
 /**
  * Validate and sanitize timestamp for API requests
  * Ensures timestamp is within acceptable range for HIC API


### PR DESCRIPTION
## Summary
- reference global polling constants in booking poller
- drop unused interval constants in API polling handler

## Testing
- `php -l includes/booking-poller.php`
- `php -l includes/api/polling.php`
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbdf982f08832f986b02a440d6a8ce