### PR TITLE
Refactor tracking ID lookup and reuse helper

### DIFF
--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -34,30 +34,9 @@ function hic_process_booking_data($data) {
   $fbclid = null;
 
   if ($sid) {
-    global $wpdb;
-    
-    // Check if wpdb is available
-    if (!$wpdb) {
-      hic_log('hic_process_booking_data: wpdb is not available');
-      return false;
-    }
-    
-    $table = $wpdb->prefix . 'hic_gclids';
-    
-    // Check if table exists before querying
-    $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
-    if ($table_exists) {
-      $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $sid));
-      
-      if ($wpdb->last_error) {
-        hic_log('hic_process_booking_data: Database error retrieving gclid/fbclid: ' . $wpdb->last_error);
-      } else if ($row) { 
-        $gclid = $row->gclid; 
-        $fbclid = $row->fbclid; 
-      }
-    } else {
-      hic_log('hic_process_booking_data: Table does not exist: ' . $table);
-    }
+    $tracking = hic_get_tracking_ids_by_sid($sid);
+    $gclid = $tracking['gclid'];
+    $fbclid = $tracking['fbclid'];
   }
 
   // Validation for amount if present

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -146,19 +146,9 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
   // Get gclid/fbclid for legacy compatibility
   // Use provided values when available before querying the database
   if (!empty($data['transaction_id']) && (empty($gclid) || empty($fbclid))) {
-    global $wpdb;
-    $table = $wpdb->prefix . 'hic_gclids';
-
-    // Check if table exists before querying
-    $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
-    if ($table_exists) {
-      // Try to find tracking data using transaction_id as sid
-      $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $data['transaction_id']));
-      if ($row) {
-        if (empty($gclid)) { $gclid = $row->gclid ?: ''; }
-        if (empty($fbclid)) { $fbclid = $row->fbclid ?: ''; }
-      }
-    }
+    $tracking = hic_get_tracking_ids_by_sid($data['transaction_id']);
+    if (empty($gclid)) { $gclid = $tracking['gclid'] ?? ''; }
+    if (empty($fbclid)) { $fbclid = $tracking['fbclid'] ?? ''; }
   }
 
   $attributes = array(
@@ -303,19 +293,9 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
 
   // Get gclid/fbclid for bucket normalization if available
   if (!empty($data['transaction_id']) && (empty($gclid) || empty($fbclid))) {
-    global $wpdb;
-    $table = $wpdb->prefix . 'hic_gclids';
-
-    // Check if table exists before querying
-    $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
-    if ($table_exists) {
-      // Try to find tracking data using transaction_id as sid
-      $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $data['transaction_id']));
-      if ($row) {
-        if (empty($gclid)) { $gclid = $row->gclid ?: ''; }
-        if (empty($fbclid)) { $fbclid = $row->fbclid ?: ''; }
-      }
-    }
+    $tracking = hic_get_tracking_ids_by_sid($data['transaction_id']);
+    if (empty($gclid)) { $gclid = $tracking['gclid'] ?? ''; }
+    if (empty($fbclid)) { $fbclid = $tracking['fbclid'] ?? ''; }
   }
 
   $bucket = fp_normalize_bucket($gclid, $fbclid);

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -158,19 +158,9 @@ function hic_dispatch_pixel_reservation($data) {
   $gclid = '';
   $fbclid = '';
   if (!empty($data['transaction_id'])) {
-    global $wpdb;
-    $table = $wpdb->prefix . 'hic_gclids';
-    
-    // Check if table exists before querying
-    $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
-    if ($table_exists) {
-      // Try to find tracking data using transaction_id as sid
-      $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $data['transaction_id']));
-      if ($row) { 
-        $gclid = $row->gclid ?: ''; 
-        $fbclid = $row->fbclid ?: ''; 
-      }
-    }
+    $tracking = hic_get_tracking_ids_by_sid($data['transaction_id']);
+    $gclid = $tracking['gclid'] ?? '';
+    $fbclid = $tracking['fbclid'] ?? '';
   }
 
   $bucket = fp_normalize_bucket($gclid, $fbclid);

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -137,19 +137,9 @@ function hic_dispatch_ga4_reservation($data) {
   $gclid = '';
   $fbclid = '';
   if (!empty($data['transaction_id'])) {
-    global $wpdb;
-    $table = $wpdb->prefix . 'hic_gclids';
-    
-    // Check if table exists before querying
-    $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
-    if ($table_exists) {
-      // Try to find tracking data using transaction_id as sid
-      $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $data['transaction_id']));
-      if ($row) { 
-        $gclid = $row->gclid ?: ''; 
-        $fbclid = $row->fbclid ?: ''; 
-      }
-    }
+    $tracking = hic_get_tracking_ids_by_sid($data['transaction_id']);
+    $gclid = $tracking['gclid'] ?? '';
+    $fbclid = $tracking['fbclid'] ?? '';
   }
 
   $bucket = fp_normalize_bucket($gclid, $fbclid);

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -236,19 +236,9 @@ function hic_dispatch_gtm_reservation($data) {
     $gclid = '';
     $fbclid = '';
     if (!empty($data['transaction_id'])) {
-        global $wpdb;
-        $table = $wpdb->prefix . 'hic_gclids';
-        
-        // Check if table exists before querying
-        $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
-        if ($table_exists) {
-            // Try to find tracking data using transaction_id as sid
-            $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $data['transaction_id']));
-            if ($row) { 
-                $gclid = $row->gclid ?: ''; 
-                $fbclid = $row->fbclid ?: ''; 
-            }
-        }
+        $tracking = hic_get_tracking_ids_by_sid($data['transaction_id']);
+        $gclid = $tracking['gclid'] ?? '';
+        $fbclid = $tracking['fbclid'] ?? '';
     }
 
     $bucket = fp_normalize_bucket($gclid, $fbclid);


### PR DESCRIPTION
## Summary
- add `hic_get_tracking_ids_by_sid` helper to centralize gclid/fbclid lookup
- replace direct database queries in booking processor and GA4, GTM, Facebook, Brevo integrations with helper

## Testing
- `php -d auto_prepend_file=/tmp/hic_stub.php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe1b2bb20832fa6ea9bb6a537d580