### PR TITLE
Sanitize hic_sid cookie retrieval

### DIFF
--- a/includes/database.php
+++ b/includes/database.php
@@ -292,7 +292,7 @@ function hic_capture_tracking_params(){
   }
 
   // Get existing SID or create new one if it doesn't exist
-  $existing_sid = isset($_COOKIE['hic_sid']) ? sanitize_text_field($_COOKIE['hic_sid']) : null;
+  $existing_sid = isset($_COOKIE['hic_sid']) ? sanitize_text_field( wp_unslash( $_COOKIE['hic_sid'] ) ) : null;
 
   if (!empty($_GET['gclid'])) {
     $gclid = sanitize_text_field( wp_unslash( $_GET['gclid'] ) );


### PR DESCRIPTION
## Summary
- sanitize `hic_sid` cookie with `wp_unslash` before using it
- confirmed no other direct cookie reads in plugin

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc0ff7303c832fb1164dcb7e53fc1b