### PR TITLE
Add database upgrade handler

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -29,17 +29,18 @@ function hic_activate($network_wide)
         $sites = \get_sites();
         foreach ($sites as $site) {
             \switch_to_blog($site->blog_id);
-            \hic_create_database_table();
+            \hic_maybe_upgrade_db();
             \restore_current_blog();
         }
     } else {
-        \hic_create_database_table();
+        \hic_maybe_upgrade_db();
     }
 }
 
 // Plugin activation hook
 \register_activation_hook(__FILE__, __NAMESPACE__ . '\\hic_activate');
 \register_deactivation_hook(__FILE__, 'hic_deactivate');
+\add_action('plugins_loaded', '\\hic_maybe_upgrade_db');
 
 // Add settings link in plugin list
 \add_filter('plugin_action_links_' . \plugin_basename(__FILE__), function ($links) {

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -117,3 +117,4 @@ define('HIC_PLUGIN_VERSION', '1.4.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
 define('HIC_MIN_WP_VERSION', '5.0');
+define('HIC_DB_VERSION', '1.1');


### PR DESCRIPTION
## Summary
- add `hic_maybe_upgrade_db` for database migrations
- run migrations on plugin activation and initialization
- track schema with new `HIC_DB_VERSION`

## Testing
- `php -l includes/database.php`
- `php -l FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php`
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbf73439f8832f8d0b9f2fa2b9fefa