### PR TITLE
Use WordPress current_time for integration timestamps

### DIFF
--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -628,7 +628,7 @@ function hic_transform_webhook_data_for_brevo($webhook_data) {
  * Test Brevo Contact API connectivity
  */
 function hic_test_brevo_contact_api() {
-  $test_email = 'test-' . time() . '@example.com';
+  $test_email = 'test-' . current_time('timestamp') . '@example.com';
   
   $body = array(
     'email' => $test_email,
@@ -668,7 +668,7 @@ function hic_test_brevo_contact_api() {
  */
 function hic_test_brevo_event_api() {
   $endpoint = Helpers\hic_get_brevo_event_endpoint();
-  $test_email = 'test-' . time() . '@example.com';
+  $test_email = 'test-' . current_time('timestamp') . '@example.com';
   
   $body = array(
     'event' => 'test_connectivity',

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -57,7 +57,7 @@ function hic_send_to_fb($data, $gclid, $fbclid){
   $payload = [
     'data' => [[
       'event_name'       => 'Purchase',      // evento standard Meta
-      'event_time'       => time(),
+      'event_time'       => current_time('timestamp'),
       'event_id'         => $event_id,
       'action_source'    => 'website',
       'event_source_url' => home_url(),
@@ -205,7 +205,7 @@ function hic_dispatch_pixel_reservation($data) {
   $payload = [
     'data' => [[
       'event_name' => 'Purchase',
-      'event_time' => time(),
+      'event_time' => current_time('timestamp'),
       'event_id' => $transaction_id,
       'action_source' => 'website',
       'event_source_url' => home_url(),

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -81,7 +81,7 @@ function hic_queue_gtm_event($event_data) {
     $queued_events = get_option('hic_gtm_queued_events', []);
     
     // Add timestamp to avoid conflicts
-    $event_data['event_timestamp'] = time();
+    $event_data['event_timestamp'] = current_time('timestamp');
     
     $queued_events[] = $event_data;
     


### PR DESCRIPTION
## Summary
- Replace `time()` with WordPress `current_time('timestamp')` in Facebook integration event payloads
- Use `current_time('timestamp')` for GTM queued event timestamps
- Generate Brevo test emails using `current_time('timestamp')`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0d6cd784832f81211256e450059f