### PR TITLE
feat: cache option lookups to reduce repeated queries

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -11,7 +11,11 @@ if (!defined('ABSPATH')) {
 
 /* ================= CONFIG FUNCTIONS ================= */
 function hic_get_option($key, $default = '') {
-    return get_option('hic_' . $key, $default);
+    static $cache = [];
+    if (!array_key_exists($key, $cache)) {
+        $cache[$key] = get_option('hic_' . $key, $default);
+    }
+    return $cache[$key];
 }
 
 // Helper functions to get configuration values


### PR DESCRIPTION
## Summary
- cache option values inside `hic_get_option` to prevent duplicate `get_option` calls

## Testing
- `composer test`
- `php -r '$calls=0; function get_option($o,$d=false){global $calls; $calls++; return "value";} define("ABSPATH", __DIR__); include "includes/functions.php"; \FpHic\Helpers\hic_get_option("test"); \FpHic\Helpers\hic_get_option("test"); \FpHic\Helpers\hic_get_option("test"); echo "calls:$calls\n";'`


------
https://chatgpt.com/codex/tasks/task_e_68bc169352b0832fb8f631feb44d4275