### PR TITLE
Prevent caching and extra output in log download

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -1518,7 +1518,8 @@ function hic_ajax_download_error_logs() {
     
     // Set headers for file download
     $filename = 'hic-error-log-' . date('Y-m-d-H-i-s') . '.txt';
-    
+
+    nocache_headers();
     header('Content-Type: text/plain');
     header('Content-Disposition: attachment; filename="' . $filename . '"');
     header('Content-Length: ' . filesize($log_file));
@@ -1527,8 +1528,8 @@ function hic_ajax_download_error_logs() {
     
     // Output the file content
     readfile($log_file);
-    
-    wp_die(); // Stop execution after download
+
+    exit; // Stop execution after download
 }
 
 /**


### PR DESCRIPTION
## Summary
- Ensure diagnostics error log downloads disable caching with `nocache_headers`
- Use `exit` after streaming log file to stop execution cleanly

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bbfe3a3174832fbd54d27917299cab