### PR TITLE
Use WordPress time reference for stored timestamps

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -237,8 +237,8 @@ function hic_get_recent_log_entries($limit = 50) {
 function hic_test_dispatch_functions() {
     // Test data for integrations
     $test_data = array(
-        'reservation_id' => 'TEST_' . time(),
-        'id' => 'TEST_' . time(),
+        'reservation_id' => 'TEST_' . current_time('timestamp'),
+        'id' => 'TEST_' . current_time('timestamp'),
         'amount' => 100.00,
         'currency' => 'EUR',
         'email' => 'test@example.com',
@@ -293,7 +293,7 @@ function hic_test_dispatch_functions() {
         // Test Admin Email
         $admin_email = Helpers\hic_get_admin_email();
         if (!empty($admin_email)) {
-            Helpers\hic_send_admin_email($test_data, $gclid, $fbclid, 'test_' . time());
+            Helpers\hic_send_admin_email($test_data, $gclid, $fbclid, 'test_' . current_time('timestamp'));
             $results['admin_email'] = 'Test email sent to admin: ' . $admin_email;
         } else {
             $results['admin_email'] = 'Admin email not configured';
@@ -1156,14 +1156,14 @@ function hic_diagnostics_page() {
                                 <td>
                                     <?php if ($last_poll > 0): ?>
                                         <?php 
-                                        $time_diff = time() - $last_poll;
+                                        $time_diff = current_time('timestamp') - $last_poll;
                                         if ($time_diff < 900): // Less than 15 minutes
                                         ?>
-                                            <span class="status ok"><?php echo esc_html(human_time_diff($last_poll, time())); ?> fa</span>
+                                            <span class="status ok"><?php echo esc_html(human_time_diff($last_poll, current_time('timestamp'))); ?> fa</span>
                                         <?php elseif ($time_diff < 3600): // Less than 1 hour ?>
-                                            <span class="status warning"><?php echo esc_html(human_time_diff($last_poll, time())); ?> fa</span>
+                                            <span class="status warning"><?php echo esc_html(human_time_diff($last_poll, current_time('timestamp'))); ?> fa</span>
                                         <?php else: ?>
-                                            <span class="status error"><?php echo esc_html(human_time_diff($last_poll, time())); ?> fa</span>
+                                            <span class="status error"><?php echo esc_html(human_time_diff($last_poll, current_time('timestamp'))); ?> fa</span>
                                         <?php endif; ?>
                                     <?php else: ?>
                                         <span class="status error">Mai</span>

--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -16,7 +16,7 @@ if (!defined('ABSPATH')) exit;
  * @return int Validated and potentially adjusted timestamp
  */
 function hic_validate_api_timestamp($timestamp, $context = 'api_request') {
-    $current_time = time();
+    $current_time = current_time('timestamp');
     $max_lookback_seconds = 6 * DAY_IN_SECONDS; // 6 days for safety margin from 7-day API limit
     $max_lookahead_seconds = 1 * DAY_IN_SECONDS; // 1 day in future for safety
     $earliest_allowed = $current_time - $max_lookback_seconds;
@@ -566,7 +566,7 @@ function hic_api_poll_bookings(){
  * Quasi-realtime polling with moving window approach
  */
 function hic_quasi_realtime_poll($prop_id, $start_time) {
-    $current_time = time();
+    $current_time = current_time('timestamp');
     
     // Moving window: 15 minutes back + 5 minutes forward
     $window_back_minutes = 15;
@@ -817,7 +817,7 @@ function hic_api_poll_updates(){
     Helpers\hic_log('Internal Scheduler: hic_api_poll_updates execution started');
     
     // Always update execution timestamp regardless of results
-    update_option('hic_last_api_poll', time());
+    update_option('hic_last_api_poll', current_time('timestamp'));
     
     $prop = Helpers\hic_get_property_id();
     
@@ -825,7 +825,7 @@ function hic_api_poll_updates(){
     $overlap_seconds = 300; // 5 minute overlap for safety
     
     // Ensure we never use a timestamp older than 6 days (API limit is 7 days)
-    $current_time = time();
+    $current_time = current_time('timestamp');
     $max_lookback_seconds = 6 * DAY_IN_SECONDS; // 6 days for safety margin
     $earliest_allowed = $current_time - $max_lookback_seconds;
     $default_since = max($earliest_allowed, $current_time - DAY_IN_SECONDS); // Default to 1 day ago or earliest allowed
@@ -867,16 +867,16 @@ function hic_api_poll_updates(){
                 }
             }
             
-            // Use the max updated_at if found, otherwise use current time
-            if ($max_updated_at > 0) {
-                $new_timestamp = $max_updated_at;
-                Helpers\hic_log("Internal Scheduler: Using max updated_at timestamp: " . date('Y-m-d H:i:s', $new_timestamp) . " ($new_timestamp)");
-            } else {
-                Helpers\hic_log("Internal Scheduler: No updated_at field found, using current time: " . date('Y-m-d H:i:s', $new_timestamp) . " ($new_timestamp)");
-            }
+              // Use the max updated_at if found, otherwise use current time
+              if ($max_updated_at > 0) {
+                  $new_timestamp = $max_updated_at;
+                  Helpers\hic_log("Internal Scheduler: Using max updated_at timestamp: " . date('Y-m-d H:i:s', $new_timestamp) . " ($new_timestamp)");
+              } else {
+                  Helpers\hic_log("Internal Scheduler: No updated_at field found, using current time: " . date('Y-m-d H:i:s', $new_timestamp) . " ($new_timestamp)");
+              }
         } else {
             // No updates found - advance timestamp only if enough time has passed to prevent infinite polling
-            $time_since_last_poll = $current_time - $last_since;
+              $time_since_last_poll = $current_time - $last_since;
             if ($time_since_last_poll > 3600) { // 1 hour
                 Helpers\hic_log("Internal Scheduler: No updates found but 1+ hour passed, advancing timestamp to prevent infinite polling");
             } else {
@@ -1533,7 +1533,7 @@ function hic_api_poll_bookings_continuous() {
             return;
         }
         
-        $current_time = time();
+        $current_time = current_time('timestamp');
         
         // Check recent reservations (last 2 hours) to catch new bookings and updates
         $window_back_minutes = 120; // 2 hours back
@@ -1661,7 +1661,7 @@ function hic_api_poll_bookings_deep_check() {
             return;
         }
         
-        $current_time = time();
+        $current_time = current_time('timestamp');
         $lookback_seconds = 5 * DAY_IN_SECONDS; // 5 days
         
         $from_date = date('Y-m-d', $current_time - $lookback_seconds);

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -185,7 +185,7 @@ if (defined('WP_CLI') && WP_CLI) {
                 $stats = $poller->perform_polling();
 
                 // Update last poll timestamp
-                update_option('hic_last_reliable_poll', time());
+                update_option('hic_last_reliable_poll', current_time('timestamp'));
 
                 $execution_time = round(microtime(true) - $start_time, 2);
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -128,7 +128,7 @@ function hic_get_polling_interval() {
  */
 function hic_acquire_polling_lock($timeout = 300) {
     $lock_key = 'hic_polling_lock';
-    $lock_value = time();
+    $lock_value = current_time('timestamp');
     
     // Check if lock exists and is still valid
     $existing_lock = get_transient($lock_key);
@@ -701,7 +701,7 @@ function hic_acquire_reservation_lock($reservation_id, $timeout = 30) {
   if (empty($reservation_id)) return false;
   
   $lock_key = 'hic_processing_lock_' . md5($reservation_id);
-  $lock_time = time();
+  $lock_time = current_time('timestamp');
   
   // Check if there's already a recent lock
   $existing_lock = get_transient($lock_key);

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -210,7 +210,7 @@ class HIC_Health_Monitor {
         
         $last_continuous = get_option('hic_last_continuous_poll');
         $last_deep = get_option('hic_last_deep_check');
-        $now = time();
+        $now = current_time('timestamp');
         
         $continuous_delay = $last_continuous ? ($now - strtotime($last_continuous)) : null;
         $deep_delay = $last_deep ? ($now - strtotime($last_deep)) : null;

--- a/includes/performance-monitor.php
+++ b/includes/performance-monitor.php
@@ -59,7 +59,7 @@ class HIC_Performance_Monitor {
             'operation' => $operation,
             'duration' => $duration,
             'memory_used' => $memory_used,
-            'timestamp' => time(),
+            'timestamp' => current_time('timestamp'),
             'date' => date('Y-m-d'),
             'additional_data' => $additional_data
         ];
@@ -107,7 +107,7 @@ class HIC_Performance_Monitor {
                 'avg_memory' => 0,
                 'min_duration' => $metric['duration'],
                 'max_duration' => $metric['duration'],
-                'last_updated' => time()
+                'last_updated' => current_time('timestamp')
             ];
         }
         
@@ -119,7 +119,7 @@ class HIC_Performance_Monitor {
         $avg['avg_memory'] = $avg['total_memory'] / $avg['count'];
         $avg['min_duration'] = min($avg['min_duration'], $metric['duration']);
         $avg['max_duration'] = max($avg['max_duration'], $metric['duration']);
-        $avg['last_updated'] = time();
+        $avg['last_updated'] = current_time('timestamp');
         
         update_option('hic_performance_averages', $averages, false);
     }
@@ -263,7 +263,7 @@ class HIC_Performance_Monitor {
             'operation' => 'api_call',
             'duration' => $duration,
             'memory_used' => 0,
-            'timestamp' => time(),
+            'timestamp' => current_time('timestamp'),
             'date' => date('Y-m-d'),
             'additional_data' => [
                 'endpoint' => $endpoint,
@@ -318,7 +318,7 @@ class HIC_Performance_Monitor {
             'operation' => 'booking_processing',
             'duration' => $duration,
             'memory_used' => 0,
-            'timestamp' => time(),
+            'timestamp' => current_time('timestamp'),
             'date' => date('Y-m-d'),
             'additional_data' => [
                 'booking_id' => $booking_id,


### PR DESCRIPTION
## Summary
- Use `current_time('timestamp')` when saving or comparing polling timestamps
- Align diagnostics and performance metrics with WordPress time zone
- Update locking utilities to store time in site timezone

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bbffaa5470832f8d6dfc9f00f8a86b