### PR TITLE
chore: consolidate logging

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -20,11 +20,15 @@ if (!defined('ABSPATH')) {
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {
     require __DIR__ . '/vendor/autoload.php';
 } else {
-    error_log('HIC Plugin: vendor/autoload.php non trovato.');
+    require_once __DIR__ . '/includes/constants.php';
+    require_once __DIR__ . '/includes/functions.php';
+    require_once __DIR__ . '/includes/log-manager.php';
+    Helpers\hic_log('HIC Plugin: vendor/autoload.php non trovato.', HIC_LOG_LEVEL_ERROR);
     return;
 }
 // Ensure plugin constants are loaded before usage
 require_once __DIR__ . '/includes/constants.php';
+require_once __DIR__ . '/includes/log-manager.php';
 require_once __DIR__ . '/includes/booking-poller.php';
 
 // Plugin activation handler

--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -543,23 +543,17 @@ function hic_mark_reservation_processed($reservation) {
 // Wrapper function - now simplified to use continuous polling by default
 function hic_api_poll_bookings(){
     $start_time = microtime(true);
+    Helpers\hic_log('Internal Scheduler: hic_api_poll_bookings execution started');
     $log_manager = hic_get_log_manager();
     if ($log_manager) {
-        $log_manager->info('Internal Scheduler: hic_api_poll_bookings execution started');
         $log_manager->rotate_if_needed();
-    } else {
-        error_log('Internal Scheduler: hic_api_poll_bookings execution started');
     }
-    
+
     // Use the new simplified continuous polling
     hic_api_poll_bookings_continuous();
-    
+
     $execution_time = round((microtime(true) - $start_time) * 1000, 2);
-    if ($log_manager) {
-        $log_manager->info("Internal Scheduler: hic_api_poll_bookings completed in {$execution_time}ms");
-    } else {
-        error_log("Internal Scheduler: hic_api_poll_bookings completed in {$execution_time}ms");
-    }
+    Helpers\hic_log("Internal Scheduler: hic_api_poll_bookings completed in {$execution_time}ms");
 }
 
 /**

--- a/includes/database.php
+++ b/includes/database.php
@@ -269,10 +269,10 @@ function hic_store_tracking_id($type, $value, $existing_sid) {
 /* ============ Cattura gclid/fbclid → cookie + DB ============ */
 function hic_capture_tracking_params(){
   global $wpdb;
-  
+
   // Check if wpdb is available
   if (!$wpdb) {
-    error_log('HIC Plugin: wpdb is not available in hic_capture_tracking_params');
+    Helpers\hic_log('hic_capture_tracking_params: wpdb is not available', HIC_LOG_LEVEL_ERROR);
     return false;
   }
   

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -339,9 +339,6 @@ function hic_log($msg, $level = HIC_LOG_LEVEL_INFO, $context = []) {
     if ($log_manager) {
         return $log_manager->log($msg, $level, $context);
     }
-
-    // Fallback to error_log if log manager is not available
-    error_log('HIC Plugin: ' . (is_scalar($msg) ? $msg : print_r($msg, true)));
     return false;
 }
 

--- a/includes/log-manager.php
+++ b/includes/log-manager.php
@@ -132,7 +132,7 @@ class HIC_Log_Manager {
         
         // Check if directory is writable
         if (!is_writable($log_dir)) {
-            error_log('HIC Plugin: Log directory is not writable: ' . $log_dir);
+            // Cannot write to log directory
             return false;
         }
         
@@ -140,7 +140,7 @@ class HIC_Log_Manager {
         $result = file_put_contents($this->log_file, $formatted_message, FILE_APPEND | LOCK_EX);
         
         if ($result === false) {
-            error_log('HIC Plugin: Failed to write to log file: ' . $this->log_file);
+            // Failed to write to log file
             return false;
         }
         
@@ -158,7 +158,7 @@ class HIC_Log_Manager {
         // Suppress potential warnings if the file is locked
         $file_size = @filesize($this->log_file);
         if ($file_size === false) {
-            error_log('HIC Plugin: Cannot get log file size: ' . $this->log_file);
+            // Cannot get log file size
             return false;
         }
 


### PR DESCRIPTION
## Summary
- replace `error_log` calls with `Helpers\hic_log` or `HIC_Log_Manager`
- drop direct `error_log` fallbacks and rely on unified log manager

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc17773acc832fb0c39a28869f7eb1