### PR TITLE
Move GTM validation script into tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -291,3 +291,9 @@ Per eseguire la suite di test da linea di comando:
 ```bash
 composer test
 ```
+
+Per validare l'integrazione Google Tag Manager:
+```bash
+php tests/validate-gtm.php
+```
+

--- a/composer.json
+++ b/composer.json
@@ -27,5 +27,11 @@
     },
     "scripts": {
         "test": "php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit"
+    },
+    "archive": {
+        "exclude": [
+            "tests/*"
+        ]
     }
 }
+

--- a/tests/README.md
+++ b/tests/README.md
@@ -15,6 +15,13 @@ This will run tests for:
 - OTA email detection
 - Configuration helpers
 
+### GTM Integration Validation
+```bash
+php tests/validate-gtm.php
+```
+
+This script validates the GTM integration logic and ensures the DataLayer events are structured correctly.
+
 ## Test Structure
 
 - `bootstrap.php` - Test environment setup and WordPress function mocks

--- a/tests/validate-gtm.php
+++ b/tests/validate-gtm.php
@@ -5,7 +5,7 @@
  * Run this to validate GTM integration works properly
  */
 
-require_once dirname(__FILE__) . '/tests/bootstrap.php';
+require_once __DIR__ . '/bootstrap.php';
 
 function validateGTMIntegration() {
     echo "🔍 Validating GTM Integration...\n\n";


### PR DESCRIPTION
## Summary
- relocate `validate-gtm.php` into `tests/` and fix bootstrap path
- document running the GTM validation script
- exclude test scripts from distribution via Composer archive settings

## Testing
- `php tests/validate-gtm.php`
- `composer validate --quiet`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0c40171c832fb0f55216ef076f6a