### PR TITLE
Conditionally load frontend script and document toggle

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -94,11 +94,13 @@ function hic_activate($network_wide)
 
 // Enqueue frontend JavaScript
 \add_action('wp_enqueue_scripts', function() {
-    \wp_enqueue_script(
-        'hic-frontend',
-        \plugin_dir_url(__FILE__) . 'assets/js/frontend.js',
-        array(),
-        HIC_PLUGIN_VERSION,
-        true
-    );
+    if (Helpers\hic_get_tracking_mode() === 'gtm_only') {
+        \wp_enqueue_script(
+            'hic-frontend',
+            \plugin_dir_url(__FILE__) . 'assets/js/frontend.js',
+            array(),
+            HIC_PLUGIN_VERSION,
+            true
+        );
+    }
 });

--- a/README.md
+++ b/README.md
@@ -17,7 +17,11 @@ Il tutto avviene **automaticamente** tramite un **sistema interno di scheduling*
 - **API Polling (Raccomandato)**: WordPress controlla HIC ogni 1-5 minuti per nuove prenotazioni
 - **Webhook**: HIC invia immediatamente le prenotazioni a WordPress (richiede configurazione su HIC)
 
-📖 **Documentazione Completa**: 
+### Caricamento dello script frontend
+
+Il file JavaScript che aggiunge il parametro SID ai link di prenotazione viene caricato solo quando la modalità di tracciamento è impostata su `gtm_only`. Per disabilitarlo è sufficiente selezionare una modalità differente nelle impostazioni del plugin; per riattivarlo ripristinare `gtm_only`.
+
+📖 **Documentazione Completa**:
 - [Come Funziona il Plugin](PLUGIN_FUNZIONAMENTO.md) - Spiegazione dettagliata
 - [Architettura Tecnica](ARCHITETTURA_TECNICA.md) - Diagrammi e flussi
 - [Guida Configurazione](GUIDA_CONFIGURAZIONE.md) - Setup passo-passo


### PR DESCRIPTION
## Summary
- Load frontend JavaScript only when tracking mode is `gtm_only`.
- Document in README how to enable or disable the frontend script.

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc20f92620832f8231873489091386