### PR TITLE
Ensure POST data is unslashed before sanitization

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -32,7 +32,7 @@ function hic_ajax_test_email() {
     }
     
     // Get email from request
-    $test_email = sanitize_email($_POST['email'] ?? '');
+    $test_email = sanitize_email( wp_unslash( $_POST['email'] ?? '' ) );
     
     if (empty($test_email) || !is_email($test_email)) {
         wp_send_json_error(array(
@@ -69,9 +69,9 @@ function hic_ajax_test_api_connection() {
     }
     
     // Get credentials from AJAX request or settings
-    $prop_id = sanitize_text_field($_POST['prop_id'] ?? '');
-    $email = sanitize_email($_POST['email'] ?? '');
-    $password = sanitize_text_field($_POST['password'] ?? '');
+    $prop_id = sanitize_text_field( wp_unslash( $_POST['prop_id'] ?? '' ) );
+    $email = sanitize_email( wp_unslash( $_POST['email'] ?? '' ) );
+    $password = sanitize_text_field( wp_unslash( $_POST['password'] ?? '' ) );
     
     // Test the API connection
     $result = hic_test_api_connection($prop_id, $email, $password);

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -741,10 +741,10 @@ function hic_ajax_backfill_reservations() {
     }
 
     // Get and validate input parameters
-    $from_date = sanitize_text_field($_POST['from_date'] ?? '');
-    $to_date = sanitize_text_field($_POST['to_date'] ?? '');
-    $date_type = sanitize_text_field($_POST['date_type'] ?? 'checkin');
-    $limit = isset($_POST['limit']) ? intval($_POST['limit']) : null;
+    $from_date = sanitize_text_field( wp_unslash( $_POST['from_date'] ?? '' ) );
+    $to_date = sanitize_text_field( wp_unslash( $_POST['to_date'] ?? '' ) );
+    $date_type = sanitize_text_field( wp_unslash( $_POST['date_type'] ?? 'checkin' ) );
+    $limit = isset($_POST['limit']) ? intval( wp_unslash( $_POST['limit'] ) ) : null;
 
     // Validate date type (based on API documentation: only checkin, checkout, presence are valid for /reservations endpoint)
     if (!in_array($date_type, array('checkin', 'checkout', 'presence'))) {
@@ -922,7 +922,7 @@ function hic_ajax_force_polling() {
 
     try {
         // Get force flag from request
-        $force = isset($_POST['force']) && $_POST['force'] === 'true';
+        $force = isset($_POST['force']) && wp_unslash( $_POST['force'] ) === 'true';
 
         // Check if poller class exists
         if (!class_exists('HIC_Booking_Poller')) {


### PR DESCRIPTION
## Summary
- Wrap POST parameters with `wp_unslash()` before sanitizing in admin email and API test handlers
- Apply same unslashing to diagnostics AJAX handlers for reservation backfill and force polling

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bbfc9599f4832f91717954267c4be3