### PR TITLE
Centralize HTTP requests via helper

### DIFF
--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -39,14 +39,14 @@ function hic_send_brevo_contact($data, $gclid, $fbclid){
     'updateEnabled' => true
   );
 
-  $res = wp_remote_post('https://api.brevo.com/v3/contacts', array(
+  $res = Helpers\hic_http_request('https://api.brevo.com/v3/contacts', array(
+    'method'  => 'POST',
     'headers' => array(
       'accept'       => 'application/json',
       'api-key'      => Helpers\hic_get_brevo_api_key(),
       'content-type' => 'application/json'
     ),
     'body'    => wp_json_encode($body),
-    'timeout' => 15
   ));
   
   $result = hic_handle_brevo_response($res, 'contact_legacy', array(
@@ -81,14 +81,14 @@ function hic_send_brevo_event($data, $gclid, $fbclid){
     )
   );
 
-  $res = wp_remote_post(Helpers\hic_get_brevo_event_endpoint(), array(
+  $res = Helpers\hic_http_request(Helpers\hic_get_brevo_event_endpoint(), array(
+    'method'  => 'POST',
     'headers' => array(
       'accept'       => 'application/json',
       'content-type' => 'application/json',
       'api-key'      => Helpers\hic_get_brevo_api_key()
     ),
     'body'    => wp_json_encode($body),
-    'timeout' => 15
   ));
   
   $result = hic_handle_brevo_response($res, 'event_legacy', array(
@@ -202,14 +202,14 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     }
   }
 
-  $res = wp_remote_post('https://api.brevo.com/v3/contacts', array(
+  $res = Helpers\hic_http_request('https://api.brevo.com/v3/contacts', array(
+    'method'  => 'POST',
     'headers' => array(
       'accept' => 'application/json',
       'api-key' => Helpers\hic_get_brevo_api_key(),
       'content-type' => 'application/json'
     ),
     'body' => wp_json_encode($body),
-    'timeout' => 15
   ));
   
   $result = hic_handle_brevo_response($res, 'contact', array(
@@ -336,14 +336,14 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
     'full_payload' => $body
   )));
 
-  $res = wp_remote_post(Helpers\hic_get_brevo_event_endpoint(), array(
+  $res = Helpers\hic_http_request(Helpers\hic_get_brevo_event_endpoint(), array(
+    'method'  => 'POST',
     'headers' => array(
       'accept' => 'application/json',
       'content-type' => 'application/json',
       'api-key' => Helpers\hic_get_brevo_api_key()
     ),
     'body' => wp_json_encode($body),
-    'timeout' => 15
   ));
   
   $result = hic_handle_brevo_response($res, 'event', array(
@@ -640,14 +640,14 @@ function hic_test_brevo_contact_api() {
     'updateEnabled' => false // Don't update if exists
   );
   
-  $res = wp_remote_post('https://api.brevo.com/v3/contacts', array(
+  $res = Helpers\hic_http_request('https://api.brevo.com/v3/contacts', array(
+    'method'  => 'POST',
     'headers' => array(
       'accept' => 'application/json',
       'api-key' => Helpers\hic_get_brevo_api_key(),
       'content-type' => 'application/json'
     ),
     'body' => wp_json_encode($body),
-    'timeout' => 15
   ));
   
   $result = hic_handle_brevo_response($res, 'contact_test', array(
@@ -686,14 +686,14 @@ function hic_test_brevo_event_api() {
     'payload' => $body
   )));
   
-  $res = wp_remote_post($endpoint, array(
+  $res = Helpers\hic_http_request($endpoint, array(
+    'method'  => 'POST',
     'headers' => array(
       'accept' => 'application/json',
       'content-type' => 'application/json',
       'api-key' => Helpers\hic_get_brevo_api_key()
     ),
     'body' => wp_json_encode($body),
-    'timeout' => 15
   ));
   
   $result = hic_handle_brevo_response($res, 'event_test', array(
@@ -718,14 +718,14 @@ function hic_test_brevo_event_api() {
       'reason' => 'Primary endpoint failed'
     )));
     
-    $alt_res = wp_remote_post($alt_endpoint, array(
+    $alt_res = Helpers\hic_http_request($alt_endpoint, array(
+      'method'  => 'POST',
       'headers' => array(
         'accept' => 'application/json',
         'content-type' => 'application/json',
         'api-key' => Helpers\hic_get_brevo_api_key()
       ),
       'body' => wp_json_encode($body),
-      'timeout' => 15
     ));
     
     $alt_result = hic_handle_brevo_response($alt_res, 'event_test_alt', array(

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -81,10 +81,10 @@ function hic_send_to_fb($data, $gclid, $fbclid){
   }
 
   $url = 'https://graph.facebook.com/v19.0/' . Helpers\hic_get_fb_pixel_id() . '/events?access_token=' . Helpers\hic_get_fb_access_token();
-  $res = wp_remote_post($url, [
+  $res = Helpers\hic_http_request($url, [
+    'method'  => 'POST',
     'headers' => ['Content-Type'=>'application/json'],
     'body'    => $json_payload,
-    'timeout' => 15
   ]);
   
   $code = is_wp_error($res) ? 0 : wp_remote_retrieve_response_code($res);
@@ -222,10 +222,10 @@ function hic_dispatch_pixel_reservation($data) {
   }
 
   $url = 'https://graph.facebook.com/v19.0/' . Helpers\hic_get_fb_pixel_id() . '/events?access_token=' . Helpers\hic_get_fb_access_token();
-  $res = wp_remote_post($url, [
+  $res = Helpers\hic_http_request($url, [
+    'method'  => 'POST',
     'headers' => ['Content-Type' => 'application/json'],
-    'body' => $json_payload,
-    'timeout' => 15
+    'body'    => $json_payload,
   ]);
   
   $code = is_wp_error($res) ? 0 : wp_remote_retrieve_response_code($res);

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -75,10 +75,10 @@ function hic_send_to_ga4($data, $gclid, $fbclid) {
        . '&api_secret='
        . rawurlencode($api_secret);
 
-  $res = wp_remote_post($url, [
+  $res = Helpers\hic_http_request($url, [
+    'method'  => 'POST',
     'headers' => ['Content-Type'=>'application/json'],
     'body'    => $json_payload,
-    'timeout' => 15
   ]);
   
   $code = is_wp_error($res) ? 0 : wp_remote_retrieve_response_code($res);
@@ -194,10 +194,10 @@ function hic_dispatch_ga4_reservation($data) {
        . '&api_secret='
        . rawurlencode($api_secret);
 
-  $res = wp_remote_post($url, [
+  $res = Helpers\hic_http_request($url, [
+    'method'  => 'POST',
     'headers' => ['Content-Type' => 'application/json'],
-    'body' => $json_payload,
-    'timeout' => 15
+    'body'    => $json_payload,
   ]);
   
   $code = is_wp_error($res) ? 0 : wp_remote_retrieve_response_code($res);

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -126,10 +126,10 @@ class HICFunctionsTest {
         if (!function_exists('wp_json_encode')) {
             function wp_json_encode($data) { return json_encode($data); }
         }
-        if (!function_exists('wp_remote_post')) {
-            function wp_remote_post($url, $args) {
-                global $hic_last_post;
-                $hic_last_post = ['url' => $url, 'args' => $args];
+        if (!function_exists('wp_remote_request')) {
+            function wp_remote_request($url, $args) {
+                global $hic_last_request;
+                $hic_last_request = ['url' => $url, 'args' => $args];
                 return ['response' => ['code' => 200], 'body' => '{}'];
             }
         }
@@ -153,42 +153,42 @@ class HICFunctionsTest {
         update_option('hic_fb_access_token', 'FBTOKEN');
         update_option('hic_log_file', sys_get_temp_dir() . '/hic-test.log');
 
-        global $hic_last_post;
+        global $hic_last_request;
 
         // GA4 room name
         $data = ['room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
         \FpHic\hic_send_to_ga4($data, null, null);
-        $payload = json_decode($hic_last_post['args']['body'], true);
+        $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Camera Deluxe', 'GA4 should use room name');
 
         // GA4 accommodation_name fallback
         $data = ['accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
         \FpHic\hic_send_to_ga4($data, null, null);
-        $payload = json_decode($hic_last_post['args']['body'], true);
+        $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Suite', 'GA4 should use accommodation name');
 
         // GA4 default
         $data = ['currency' => 'EUR', 'amount' => 100];
         \FpHic\hic_send_to_ga4($data, null, null);
-        $payload = json_decode($hic_last_post['args']['body'], true);
+        $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Prenotazione', 'GA4 should default to Prenotazione');
 
         // FB room name
         $data = ['email' => 'user@example.com', 'room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
         \FpHic\hic_send_to_fb($data, null, null);
-        $payload = json_decode($hic_last_post['args']['body'], true);
+        $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Camera Deluxe', 'FB should use room name');
 
         // FB accommodation_name fallback
         $data = ['email' => 'user@example.com', 'accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
         \FpHic\hic_send_to_fb($data, null, null);
-        $payload = json_decode($hic_last_post['args']['body'], true);
+        $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Suite', 'FB should use accommodation name');
 
         // FB default
         $data = ['email' => 'user@example.com', 'currency' => 'EUR', 'amount' => 100];
         \FpHic\hic_send_to_fb($data, null, null);
-        $payload = json_decode($hic_last_post['args']['body'], true);
+        $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Prenotazione', 'FB should default to Prenotazione');
 
         echo "✅ Event room name fallback tests passed\n";


### PR DESCRIPTION
## Summary
- add `hic_http_request()` helper with default timeout/user-agent and error logging
- route GA4, Facebook and Brevo integrations through the new helper
- update tests to mock the new request function

## Testing
- `composer test`
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68bc0a1f3e90832f945d539a7f26e72f