### PR TITLE
Use plugin version constant for enqueued assets

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -18,6 +18,8 @@ if (!defined('ABSPATH')) {
 
 // Load Composer autoloader
 require __DIR__ . '/vendor/autoload.php';
+// Ensure plugin constants are loaded before usage
+require_once __DIR__ . '/includes/constants.php';
 require_once __DIR__ . '/includes/booking-poller.php';
 
 // Plugin activation hook
@@ -59,7 +61,7 @@ require_once __DIR__ . '/includes/booking-poller.php';
         'hic-frontend',
         \plugin_dir_url(__FILE__) . 'assets/js/frontend.js',
         array(),
-        '1.4.0',
+        HIC_PLUGIN_VERSION,
         true
     );
 });


### PR DESCRIPTION
## Summary
- Load constants file before any enqueues
- Use `HIC_PLUGIN_VERSION` in frontend script enqueue

## Testing
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbf395d914832fa8cdbf32c610094d