### PR TITLE
Refactor logging to use central manager

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -542,16 +542,23 @@ function hic_mark_reservation_processed($reservation) {
 // Wrapper function - now simplified to use continuous polling by default
 function hic_api_poll_bookings(){
     $start_time = microtime(true);
-    hic_log('Internal Scheduler: hic_api_poll_bookings execution started');
-    
-    // Rotate log if needed
-    hic_rotate_log_if_needed();
+    $log_manager = hic_get_log_manager();
+    if ($log_manager) {
+        $log_manager->info('Internal Scheduler: hic_api_poll_bookings execution started');
+        $log_manager->rotate_if_needed();
+    } else {
+        error_log('Internal Scheduler: hic_api_poll_bookings execution started');
+    }
     
     // Use the new simplified continuous polling
     hic_api_poll_bookings_continuous();
     
     $execution_time = round((microtime(true) - $start_time) * 1000, 2);
-    hic_log("Internal Scheduler: hic_api_poll_bookings completed in {$execution_time}ms");
+    if ($log_manager) {
+        $log_manager->info("Internal Scheduler: hic_api_poll_bookings completed in {$execution_time}ms");
+    } else {
+        error_log("Internal Scheduler: hic_api_poll_bookings completed in {$execution_time}ms");
+    }
 }
 
 /**

--- a/includes/log-manager.php
+++ b/includes/log-manager.php
@@ -39,7 +39,7 @@ class HIC_Log_Manager {
         }
         
         // Rotate log if needed
-        $this->rotate_log_if_needed();
+        $this->rotate_if_needed();
         
         // Format log entry
         $formatted_message = $this->format_log_entry($message, $level, $context);
@@ -148,19 +148,26 @@ class HIC_Log_Manager {
     }
     
     /**
-     * Rotate log file if it's too large
+     * Rotate log file if it exceeds the configured size
      */
-    private function rotate_log_if_needed() {
+    public function rotate_if_needed() {
         if (!file_exists($this->log_file)) {
-            return;
+            return false;
         }
-        
-        $file_size = filesize($this->log_file);
-        if ($file_size <= $this->max_size) {
-            return;
+
+        // Suppress potential warnings if the file is locked
+        $file_size = @filesize($this->log_file);
+        if ($file_size === false) {
+            error_log('HIC Plugin: Cannot get log file size: ' . $this->log_file);
+            return false;
         }
-        
-        $this->rotate_log();
+
+        if ($file_size > $this->max_size) {
+            $this->rotate_log();
+            return true;
+        }
+
+        return true;
     }
     
     /**


### PR DESCRIPTION
## Summary
- Delegate hic_log to centralized HIC_Log_Manager and drop old rotation helper
- Expose rotation logic within HIC_Log_Manager
- Update polling scheduler to use log manager for rotation and messages

## Testing
- `composer test` *(fails: Command "test" is not defined)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe0b9c088832f9b2fdf45948e2da6