### PR TITLE
Add deactivation cleanup for cron and transient data

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -14,9 +14,11 @@ if (!defined('ABSPATH')) {
 
 // Load Composer autoloader
 require __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/includes/booking-poller.php';
 
 // Plugin activation hook
 \register_activation_hook(__FILE__, 'hic_create_database_table');
+\register_deactivation_hook(__FILE__, 'hic_deactivate');
 
 // Initialize tracking parameters capture
 \add_action('init', 'hic_capture_tracking_params');


### PR DESCRIPTION
## Summary
- Register deactivation hook to clean up on plugin shutdown
- Implement `hic_deactivate` to clear cron events, transients and temporary options

## Testing
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbe86cd7c0832fa58d4c2462252a56