### PR TITLE
Add GA4 payload filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,21 @@ add_filter( 'hic_admin_email_body', function ( $body, $data ) {
 
 I parametri `$subject` e `$body` rappresentano rispettivamente oggetto e corpo generati dal plugin, mentre `$data` contiene i dettagli della prenotazione.
 
+### Personalizzazione payload GA4
+
+Il filtro `hic_ga4_payload` consente di modificare il payload inviato a Google Analytics 4 prima della codifica JSON. Il filtro riceve il payload generato dal plugin, i dati originali della prenotazione e gli identificatori di tracciamento `gclid` e `fbclid`.
+
+Esempio di aggiunta di un parametro personalizzato:
+
+```php
+add_filter( 'hic_ga4_payload', function ( $payload, $data, $gclid, $fbclid ) {
+    $payload['events'][0]['params']['coupon'] = 'SUMMER_PROMO';
+    return $payload;
+}, 10, 4 );
+```
+
+Il valore restituito dal filtro verrà inviato a GA4 come parte dell'evento.
+
 ### Personalizzazione Log
 
 È possibile modificare i giorni di conservazione dei log tramite il filtro WordPress `hic_log_retention_days`:

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -63,6 +63,8 @@ function hic_send_to_ga4($data, $gclid, $fbclid) {
     ]]
   ];
 
+  $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid);
+
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);
   if ($json_payload === false) {
@@ -181,6 +183,8 @@ function hic_dispatch_ga4_reservation($data) {
       'params' => $params
     ]]
   ];
+
+  $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid);
 
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);


### PR DESCRIPTION
## Summary
- Allow GA4 payload customization via `hic_ga4_payload` filter
- Document GA4 payload filter usage in README

## Testing
- `composer install`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc29ff0358832f9d3eaaee144040bd