### PR TITLE
Add filter for configurable log retention days

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,18 @@ add_filter( 'hic_admin_email_body', function ( $body, $data ) {
 
 I parametri `$subject` e `$body` rappresentano rispettivamente oggetto e corpo generati dal plugin, mentre `$data` contiene i dettagli della prenotazione.
 
+### Personalizzazione Log
+
+È possibile modificare i giorni di conservazione dei log tramite il filtro WordPress `hic_log_retention_days`:
+
+```php
+add_filter( 'hic_log_retention_days', function ( $days ) {
+    return 7; // Conserva i log per 7 giorni invece dei 30 predefiniti
+} );
+```
+
+L'hook riceve il numero di giorni di retention configurato dal plugin (default 30) e deve restituire il nuovo valore da applicare.
+
 ## Note su Privacy e Rate Limits
 
 - Il plugin rispetta i rate limits delle API Hotel in Cloud

--- a/includes/log-manager.php
+++ b/includes/log-manager.php
@@ -21,7 +21,7 @@ class HIC_Log_Manager {
         
         $this->log_file = Helpers\hic_get_log_file();
         $this->max_size = HIC_LOG_MAX_SIZE;
-        $this->retention_days = HIC_LOG_RETENTION_DAYS;
+        $this->retention_days = apply_filters( 'hic_log_retention_days', HIC_LOG_RETENTION_DAYS );
         
         // Hook into WordPress shutdown to clean up logs (only if add_action exists)
         if (function_exists('add_action')) {


### PR DESCRIPTION
## Summary
- allow customizing log retention days with `hic_log_retention_days` filter
- document log retention filter in README with example

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc0e59015c832faf835b620ce61667