### PR TITLE
Add filter for Facebook payload customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,21 @@ add_filter( 'hic_ga4_payload', function ( $payload, $data, $gclid, $fbclid ) {
 
 Il valore restituito dal filtro verrà inviato a GA4 come parte dell'evento.
 
+### Personalizzazione payload Facebook
+
+Il filtro `hic_fb_payload` consente di modificare il payload inviato a Facebook Meta prima della codifica JSON. Il filtro riceve il payload generato dal plugin, i dati originali della prenotazione e gli identificatori di tracciamento `gclid` e `fbclid`.
+
+Esempio di aggiunta di un parametro personalizzato:
+
+```php
+add_filter( 'hic_fb_payload', function ( $payload, $data, $gclid, $fbclid ) {
+    $payload['data'][0]['custom_data']['coupon'] = 'SUMMER_PROMO';
+    return $payload;
+}, 10, 4 );
+```
+
+Il valore restituito dal filtro verrà inviato a Meta come parte dell'evento.
+
 ### Personalizzazione Log
 
 È possibile modificare i giorni di conservazione dei log tramite il filtro WordPress `hic_log_retention_days`:

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -68,10 +68,13 @@ function hic_send_to_fb($data, $gclid, $fbclid){
         'order_id'     => $event_id,
         'bucket'       => $bucket,           // per creare custom conversions per fbads/organic/gads
         'content_name' => sanitize_text_field($data['room'] ?? $data['accommodation_name'] ?? 'Prenotazione'),
-        'vertical'     => 'hotel'
-      ]
-    ]]
-  ];
+      'vertical'     => 'hotel'
+    ]
+  ]]
+];
+
+  // Allow payload customization before encoding
+  $payload = apply_filters('hic_fb_payload', $payload, $data, $gclid, $fbclid);
 
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);
@@ -213,6 +216,9 @@ function hic_dispatch_pixel_reservation($data) {
       'custom_data' => $custom_data
     ]]
   ];
+
+  // Allow payload customization before encoding
+  $payload = apply_filters('hic_fb_payload', $payload, $data, $gclid, $fbclid);
 
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);


### PR DESCRIPTION
## Summary
- allow customization of Facebook CAPI payload via new `hic_fb_payload` filter
- document how to modify the Meta payload with a filter example

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2ad25534832fbca4b6c9498ebdf3