### PR TITLE
Use custom hic_manage capability for plugin access

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -30,10 +30,18 @@ function hic_activate($network_wide)
         foreach ($sites as $site) {
             \switch_to_blog($site->blog_id);
             \hic_maybe_upgrade_db();
+            $role = \get_role('administrator');
+            if ($role && !$role->has_cap('hic_manage')) {
+                $role->add_cap('hic_manage');
+            }
             \restore_current_blog();
         }
     } else {
         \hic_maybe_upgrade_db();
+        $role = \get_role('administrator');
+        if ($role && !$role->has_cap('hic_manage')) {
+            $role->add_cap('hic_manage');
+        }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,21 @@ Il tutto avviene **automaticamente** tramite un **sistema interno di scheduling*
 2. Caricare il plugin normalmente in WordPress.
 3. In installazioni WordPress Multisite, l'attivazione a livello di rete inizializza le tabelle del database per ogni sito.
 
+### Permessi
+
+Durante l'attivazione il plugin assegna automaticamente la capability `hic_manage` agli amministratori.  
+Per concedere l'accesso ad altri ruoli è possibile utilizzare un plugin di gestione ruoli oppure aggiungere una semplice funzione personalizzata:
+
+```php
+add_action('init', function () {
+    if ($role = get_role('editor')) {
+        $role->add_cap('hic_manage');
+    }
+});
+```
+
+Il ruolo scelto otterrà così i permessi per configurare il plugin e visualizzare le pagine di amministrazione.
+
 ## Configurazione API
 
 ### API Hotel in Cloud

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -25,7 +25,7 @@ function hic_ajax_test_email() {
     }
     
     // Check user permissions
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can('hic_manage')) {
         wp_send_json_error(array(
             'message' => 'Permessi insufficienti.'
         ));
@@ -62,7 +62,7 @@ function hic_ajax_test_api_connection() {
     }
     
     // Check user permissions
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can('hic_manage')) {
         wp_send_json_error(array(
             'message' => 'Permessi insufficienti.'
         ));
@@ -90,7 +90,7 @@ function hic_add_admin_menu() {
     add_menu_page(
         'HIC Monitoring Settings',
         'HIC Monitoring',
-        'manage_options',
+        'hic_manage',
         'hic-monitoring',
         'hic_options_page'
     );
@@ -100,7 +100,7 @@ function hic_add_admin_menu() {
         'hic-monitoring',
         'Diagnostics',
         'Diagnostics',
-        'manage_options',
+        'hic_manage',
         'hic-diagnostics',
         'hic_diagnostics_page'
     );

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -593,7 +593,7 @@ add_action('wp_ajax_hic_get_system_status', 'hic_ajax_get_system_status');
 
 
 function hic_ajax_refresh_diagnostics() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -621,7 +621,7 @@ function hic_ajax_refresh_diagnostics() {
 }
 
 function hic_ajax_test_dispatch() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -640,7 +640,7 @@ function hic_ajax_test_dispatch() {
 }
 
 function hic_ajax_force_reschedule() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -653,7 +653,7 @@ function hic_ajax_force_reschedule() {
 }
 
 function hic_ajax_create_tables() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -708,7 +708,7 @@ function hic_ajax_create_tables() {
 }
 
 function hic_ajax_backfill_reservations() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -771,7 +771,7 @@ function hic_convert_api_booking_to_processor_format($api_booking) {
 }
 
 function hic_ajax_download_latest_bookings() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -861,7 +861,7 @@ function hic_ajax_download_latest_bookings() {
 }
 
 function hic_ajax_reset_download_tracking() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -882,7 +882,7 @@ function hic_ajax_reset_download_tracking() {
 }
 
 function hic_ajax_force_polling() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -940,7 +940,7 @@ function hic_ajax_force_polling() {
  * AJAX handler for triggering watchdog check
  */
 function hic_ajax_trigger_watchdog() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -987,7 +987,7 @@ function hic_ajax_trigger_watchdog() {
  * AJAX handler for resetting timestamps (emergency recovery)
  */
 function hic_ajax_reset_timestamps() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -1029,7 +1029,7 @@ function hic_ajax_reset_timestamps() {
  * AJAX handler for getting system status updates
  */
 function hic_ajax_get_system_status() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 
@@ -1061,7 +1061,7 @@ function hic_ajax_get_system_status() {
  * HIC Diagnostics Admin Page
  */
 function hic_diagnostics_page() {
-    if (!current_user_can('manage_options')) {
+    if (!current_user_can('hic_manage')) {
         wp_die( __( 'Non hai i permessi necessari per accedere a questa pagina.', 'hotel-in-cloud' ) );
     }
     
@@ -1488,7 +1488,7 @@ function hic_diagnostics_page() {
  * AJAX handler for downloading error logs
  */
 function hic_ajax_download_error_logs() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_die( __( 'Permessi insufficienti', 'hotel-in-cloud' ) );
     }
 
@@ -1522,7 +1522,7 @@ function hic_ajax_download_error_logs() {
  * AJAX handler for testing Brevo API connectivity
  */
 function hic_ajax_test_brevo_connectivity() {
-    if ( ! current_user_can( 'manage_options' ) ) {
+    if ( ! current_user_can('hic_manage') ) {
         wp_send_json_error( [ 'message' => __( 'Permessi insufficienti', 'hotel-in-cloud' ) ] );
     }
 

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -466,7 +466,7 @@ class HIC_Health_Monitor {
             wp_send_json(['error' => 'Invalid nonce'], 403);
         }
 
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('hic_manage')) {
             wp_send_json(['error' => 'Insufficient permissions'], 403);
         }
 
@@ -501,7 +501,7 @@ class HIC_Health_Monitor {
         $level = $request->get_param('level') ?: HIC_DIAGNOSTIC_BASIC;
         
         // Public endpoint only returns basic info
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('hic_manage')) {
             $level = HIC_DIAGNOSTIC_BASIC;
         }
         

--- a/includes/performance-monitor.php
+++ b/includes/performance-monitor.php
@@ -451,7 +451,7 @@ class HIC_Performance_Monitor {
             wp_send_json(['error' => 'Invalid nonce'], 403);
         }
 
-        if (!current_user_can('manage_options')) {
+        if (!current_user_can('hic_manage')) {
             wp_send_json(['error' => 'Insufficient permissions'], 403);
         }
 


### PR DESCRIPTION
## Summary
- Add hic_manage capability to administrators on plugin activation
- Require hic_manage for accessing admin settings, diagnostics, and health checks
- Document how to grant hic_manage to other roles

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc114b35c0832fa2513b07c0675595