### PR TITLE
Add filters for customizing admin email notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,23 @@ Se le email non arrivano:
 
 Il sistema include diagnostica avanzata per identificare automaticamente problemi comuni di configurazione email.
 
+### Personalizzazione Notifiche Email
+
+Il plugin espone filtri WordPress per modificare oggetto e contenuto delle notifiche inviate all'amministratore:
+
+```php
+add_filter( 'hic_admin_email_subject', function ( $subject, $data ) {
+    return '[Prenotazione] ' . $subject;
+}, 10, 2 );
+
+add_filter( 'hic_admin_email_body', function ( $body, $data ) {
+    $body .= "\nFonte: " . ( $data['source'] ?? 'sconosciuta' );
+    return $body;
+}, 10, 2 );
+```
+
+I parametri `$subject` e `$body` rappresentano rispettivamente oggetto e corpo generati dal plugin, mentre `$data` contiene i dettagli della prenotazione.
+
 ## Note su Privacy e Rate Limits
 
 - Il plugin rispetta i rate limits delle API Hotel in Cloud

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -410,6 +410,10 @@ function hic_send_admin_email($data, $gclid, $fbclid, $sid){
   $body .= "FBCLID: " . ($fbclid ?? 'n/a') . "\n";
   $body .= "Bucket: " . $bucket . "\n";
 
+  // Allow customization of admin email subject and body
+  $subject = apply_filters('hic_admin_email_subject', $subject, $data);
+  $body    = apply_filters('hic_admin_email_body', $body, $data);
+
   $content_type_filter = function(){ return 'text/plain; charset=UTF-8'; };
   add_filter('wp_mail_content_type', $content_type_filter);
   


### PR DESCRIPTION
## Summary
- Allow filtering admin email subject and body via `hic_admin_email_subject` and `hic_admin_email_body`
- Document admin email customization filters with usage examples in README

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc03e81da0832f8456bb9adc68ec41