### PR TITLE
Introduce Composer autoloading

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,6 @@ hic-log*.txt
 # Temporary files
 *.tmp
 *.temp
+
+# Composer
+vendor/

--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -12,49 +12,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
-// Include constants first
-require_once __DIR__ . '/includes/constants.php';
-
-// Include core functionality files
-require_once __DIR__ . '/includes/functions.php';
-require_once __DIR__ . '/includes/database.php';
-require_once __DIR__ . '/includes/booking-processor.php';
-
-// Include integration files
-require_once __DIR__ . '/includes/integrations/ga4.php';
-require_once __DIR__ . '/includes/integrations/gtm.php';
-require_once __DIR__ . '/includes/integrations/facebook.php';
-require_once __DIR__ . '/includes/integrations/brevo.php';
-
-// Include API handlers
-require_once __DIR__ . '/includes/api/webhook.php';
-require_once __DIR__ . '/includes/api/polling.php';
-
-// Include new reliable booking poller
-require_once __DIR__ . '/includes/booking-poller.php';
-
-// Include enhanced log management
-require_once __DIR__ . '/includes/log-manager.php';
-
-// Include configuration validator
-require_once __DIR__ . '/includes/config-validator.php';
-
-// Include performance monitoring
-require_once __DIR__ . '/includes/performance-monitor.php';
-
-// Include health monitoring system
-require_once __DIR__ . '/includes/health-monitor.php';
-
-// Include CLI commands (only if WP-CLI is available)
-if (defined('WP_CLI') && WP_CLI) {
-    require_once __DIR__ . '/includes/cli.php';
-}
-
-// Include admin interface (only in admin area)
-if (is_admin()) {
-    require_once __DIR__ . '/includes/admin/admin-settings.php';
-    require_once __DIR__ . '/includes/admin/diagnostics.php';
-}
+// Load Composer autoloader
+require __DIR__ . '/vendor/autoload.php';
 
 // Plugin activation hook
 \register_activation_hook(__FILE__, 'hic_create_database_table');
@@ -65,16 +24,16 @@ if (is_admin()) {
 // Initialize enhanced systems when WordPress is ready
 \add_action('init', function() {
     // Initialize log manager
-    hic_get_log_manager();
+    \hic_get_log_manager();
 
     // Initialize performance monitor
-    hic_get_performance_monitor();
+    \hic_get_performance_monitor();
 
     // Initialize config validator
-    hic_get_config_validator();
+    \hic_get_config_validator();
 
     // Initialize health monitor
-    hic_get_health_monitor();
+    \hic_get_health_monitor();
 });
 
 // Enqueue frontend JavaScript

--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Il tutto avviene **automaticamente** tramite un **sistema interno di scheduling*
 - [Integrazione Google Tag Manager](GUIDA_GTM_INTEGRAZIONE.md) - GTM vs GA4, prevenzione doppia misurazione
 - [FAQ - Domande Frequenti](FAQ.md) - Risposte alle domande comuni
 
+## Installazione
+
+1. Eseguire `composer install` per generare il loader delle classi.
+2. Caricare il plugin normalmente in WordPress.
+
 ## Configurazione API
 
 ### API Hotel in Cloud

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,25 @@
+{
+    "name": "fp-hotel-in-cloud/monitoraggio-conversioni",
+    "description": "HIC GA4 + Brevo + Meta plugin",
+    "type": "wordpress-plugin",
+    "autoload": {
+        "psr-4": {
+            "FpHic\\": "includes/"
+        },
+        "files": [
+            "includes/constants.php",
+            "includes/functions.php",
+            "includes/database.php",
+            "includes/booking-processor.php",
+            "includes/integrations/ga4.php",
+            "includes/integrations/gtm.php",
+            "includes/integrations/facebook.php",
+            "includes/integrations/brevo.php",
+            "includes/api/webhook.php",
+            "includes/api/polling.php",
+            "includes/cli.php",
+            "includes/admin/admin-settings.php",
+            "includes/admin/diagnostics.php"
+        ]
+    }
+}

--- a/composer.lock
+++ b/composer.lock
@@ -1,0 +1,18 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "1b868afe246784cc7342cf13a16d6564",
+    "packages": [],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": {},
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": {},
+    "platform-dev": {},
+    "plugin-api-version": "2.6.0"
+}


### PR DESCRIPTION
## Summary
- add Composer configuration with PSR-4 autoload pointing to `includes/`
- remove manual file includes in plugin bootstrap and load Composer autoloader
- document installing dependencies with `composer install`

## Testing
- `composer install`
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bbe69d1d94832f9737a615d067dd2c