### PR TITLE
Add daily cleanup for processed booking events

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Il token deve corrispondere al valore salvato nell'opzione `hic_health_token`.
 - `hic_continuous_poll_event` – polling continuo ogni minuto
 - `hic_deep_check_event` – verifica approfondita ogni 10 minuti
 - `hic_cleanup_event` – pulizia giornaliera degli identificatori
+- `hic_booking_events_cleanup` – pulizia giornaliera degli eventi di prenotazione processati
 - `hic_fallback_poll_event` – attivato in caso di ritardi o errori
 - `hic_health_monitor_event` – controllo periodico dello stato del plugin
 

--- a/includes/database.php
+++ b/includes/database.php
@@ -537,3 +537,34 @@ function hic_cleanup_old_gclids($days = 90) {
 
   return $deleted;
 }
+
+/* ============ Cleanup processed booking events ============ */
+function hic_cleanup_booking_events($days = 30) {
+  if ($days <= 0) return 0;
+
+  global $wpdb;
+
+  // Check if wpdb is available
+  if (!$wpdb) {
+    Helpers\hic_log('hic_cleanup_booking_events: wpdb is not available');
+    return false;
+  }
+
+  $table = $wpdb->prefix . 'hic_booking_events';
+  $cutoff = gmdate('Y-m-d H:i:s', strtotime("-{$days} days"));
+
+  // Delete processed records older than cutoff
+  $deleted = $wpdb->query($wpdb->prepare(
+    "DELETE FROM $table WHERE processed = 1 AND processed_at IS NOT NULL AND processed_at < %s",
+    $cutoff
+  ));
+
+  if ($deleted === false) {
+    Helpers\hic_log('hic_cleanup_booking_events: Database error: ' . $wpdb->last_error);
+    return false;
+  }
+
+  Helpers\hic_log("hic_cleanup_booking_events: Removed $deleted processed booking events older than $days days");
+
+  return $deleted;
+}


### PR DESCRIPTION
## Summary
- implement `hic_cleanup_booking_events()` to purge processed records older than a given age
- schedule daily WP-Cron `hic_booking_events_cleanup` and wire it into existing scheduler
- document new cron hook in README

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc25e9821c832f97f9b51b40cc2369