### PR TITLE
Add validation for log file option

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -119,7 +119,11 @@ function hic_settings_init() {
     register_setting('hic_settings', 'hic_admin_email', array(
         'sanitize_callback' => 'hic_validate_admin_email'
     ));
-    register_setting('hic_settings', 'hic_log_file');
+    register_setting(
+        'hic_settings',
+        'hic_log_file',
+        array('sanitize_callback' => '\\FpHic\\Helpers\\hic_validate_log_path')
+    );
     register_setting('hic_settings', 'hic_connection_type');
     register_setting('hic_settings', 'hic_api_url');
     // New Basic Auth settings

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -43,6 +43,24 @@ function hic_reliable_polling_enabled() { return hic_get_option('reliable_pollin
 function hic_get_admin_email() { return hic_get_option('admin_email', get_option('admin_email')); }
 function hic_get_log_file() { return hic_get_option('log_file', WP_CONTENT_DIR . '/hic-log.txt'); }
 
+function hic_validate_log_path($path) {
+    $default = WP_CONTENT_DIR . '/hic-log.txt';
+
+    $path = sanitize_text_field($path);
+    if (empty($path)) {
+        return $default;
+    }
+
+    $normalized_path = str_replace('\\', '/', $path);
+    $base_path = rtrim(str_replace('\\', '/', WP_CONTENT_DIR), '/') . '/';
+
+    if (strpos($normalized_path, '..') !== false || strpos($normalized_path, $base_path) !== 0) {
+        return $default;
+    }
+
+    return $normalized_path;
+}
+
 // GTM Settings
 function hic_is_gtm_enabled() { return hic_get_option('gtm_enabled', '0') === '1'; }
 function hic_get_gtm_container_id() { return hic_get_option('gtm_container_id', ''); }


### PR DESCRIPTION
## Summary
- validate custom log file path to ensure it stays inside `WP_CONTENT_DIR`
- sanitize and register `hic_log_file` option with custom callback

## Testing
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbf1c99a50832fbba646c2dd5f63f1