### PR TITLE
Add filter for SID cookie args and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,19 @@ add_filter( 'hic_log_retention_days', function ( $days ) {
 
 L'hook riceve il numero di giorni di retention configurato dal plugin (default 30) e deve restituire il nuovo valore da applicare.
 
+### Personalizzazione cookie SID
+
+Il filtro `hic_sid_cookie_args` permette di modificare i parametri del cookie `hic_sid` (scadenza, path, ecc.). Riceve l'array di argomenti di default e il valore del SID.
+
+```php
+add_filter( 'hic_sid_cookie_args', function ( $args, $sid ) {
+    $args['secure'] = false; // esempio: invio cookie anche su HTTP
+    return $args;
+}, 10, 2 );
+```
+
+Il filtro deve restituire l'array di argomenti che verrà passato a `setcookie()`.
+
 ## Note su Privacy e Rate Limits
 
 - Il plugin rispetta i rate limits delle API Hotel in Cloud

--- a/includes/database.php
+++ b/includes/database.php
@@ -228,13 +228,14 @@ function hic_store_tracking_id($type, $value, $existing_sid) {
 
   // Set cookie if needed
   if (!$existing_sid || $existing_sid === $value) {
-    $cookie_set = setcookie('hic_sid', $value, [
-      'expires'  => time() + 60 * 60 * 24 * 90,
+    $cookie_args = apply_filters('hic_sid_cookie_args', [
+      'expires'  => time() + 60*60*24*90,
       'path'     => '/',
       'secure'   => is_ssl(),
       'httponly' => true,
       'samesite' => 'Lax',
-    ]);
+    ], $value);
+    $cookie_set = setcookie('hic_sid', $value, $cookie_args);
     if ($cookie_set) {
       $_COOKIE['hic_sid'] = $value;
     } else {


### PR DESCRIPTION
## Summary
- allow customizing `hic_sid` cookie parameters via new `hic_sid_cookie_args` filter
- document `hic_sid_cookie_args` filter in README

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bc2c40aed0832fa9f1ab897c53e3bf