### PR TITLE
Add option cache clearing and invalidate after updates

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -437,6 +437,7 @@ function hic_mark_bookings_as_downloaded($booking_ids) {
     }
     
     update_option('hic_downloaded_booking_ids', $downloaded_ids, false);
+    Helpers\hic_clear_option_cache('hic_downloaded_booking_ids');
     
     Helpers\hic_log("Marked " . count($booking_ids) . " bookings as downloaded. Total tracked: " . count($downloaded_ids));
 }

--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -537,6 +537,7 @@ function hic_mark_reservation_processed($reservation) {
         }
         
         update_option('hic_synced_res_ids', $synced, false); // autoload=false
+        Helpers\hic_clear_option_cache('hic_synced_res_ids');
     }
 }
 
@@ -593,6 +594,7 @@ function hic_quasi_realtime_poll($prop_id, $start_time) {
         // Update stored timestamp if it was adjusted
         if ($validated_check !== $last_update_check) {
             update_option('hic_last_update_check', $validated_check, false);
+            Helpers\hic_clear_option_cache('hic_last_update_check');
             Helpers\hic_log("Quasi-realtime Poll: Updated stored timestamp from " . date('Y-m-d H:i:s', $last_update_check) . " to " . date('Y-m-d H:i:s', $validated_check));
             $last_update_check = $validated_check;
         }
@@ -612,6 +614,7 @@ function hic_quasi_realtime_poll($prop_id, $start_time) {
             
             // Update the last check timestamp
             update_option('hic_last_update_check', $current_time, false);
+            Helpers\hic_clear_option_cache('hic_last_update_check');
         } else {
             $error_message = $updated_reservations->get_error_message();
             $polling_errors[] = "updates polling: " . $error_message;
@@ -626,6 +629,7 @@ function hic_quasi_realtime_poll($prop_id, $start_time) {
                 $validated_reset = hic_validate_api_timestamp($reset_timestamp, 'Quasi-realtime Poll timestamp reset');
                 
                 update_option('hic_last_update_check', $validated_reset, false);
+                Helpers\hic_clear_option_cache('hic_last_update_check');
                 Helpers\hic_log('Quasi-realtime Poll: Timestamp error detected, reset timestamp to: ' . date('Y-m-d H:i:s', $validated_reset) . " ($validated_reset)");
                 
                 // Also reset scheduler timestamps to restart polling immediately with safe values
@@ -633,7 +637,9 @@ function hic_quasi_realtime_poll($prop_id, $start_time) {
                 $validated_recent = hic_validate_api_timestamp($recent_timestamp, 'Quasi-realtime Poll scheduler restart');
                 
                 update_option('hic_last_continuous_poll', $validated_recent, false);
+                Helpers\hic_clear_option_cache('hic_last_continuous_poll');
                 update_option('hic_last_deep_check', $validated_recent, false);
+                Helpers\hic_clear_option_cache('hic_last_deep_check');
                 Helpers\hic_log('Quasi-realtime Poll: Reset scheduler timestamps to restart polling: ' . date('Y-m-d H:i:s', $validated_recent));
             }
         }
@@ -665,13 +671,17 @@ function hic_quasi_realtime_poll($prop_id, $start_time) {
     
     // Store metrics for diagnostics
     update_option('hic_last_poll_count', $total_new, false);
+    Helpers\hic_clear_option_cache('hic_last_poll_count');
     update_option('hic_last_poll_skipped', $total_skipped, false);
+    Helpers\hic_clear_option_cache('hic_last_poll_skipped');
     update_option('hic_last_poll_duration', $execution_time, false);
+    Helpers\hic_clear_option_cache('hic_last_poll_duration');
     
     // Update last successful run only if polling was successful
     $polling_successful = empty($polling_errors) && $total_errors === 0;
     if ($polling_successful) {
         update_option('hic_last_successful_poll', $current_time, false);
+        Helpers\hic_clear_option_cache('hic_last_successful_poll');
         Helpers\hic_log("Internal Scheduler: Updated last successful poll timestamp");
     }
     
@@ -812,6 +822,7 @@ function hic_api_poll_updates(){
     
     // Always update execution timestamp regardless of results
     update_option('hic_last_api_poll', current_time('timestamp'), false);
+    Helpers\hic_clear_option_cache('hic_last_api_poll');
     
     $prop = Helpers\hic_get_property_id();
     
@@ -832,6 +843,7 @@ function hic_api_poll_updates(){
     // Update stored timestamp if it was adjusted
     if ($validated_last_since !== $last_since) {
         update_option('hic_last_updates_since', $validated_last_since, false);
+        Helpers\hic_clear_option_cache('hic_last_updates_since');
         Helpers\hic_log("Internal Scheduler: Updated stored timestamp from " . date('Y-m-d H:i:s', $last_since) . " to " . date('Y-m-d H:i:s', $validated_last_since));
         $last_since = $validated_last_since;
     }
@@ -881,6 +893,7 @@ function hic_api_poll_updates(){
         }
         
         update_option('hic_last_updates_since', $new_timestamp, false);
+        Helpers\hic_clear_option_cache('hic_last_updates_since');
         Helpers\hic_log('Internal Scheduler: hic_api_poll_updates completed successfully');
     } else {
         $error_message = $out->get_error_message();
@@ -895,6 +908,7 @@ function hic_api_poll_updates(){
             $validated_reset = hic_validate_api_timestamp($reset_timestamp, 'Internal Scheduler timestamp reset');
             
             update_option('hic_last_updates_since', $validated_reset, false);
+            Helpers\hic_clear_option_cache('hic_last_updates_since');
             Helpers\hic_log('Internal Scheduler: Timestamp error detected, reset timestamp to: ' . date('Y-m-d H:i:s', $validated_reset) . " ($validated_reset)");
             
             // Also reset scheduler timestamps to restart polling immediately with safe values
@@ -902,7 +916,9 @@ function hic_api_poll_updates(){
             $validated_recent = hic_validate_api_timestamp($recent_timestamp, 'Internal Scheduler scheduler restart');
             
             update_option('hic_last_continuous_poll', $validated_recent, false);
+            Helpers\hic_clear_option_cache('hic_last_continuous_poll');
             update_option('hic_last_deep_check', $validated_recent, false);
+            Helpers\hic_clear_option_cache('hic_last_deep_check');
             Helpers\hic_log('Internal Scheduler: Reset scheduler timestamps to restart polling: ' . date('Y-m-d H:i:s', $validated_recent));
         }
     }
@@ -1559,6 +1575,7 @@ function hic_api_poll_bookings_continuous() {
         // Update stored timestamp if it was adjusted
         if ($validated_check !== $last_continuous_check) {
             update_option('hic_last_continuous_check', $validated_check, false);
+            Helpers\hic_clear_option_cache('hic_last_continuous_check');
             Helpers\hic_log("Continuous Polling: Updated stored timestamp from " . date('Y-m-d H:i:s', $last_continuous_check) . " to " . date('Y-m-d H:i:s', $validated_check));
             $last_continuous_check = $validated_check;
         }
@@ -1578,6 +1595,7 @@ function hic_api_poll_bookings_continuous() {
             
             // Update the last check timestamp
             update_option('hic_last_continuous_check', $current_time, false);
+            Helpers\hic_clear_option_cache('hic_last_continuous_check');
         } else {
             $error_message = $updated_reservations->get_error_message();
             Helpers\hic_log("Continuous Polling: Error checking for updates: " . $error_message);
@@ -1592,6 +1610,7 @@ function hic_api_poll_bookings_continuous() {
                 $validated_reset = hic_validate_api_timestamp($reset_timestamp, 'Continuous Polling timestamp reset');
                 
                 update_option('hic_last_continuous_check', $validated_reset, false);
+                Helpers\hic_clear_option_cache('hic_last_continuous_check');
                 Helpers\hic_log('Continuous Polling: Timestamp error detected, reset timestamp to: ' . date('Y-m-d H:i:s', $validated_reset) . " ($validated_reset)");
                 
                 // Also reset scheduler timestamps to restart polling immediately with safe values
@@ -1599,7 +1618,9 @@ function hic_api_poll_bookings_continuous() {
                 $validated_recent = hic_validate_api_timestamp($recent_timestamp, 'Continuous Polling scheduler restart');
                 
                 update_option('hic_last_continuous_poll', $validated_recent, false);
+                Helpers\hic_clear_option_cache('hic_last_continuous_poll');
                 update_option('hic_last_deep_check', $validated_recent, false);
+                Helpers\hic_clear_option_cache('hic_last_deep_check');
                 Helpers\hic_log('Continuous Polling: Reset scheduler timestamps to restart polling: ' . date('Y-m-d H:i:s', $validated_recent));
             }
         }
@@ -1625,7 +1646,9 @@ function hic_api_poll_bookings_continuous() {
         
         // Store metrics for diagnostics
         update_option('hic_last_continuous_poll_count', $total_new, false);
+        Helpers\hic_clear_option_cache('hic_last_continuous_poll_count');
         update_option('hic_last_continuous_poll_duration', $execution_time, false);
+        Helpers\hic_clear_option_cache('hic_last_continuous_poll_duration');
         
         Helpers\hic_log("Continuous Polling: Completed in {$execution_time}ms - New: $total_new, Skipped: $total_skipped, Errors: $total_errors");
         
@@ -1708,12 +1731,17 @@ function hic_api_poll_bookings_deep_check() {
                 $validated_recent = hic_validate_api_timestamp($recent_timestamp, 'Deep Check scheduler restart');
                 
                 update_option('hic_last_updates_since', $validated_safe, false);
+                Helpers\hic_clear_option_cache('hic_last_updates_since');
                 update_option('hic_last_update_check', $validated_safe, false);
+                Helpers\hic_clear_option_cache('hic_last_update_check');
                 update_option('hic_last_continuous_check', $validated_safe, false);
+                Helpers\hic_clear_option_cache('hic_last_continuous_check');
                 
                 // Reset scheduler timestamps to restart polling immediately
                 update_option('hic_last_continuous_poll', $validated_recent, false);
+                Helpers\hic_clear_option_cache('hic_last_continuous_poll');
                 update_option('hic_last_deep_check', $validated_recent, false);
+                Helpers\hic_clear_option_cache('hic_last_deep_check');
                 
                 Helpers\hic_log('Deep Check: Reset all timestamps to: ' . date('Y-m-d H:i:s', $validated_safe) . " for recovery");
                 Helpers\hic_log('Deep Check: Reset scheduler timestamps to restart polling immediately: ' . date('Y-m-d H:i:s', $validated_recent));
@@ -1747,11 +1775,14 @@ function hic_api_poll_bookings_deep_check() {
         
         // Store metrics for diagnostics
         update_option('hic_last_deep_check_count', $total_new, false);
+        Helpers\hic_clear_option_cache('hic_last_deep_check_count');
         update_option('hic_last_deep_check_duration', $execution_time, false);
+        Helpers\hic_clear_option_cache('hic_last_deep_check_duration');
         
         // Update last successful deep check if no errors
         if ($total_errors === 0) {
             update_option('hic_last_successful_deep_check', $current_time, false);
+            Helpers\hic_clear_option_cache('hic_last_successful_deep_check');
         }
         
         Helpers\hic_log("Deep Check: Completed in {$execution_time}ms - Window: $from_date to $to_date, New: $total_new, Skipped: $total_skipped, Errors: $total_errors");

--- a/includes/api/webhook.php
+++ b/includes/api/webhook.php
@@ -71,6 +71,7 @@ function hic_webhook_handler(WP_REST_Request $request) {
     
     // Update last webhook processing time for diagnostics
     update_option('hic_last_webhook_processing', current_time('mysql'), false);
+    Helpers\hic_clear_option_cache('hic_last_webhook_processing');
     
     if ($result === false) {
       Helpers\hic_log('Webhook: elaborazione fallita per dati ricevuti');

--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -278,10 +278,15 @@ class HIC_Booking_Poller {
                 }
                 
                 update_option('hic_last_updates_since', $safe_timestamp, false);
+                \FpHic\Helpers\hic_clear_option_cache('hic_last_updates_since');
                 update_option('hic_last_update_check', $safe_timestamp, false);
+                \FpHic\Helpers\hic_clear_option_cache('hic_last_update_check');
                 update_option('hic_last_continuous_check', $safe_timestamp, false);
+                \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_check');
                 update_option('hic_last_continuous_poll', $recent_timestamp, false);
+                \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
                 update_option('hic_last_deep_check', $recent_timestamp, false);
+                \FpHic\Helpers\hic_clear_option_cache('hic_last_deep_check');
                 
                 // Also restart the scheduler to ensure clean state
                 $this->clear_all_scheduled_events();
@@ -459,6 +464,7 @@ class HIC_Booking_Poller {
         
         // Update timestamp first to prevent overlapping executions
         update_option('hic_last_continuous_poll', current_time('timestamp'), false);
+        \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
         
         if (function_exists('hic_api_poll_bookings_continuous')) {
             hic_api_poll_bookings_continuous();
@@ -477,6 +483,7 @@ class HIC_Booking_Poller {
         
         // Update timestamp first to prevent overlapping executions
         update_option('hic_last_deep_check', current_time('timestamp'), false);
+        \FpHic\Helpers\hic_clear_option_cache('hic_last_deep_check');
         
         if (function_exists('hic_api_poll_bookings_deep_check')) {
             hic_api_poll_bookings_deep_check();

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -186,6 +186,7 @@ if (defined('WP_CLI') && WP_CLI) {
 
                 // Update last poll timestamp
                 update_option('hic_last_reliable_poll', current_time('timestamp'));
+                \FpHic\Helpers\hic_clear_option_cache('hic_last_reliable_poll');
 
                 $execution_time = round(microtime(true) - $start_time, 2);
 

--- a/includes/database.php
+++ b/includes/database.php
@@ -172,6 +172,7 @@ function hic_maybe_upgrade_db() {
   // Fresh install
   if (!$installed_version) {
     update_option('hic_db_version', HIC_DB_VERSION);
+    Helpers\hic_clear_option_cache('hic_db_version');
     return;
   }
 
@@ -183,11 +184,13 @@ function hic_maybe_upgrade_db() {
       $wpdb->query("ALTER TABLE $table ADD COLUMN brevo_event_sent TINYINT(1) DEFAULT 0");
     }
     update_option('hic_db_version', '1.1');
+    Helpers\hic_clear_option_cache('hic_db_version');
     $installed_version = '1.1';
   }
 
   // Set final version
   update_option('hic_db_version', HIC_DB_VERSION);
+  Helpers\hic_clear_option_cache('hic_db_version');
 }
 
 /**

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -91,6 +91,7 @@ function hic_queue_gtm_event($event_data) {
     }
     
     update_option('hic_gtm_queued_events', $queued_events);
+    Helpers\hic_clear_option_cache('hic_gtm_queued_events');
 }
 
 /**

--- a/includes/performance-monitor.php
+++ b/includes/performance-monitor.php
@@ -122,6 +122,7 @@ class HIC_Performance_Monitor {
         $avg['last_updated'] = current_time('timestamp');
         
         update_option('hic_performance_averages', $averages, false);
+        \FpHic\Helpers\hic_clear_option_cache('hic_performance_averages');
     }
     
     /**
@@ -391,11 +392,15 @@ class HIC_Performance_Monitor {
         
         if ($last_init !== $today) {
             update_option('hic_metrics_last_init', $today, false);
-            
+            \FpHic\Helpers\hic_clear_option_cache('hic_metrics_last_init');
+
             // Reset daily counters
             update_option('hic_api_calls_today', 0, false);
+            \FpHic\Helpers\hic_clear_option_cache('hic_api_calls_today');
             update_option('hic_successful_bookings_today', 0, false);
+            \FpHic\Helpers\hic_clear_option_cache('hic_successful_bookings_today');
             update_option('hic_failed_bookings_today', 0, false);
+            \FpHic\Helpers\hic_clear_option_cache('hic_failed_bookings_today');
         }
     }
     


### PR DESCRIPTION
## Summary
- add `hic_clear_option_cache` to manage in-memory option cache and hook it to `updated_option`
- invoke `hic_clear_option_cache` after each `update_option` to keep cache fresh

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc21a88c44832f8bda2aadd700d406