### PR TITLE
Add script translation hooks for admin pages

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -231,6 +231,11 @@ function hic_admin_enqueue_scripts($hook) {
             HIC_PLUGIN_VERSION,
             true
         );
+        wp_set_script_translations(
+            'hic-admin-settings',
+            'hotel-in-cloud',
+            plugin_dir_path(__FILE__) . '../../languages'
+        );
         wp_localize_script('hic-admin-settings', 'hicAdminSettings', array(
             'ajax_url' => admin_url('admin-ajax.php'),
             'api_nonce' => wp_create_nonce('hic_test_api_nonce'),
@@ -251,6 +256,11 @@ function hic_admin_enqueue_scripts($hook) {
             array('jquery'),
             HIC_PLUGIN_VERSION,
             true
+        );
+        wp_set_script_translations(
+            'hic-diagnostics',
+            'hotel-in-cloud',
+            plugin_dir_path(__FILE__) . '../../languages'
         );
         wp_localize_script('hic-diagnostics', 'hicDiagnostics', array(
             'ajax_url' => admin_url('admin-ajax.php'),

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -5,6 +5,20 @@
 
 if (!defined('ABSPATH')) exit;
 
+add_action(
+    'admin_enqueue_scripts',
+    function ($hook) {
+        if ($hook === 'hic-monitoring_page_hic-diagnostics') {
+            wp_set_script_translations(
+                'hic-diagnostics',
+                'hotel-in-cloud',
+                plugin_dir_path(__FILE__) . '../../languages'
+            );
+        }
+    },
+    20
+);
+
 /* ============ Cron Diagnostics Functions ============ */
 
 /**


### PR DESCRIPTION
## Summary
- load translations for admin settings JS
- load translations for diagnostics JS

## Testing
- `wp i18n make-json . --allow-root`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc023debf8832faf0097f9ab77ebd3