### PR TITLE
Add HIC Monitoring top-level menu with diagnostics submenu

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -87,18 +87,19 @@ function hic_ajax_test_api_connection() {
 }
 
 function hic_add_admin_menu() {
-    add_options_page(
+    add_menu_page(
         'HIC Monitoring Settings',
         'HIC Monitoring',
         'manage_options',
         'hic-monitoring',
         'hic_options_page'
     );
-    
+
     // Add diagnostics submenu
-    add_options_page(
-        'HIC Diagnostics',
-        'HIC Diagnostics',
+    add_submenu_page(
+        'hic-monitoring',
+        'Diagnostics',
+        'Diagnostics',
         'manage_options',
         'hic-diagnostics',
         'hic_diagnostics_page'
@@ -213,7 +214,7 @@ function hic_settings_init() {
  */
 function hic_admin_enqueue_scripts($hook) {
     // Only load on our plugin pages
-    if ($hook === 'settings_page_hic-diagnostics' || $hook === 'settings_page_hic-monitoring') {
+    if ($hook === 'hic-monitoring_page_hic-diagnostics' || $hook === 'toplevel_page_hic-monitoring') {
         // Ensure jQuery is loaded
         wp_enqueue_script('jquery');
 
@@ -225,7 +226,7 @@ function hic_admin_enqueue_scripts($hook) {
         ');
     }
 
-    if ($hook === 'settings_page_hic-diagnostics') {
+    if ($hook === 'hic-monitoring_page_hic-diagnostics') {
         wp_enqueue_style(
             'hic-diagnostics',
             plugin_dir_url(__FILE__) . '../../assets/css/diagnostics.css',


### PR DESCRIPTION
## Summary
- Convert HIC Monitoring settings to a top-level admin menu
- Add Diagnostics as a submenu under HIC Monitoring
- Update admin enqueue hooks for new menu slugs

## Testing
- `php tests/test-functions.php`

------
https://chatgpt.com/codex/tasks/task_e_68bbef4b3934832f957001341865309b