### PR TITLE
Use WordPress time for log entries

### DIFF
--- a/includes/log-manager.php
+++ b/includes/log-manager.php
@@ -83,7 +83,7 @@ class HIC_Log_Manager {
      * Format log entry
      */
     private function format_log_entry($message, $level, $context) {
-        $timestamp = date('Y-m-d H:i:s');
+        $timestamp = current_time('mysql');
         $level_str = strtoupper($level);
         
         // Convert message to string if it's an array or object

--- a/tests/LogManagerTest.php
+++ b/tests/LogManagerTest.php
@@ -1,0 +1,48 @@
+<?php
+namespace Helpers {
+    function hic_get_log_file() { return \FpHic\Helpers\hic_get_log_file(); }
+    function hic_is_debug_verbose() { return \FpHic\Helpers\hic_is_debug_verbose(); }
+}
+
+namespace {
+use PHPUnit\Framework\TestCase;
+use FpHic\Helpers;
+
+if (!function_exists('apply_filters')) {
+    function apply_filters($tag, $value) { return $value; }
+}
+
+require_once __DIR__ . '/../includes/log-manager.php';
+
+final class LogManagerTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        date_default_timezone_set('UTC');
+        $log_file = sys_get_temp_dir() . '/hic-log-timezone.log';
+        update_option('hic_log_file', $log_file);
+        if (file_exists($log_file)) {
+            unlink($log_file);
+        }
+    }
+
+    public function test_log_uses_wordpress_timezone(): void {
+        update_option('timezone_string', 'Europe/Rome');
+
+        $manager = new \HIC_Log_Manager();
+        $manager->info('timezone check');
+
+        $log_file = Helpers\hic_get_log_file();
+        $this->assertFileExists($log_file);
+        $line = trim(file_get_contents($log_file));
+        $timestamp = substr($line, 1, 19);
+
+        $wp_now = new \DateTime('now', new \DateTimeZone('Europe/Rome'));
+        $logged_wp = new \DateTime($timestamp, new \DateTimeZone('Europe/Rome'));
+        $this->assertLessThan(5, abs($wp_now->getTimestamp() - $logged_wp->getTimestamp()));
+
+        $server_now = new \DateTime('now', new \DateTimeZone('UTC'));
+        $logged_server = new \DateTime($timestamp, new \DateTimeZone('UTC'));
+        $this->assertGreaterThan(3000, abs($server_now->getTimestamp() - $logged_server->getTimestamp()));
+    }
+}
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -36,7 +36,25 @@ if (!function_exists('update_option')) {
 
 if (!function_exists('current_time')) {
     function current_time($type, $gmt = 0) {
-        return date($type === 'mysql' ? 'Y-m-d H:i:s' : 'U');
+        // Allow tests to override the time
+        if (isset($GLOBALS['hic_test_current_time'])) {
+            return $GLOBALS['hic_test_current_time'];
+        }
+
+        $timezone_string = get_option('timezone_string', 'UTC');
+        try {
+            $timezone = new DateTimeZone($timezone_string);
+        } catch (Exception $e) {
+            $timezone = new DateTimeZone('UTC');
+        }
+
+        $datetime = new DateTime('now', $timezone);
+
+        if ($gmt) {
+            $datetime->setTimezone(new DateTimeZone('UTC'));
+        }
+
+        return $datetime->format($type === 'mysql' ? 'Y-m-d H:i:s' : 'U');
     }
 }
 


### PR DESCRIPTION
## Summary
- Log entries now use `current_time('mysql')` so timestamps reflect WordPress timezone.
- Added `current_time` stub supporting timezone and override in test bootstrap.
- Added unit test verifying log manager records timestamps in WordPress timezone.

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc19f1516c832fa26c7ac2d98f6bdf