### PR TITLE
Handle missing composer autoload and update installation docs

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -17,7 +17,12 @@ if (!defined('ABSPATH')) {
 }
 
 // Load Composer autoloader
-require __DIR__ . '/vendor/autoload.php';
+if (file_exists(__DIR__ . '/vendor/autoload.php')) {
+    require __DIR__ . '/vendor/autoload.php';
+} else {
+    error_log('HIC Plugin: vendor/autoload.php non trovato.');
+    return;
+}
 // Ensure plugin constants are loaded before usage
 require_once __DIR__ . '/includes/constants.php';
 require_once __DIR__ . '/includes/booking-poller.php';

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Il tutto avviene **automaticamente** tramite un **sistema interno di scheduling*
 
 ## Installazione
 
-1. Eseguire `composer install` per generare il loader delle classi.
+1. Dopo aver scaricato il plugin, entrare nella sua directory ed eseguire `composer install` per installare le dipendenze e generare il loader delle classi.
 2. Caricare il plugin normalmente in WordPress.
 3. In installazioni WordPress Multisite, l'attivazione a livello di rete inizializza le tabelle del database per ogni sito.
 


### PR DESCRIPTION
## Summary
- Prevent plugin execution if `vendor/autoload.php` is missing and log an error
- Document running `composer install` after downloading the plugin

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc144541e4832fa700786132161026