### PR TITLE
Sanitize admin output

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -440,7 +440,7 @@ function hic_webhook_token_render() {
 }
 
 function hic_api_url_render() {
-    echo '<input type="url" name="hic_api_url" value="' . esc_attr(Helpers\hic_get_api_url()) . '" class="regular-text" />';
+    echo '<input type="url" name="hic_api_url" value="' . esc_url(Helpers\hic_get_api_url()) . '" class="regular-text" />';
     echo '<p class="description">URL delle API Hotel in Cloud (solo se si usa API Polling)</p>';
 }
 
@@ -515,17 +515,17 @@ function hic_currency_render() {
 
 function hic_ga4_use_net_value_render() {
     $checked = Helpers\hic_use_net_value() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_ga4_use_net_value" value="1" ' . $checked . ' /> Usa price - unpaid_balance come valore per GA4/Pixel';
+    echo '<input type="checkbox" name="hic_ga4_use_net_value" value="1" ' . esc_attr($checked) . ' /> Usa price - unpaid_balance come valore per GA4/Pixel';
 }
 
 function hic_process_invalid_render() {
     $checked = Helpers\hic_process_invalid() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_process_invalid" value="1" ' . $checked . ' /> Processa anche prenotazioni con valid=0';
+    echo '<input type="checkbox" name="hic_process_invalid" value="1" ' . esc_attr($checked) . ' /> Processa anche prenotazioni con valid=0';
 }
 
 function hic_allow_status_updates_render() {
     $checked = Helpers\hic_allow_status_updates() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_allow_status_updates" value="1" ' . $checked . ' /> Permetti aggiornamenti quando cambia presence';
+    echo '<input type="checkbox" name="hic_allow_status_updates" value="1" ' . esc_attr($checked) . ' /> Permetti aggiornamenti quando cambia presence';
 }
 
 function hic_brevo_list_it_render() {
@@ -545,23 +545,23 @@ function hic_brevo_list_default_render() {
 
 function hic_brevo_optin_default_render() {
     $checked = Helpers\hic_get_brevo_optin_default() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_brevo_optin_default" value="1" ' . $checked . ' /> Opt-in marketing di default per nuovi contatti';
+    echo '<input type="checkbox" name="hic_brevo_optin_default" value="1" ' . esc_attr($checked) . ' /> Opt-in marketing di default per nuovi contatti';
 }
 
 function hic_debug_verbose_render() {
     $checked = Helpers\hic_is_debug_verbose() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_debug_verbose" value="1" ' . $checked . ' /> Abilita log debug estesi (solo per test)';
+    echo '<input type="checkbox" name="hic_debug_verbose" value="1" ' . esc_attr($checked) . ' /> Abilita log debug estesi (solo per test)';
 }
 
 // Email enrichment render functions
 function hic_updates_enrich_contacts_render() {
     $checked = Helpers\hic_updates_enrich_contacts() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_updates_enrich_contacts" value="1" ' . $checked . ' /> Aggiorna contatti Brevo quando arriva email reale da updates';
+    echo '<input type="checkbox" name="hic_updates_enrich_contacts" value="1" ' . esc_attr($checked) . ' /> Aggiorna contatti Brevo quando arriva email reale da updates';
 }
 
 function hic_realtime_brevo_sync_render() {
     $checked = Helpers\hic_realtime_brevo_sync_enabled() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_realtime_brevo_sync" value="1" ' . $checked . ' /> Invia eventi "reservation_created" a Brevo in tempo reale per nuove prenotazioni';
+    echo '<input type="checkbox" name="hic_realtime_brevo_sync" value="1" ' . esc_attr($checked) . ' /> Invia eventi "reservation_created" a Brevo in tempo reale per nuove prenotazioni';
     echo '<p class="description">Quando abilitato, le nuove prenotazioni rilevate dal polling updates invieranno automaticamente eventi a Brevo per automazioni e tracciamento.</p>';
 }
 
@@ -572,12 +572,12 @@ function hic_brevo_list_alias_render() {
 
 function hic_brevo_double_optin_on_enrich_render() {
     $checked = Helpers\hic_brevo_double_optin_on_enrich() ? 'checked' : '';
-    echo '<input type="checkbox" name="hic_brevo_double_optin_on_enrich" value="1" ' . $checked . ' /> Invia double opt-in quando arriva email reale';
+    echo '<input type="checkbox" name="hic_brevo_double_optin_on_enrich" value="1" ' . esc_attr($checked) . ' /> Invia double opt-in quando arriva email reale';
 }
 
 function hic_brevo_event_endpoint_render() {
     $endpoint = Helpers\hic_get_brevo_event_endpoint();
-    echo '<input type="url" name="hic_brevo_event_endpoint" value="' . esc_attr($endpoint) . '" style="width: 100%;" />';
+    echo '<input type="url" name="hic_brevo_event_endpoint" value="' . esc_url($endpoint) . '" style="width: 100%;" />';
     echo '<p class="description">Endpoint API per eventi Brevo. Default: https://in-automate.brevo.com/api/v2/trackEvent<br>';
     echo 'Modificare solo se Brevo cambia il proprio endpoint per gli eventi o se si utilizza un endpoint personalizzato.</p>';
 }

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -1135,7 +1135,7 @@ function hic_diagnostics_page() {
                                 <td><span class="status <?php echo esc_attr($credentials_status['api_url'] ? 'ok' : 'error'); ?>">
                                     <?php echo esc_html($credentials_status['api_url'] ? 'Configurato' : 'Mancante'); ?>
                                 </span></td>
-                                <td><?php echo $credentials_status['api_url'] ? 'Connessione disponibile' : 'Configurazione richiesta'; ?></td>
+                                <td><?php echo esc_html($credentials_status['api_url'] ? 'Connessione disponibile' : 'Configurazione richiesta'); ?></td>
                             </tr>
                             <tr>
                                 <td>Credenziali</td>
@@ -1163,7 +1163,7 @@ function hic_diagnostics_page() {
                                         <span class="status error">✗ Inattivo</span>
                                     <?php endif; ?>
                                 </td>
-                                <td><?php echo $polling_active ? 'Polling automatico funzionante' : 'Richiede configurazione'; ?></td>
+                                <td><?php echo esc_html($polling_active ? 'Polling automatico funzionante' : 'Richiede configurazione'); ?></td>
                             </tr>
                             <tr>
                                 <td>Ultimo Successo</td>
@@ -1346,7 +1346,7 @@ function hic_diagnostics_page() {
                         <?php if ($downloaded_count > 0): ?>
                             <button class="button button-secondary" id="reset-download-tracking">
                                 <span class="dashicons dashicons-update-alt"></span>
-                                Reset Tracking (<?php echo $downloaded_count; ?> inviate)
+                                Reset Tracking (<?php echo esc_html($downloaded_count); ?> inviate)
                             </button>
                         <?php endif; ?>
                     </div>
@@ -1369,7 +1369,7 @@ function hic_diagnostics_page() {
                         <table class="hic-stats-table">
                             <tr>
                                 <td>Ultimo Polling</td>
-                                <td><?php echo $execution_stats['last_poll_time'] ? esc_html(date('Y-m-d H:i:s', $execution_stats['last_poll_time'])) : 'Mai'; ?></td>
+                                <td><?php echo esc_html($execution_stats['last_poll_time'] ? date('Y-m-d H:i:s', $execution_stats['last_poll_time']) : 'Mai'); ?></td>
                             </tr>
                             <tr>
                                 <td>Prenotazioni Elaborate</td>
@@ -1394,7 +1394,7 @@ function hic_diagnostics_page() {
                                     <?php 
                                     $duration = $execution_stats['last_poll_duration'];
                                     if ($duration > 0) {
-                                        echo '<span class="status ' . ($duration > 10000 ? 'warning' : 'ok') . '">' . esc_html($duration) . ' ms</span>';
+                                        echo '<span class="status ' . esc_attr($duration > 10000 ? 'warning' : 'ok') . '">' . esc_html($duration) . ' ms</span>';
                                     } else {
                                         echo '<span class="status neutral">N/A</span>';
                                     }
@@ -1420,7 +1420,7 @@ function hic_diagnostics_page() {
                                     <div class="hic-log-entry"><?php echo esc_html($log_line); ?></div>
                                 <?php endforeach; ?>
                                 <?php if (count($recent_logs) > 8): ?>
-                                    <div class="hic-log-more">... e altri <?php echo count($recent_logs) - 8; ?> eventi</div>
+                                    <div class="hic-log-more">... e altri <?php echo esc_html(count($recent_logs) - 8); ?> eventi</div>
                                 <?php endif; ?>
                             <?php endif; ?>
                         </div>


### PR DESCRIPTION
## Summary
- Escape URL and checkbox values in admin settings renderers
- Sanitize diagnostic descriptions and status outputs

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc069ca8b8832f8a49feb0c55547b6