### PR TITLE
Use array syntax for hic_sid cookie

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -231,9 +231,13 @@ function hic_capture_tracking_params(){
     
     // Only update cookie if we don't have an existing SID or if existing SID was the gclid
     if (!$existing_sid || $existing_sid === $gclid) {
-      $secure_flag = is_ssl();
-      $httponly_flag = true;
-      $cookie_set = setcookie('hic_sid', $gclid, time() + 60*60*24*90, '/', '', $secure_flag, $httponly_flag);
+      $cookie_set = setcookie('hic_sid', $gclid, [
+        'expires'  => time() + 60 * 60 * 24 * 90,
+        'path'     => '/',
+        'secure'   => is_ssl(),
+        'httponly' => true,
+        'samesite' => 'Lax',
+      ]);
       if ($cookie_set) {
         $_COOKIE['hic_sid'] = $gclid;
       } else {
@@ -276,9 +280,13 @@ function hic_capture_tracking_params(){
     
     // Only update cookie if we don't have an existing SID or if existing SID was the fbclid
     if (!$existing_sid || $existing_sid === $fbclid) {
-      $secure_flag = is_ssl();
-      $httponly_flag = true;
-      $cookie_set = setcookie('hic_sid', $fbclid, time() + 60*60*24*90, '/', '', $secure_flag, $httponly_flag);
+      $cookie_set = setcookie('hic_sid', $fbclid, [
+        'expires'  => time() + 60 * 60 * 24 * 90,
+        'path'     => '/',
+        'secure'   => is_ssl(),
+        'httponly' => true,
+        'samesite' => 'Lax',
+      ]);
       if ($cookie_set) {
         $_COOKIE['hic_sid'] = $fbclid;
       } else {


### PR DESCRIPTION
## Summary
- switch setcookie to options array for hic_sid and include security flags

## Testing
- `composer install`
- `composer test`
- `curl -I http://127.0.0.1:8000/test_cookie.php`


------
https://chatgpt.com/codex/tasks/task_e_68bbfbb082d4832faf4eeda16e44f8a0