### PR TITLE
Unslash GET parameters before sanitizing

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -347,7 +347,7 @@ class HIC_Booking_Poller {
      */
     public function admin_watchdog_check() {
         // Only run on HIC admin pages to avoid unnecessary overhead
-        if (!isset($_GET['page']) || strpos(sanitize_text_field($_GET['page']), 'hic') === false) {
+        if (!isset($_GET['page']) || strpos( sanitize_text_field( wp_unslash( $_GET['page'] ) ), 'hic' ) === false) {
             return;
         }
         

--- a/includes/database.php
+++ b/includes/database.php
@@ -295,7 +295,8 @@ function hic_capture_tracking_params(){
   $existing_sid = isset($_COOKIE['hic_sid']) ? sanitize_text_field($_COOKIE['hic_sid']) : null;
 
   if (!empty($_GET['gclid'])) {
-    $result = hic_store_tracking_id('gclid', sanitize_text_field($_GET['gclid']), $existing_sid);
+    $gclid = sanitize_text_field( wp_unslash( $_GET['gclid'] ) );
+    $result = hic_store_tracking_id('gclid', $gclid, $existing_sid);
     if (is_wp_error($result)) {
       Helpers\hic_log('hic_capture_tracking_params: ' . $result->get_error_message());
       return false;
@@ -303,7 +304,8 @@ function hic_capture_tracking_params(){
   }
 
   if (!empty($_GET['fbclid'])) {
-    $result = hic_store_tracking_id('fbclid', sanitize_text_field($_GET['fbclid']), $existing_sid);
+    $fbclid = sanitize_text_field( wp_unslash( $_GET['fbclid'] ) );
+    $result = hic_store_tracking_id('fbclid', $fbclid, $existing_sid);
     if (is_wp_error($result)) {
       Helpers\hic_log('hic_capture_tracking_params: ' . $result->get_error_message());
       return false;

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -470,7 +470,7 @@ class HIC_Health_Monitor {
             wp_send_json(['error' => 'Insufficient permissions'], 403);
         }
 
-        $level = sanitize_text_field($_GET['level'] ?? HIC_DIAGNOSTIC_BASIC);
+        $level = sanitize_text_field( wp_unslash( $_GET['level'] ?? HIC_DIAGNOSTIC_BASIC ) );
         $health_data = $this->check_health($level);
 
         wp_send_json($health_data);
@@ -480,7 +480,7 @@ class HIC_Health_Monitor {
      * Public health check (limited info)
      */
     public function public_health_check() {
-        $token = sanitize_text_field($_GET['token'] ?? '');
+        $token = sanitize_text_field( wp_unslash( $_GET['token'] ?? '' ) );
         if (!$this->validate_health_token($token)) {
             wp_send_json(['error' => 'Invalid token'], 403);
         }

--- a/includes/performance-monitor.php
+++ b/includes/performance-monitor.php
@@ -455,8 +455,8 @@ class HIC_Performance_Monitor {
             wp_send_json(['error' => 'Insufficient permissions'], 403);
         }
 
-        $type = sanitize_text_field($_GET['type'] ?? 'summary');
-        $days = absint($_GET['days'] ?? 7);
+        $type = sanitize_text_field( wp_unslash( $_GET['type'] ?? 'summary' ) );
+        $days = absint( wp_unslash( $_GET['days'] ?? 7 ) );
 
         switch ($type) {
             case 'summary':


### PR DESCRIPTION
## Summary
- unslash GET tracking parameters before storing to avoid magic quotes issues
- sanitize admin and AJAX GET inputs using wp_unslash across plugin

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc05a5bee4832f8fb211b960c29762