### PR TITLE
Enforce version requirements during plugin activation

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -25,6 +25,10 @@ require_once __DIR__ . '/includes/booking-poller.php';
 // Plugin activation handler
 function hic_activate($network_wide)
 {
+    if (\version_compare(PHP_VERSION, HIC_MIN_PHP_VERSION, '<') || \version_compare(\get_bloginfo('version'), HIC_MIN_WP_VERSION, '<')) {
+        \deactivate_plugins(\plugin_basename(__FILE__));
+        \wp_die(\sprintf(\__('Richiede almeno PHP %s e WordPress %s', 'hotel-in-cloud'), HIC_MIN_PHP_VERSION, HIC_MIN_WP_VERSION));
+    }
     if ($network_wide) {
         $sites = \get_sites();
         foreach ($sites as $site) {

--- a/tests/ActivationVersionCheckTest.php
+++ b/tests/ActivationVersionCheckTest.php
@@ -1,0 +1,47 @@
+<?php
+if (!function_exists('get_bloginfo')) {
+    function get_bloginfo($show = '') {
+        return '4.0';
+    }
+}
+if (!function_exists('deactivate_plugins')) {
+    function deactivate_plugins($plugin) {
+        $GLOBALS['deactivated_plugin'] = $plugin;
+    }
+}
+if (!function_exists('plugin_basename')) {
+    function plugin_basename($file) {
+        return $file;
+    }
+}
+if (!function_exists('wp_die')) {
+    function wp_die($message) {
+        throw new Exception($message);
+    }
+}
+if (!function_exists('__')) {
+    function __($text, $domain = null) {
+        return $text;
+    }
+}
+
+use PHPUnit\Framework\TestCase;
+
+class ActivationVersionCheckTest extends TestCase
+{
+    public function test_activation_blocks_on_low_wp_version()
+    {
+        require_once __DIR__ . '/../FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php';
+
+        try {
+            \FpHic\hic_activate(false);
+            $this->fail('Activation should have been blocked.');
+        } catch (Exception $e) {
+            $this->assertStringContainsString('Richiede almeno PHP', $e->getMessage());
+            $this->assertEquals(
+                realpath(__DIR__ . '/../FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php'),
+                $GLOBALS['deactivated_plugin'] ?? null
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- abort plugin activation if PHP or WordPress versions are below defined minimums
- add PHPUnit test to ensure activation is blocked on outdated WordPress setups

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc12dd2f08832f8f4fc38d36dec34e