### PR TITLE
Avoid setting tracking cookies in admin or CLI contexts

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -32,7 +32,11 @@ require_once __DIR__ . '/includes/booking-poller.php';
 });
 
 // Initialize tracking parameters capture
-\add_action('init', 'hic_capture_tracking_params');
+\add_action('init', function () {
+    if (!\is_admin() && \php_sapi_name() !== 'cli') {
+        \hic_capture_tracking_params();
+    }
+});
 
 // Initialize enhanced systems when WordPress is ready
 \add_action('init', function() {


### PR DESCRIPTION
## Summary
- prevent `hic_capture_tracking_params` from running in admin or CLI

## Testing
- `php tests/test-functions.php`
- `php -r 'function add_action($h,$c){global $a;$a[$h][]=$c;} function do_action($h){global $a;if(isset($a[$h]))foreach($a[$h] as $c){$c();}} function is_admin(){return false;} function hic_capture_tracking_params(){setcookie("hic_sid","123"); $_COOKIE["hic_sid"]="123";} $_GET["gclid"]="ABC"; add_action("init", function(){ if (!is_admin() && php_sapi_name() !== "cli"){ hic_capture_tracking_params();}}); do_action("init"); var_export($_COOKIE);'`

------
https://chatgpt.com/codex/tasks/task_e_68bbf2b5a0a0832fb14d140463286bb2