### PR TITLE
refactor: externalize admin settings styles

### DIFF
--- a/assets/css/admin-settings.css
+++ b/assets/css/admin-settings.css
@@ -1,0 +1,15 @@
+.hic-api-test-section .dashicons {
+    vertical-align: middle;
+    margin-right: 5px;
+}
+.hic-api-test-section .notice {
+    margin: 0;
+    padding: 10px;
+}
+.hic-api-test-section .notice p {
+    margin: 0;
+}
+.hic-api-test-section .spinner {
+    visibility: visible;
+}
+

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -224,6 +224,12 @@ function hic_admin_enqueue_scripts($hook) {
     }
 
     if ($hook === 'toplevel_page_hic-monitoring') {
+        wp_enqueue_style(
+            'hic-admin-settings',
+            plugin_dir_url(__FILE__) . '../../assets/css/admin-settings.css',
+            array(),
+            HIC_PLUGIN_VERSION
+        );
         wp_enqueue_script(
             'hic-admin-settings',
             plugin_dir_url(__FILE__) . '../../assets/js/admin-settings.js',
@@ -306,23 +312,6 @@ function hic_options_page() {
         </div>
         <?php endif; ?>
     </div>
-    
-    <style>
-    .hic-api-test-section .dashicons {
-        vertical-align: middle;
-        margin-right: 5px;
-    }
-    .hic-api-test-section .notice {
-        margin: 0;
-        padding: 10px;
-    }
-    .hic-api-test-section .notice p {
-        margin: 0;
-    }
-    .hic-api-test-section .spinner {
-        visibility: visible;
-    }
-    </style>
     <?php
 }
 


### PR DESCRIPTION
## Summary
- move admin page inline styles into a new stylesheet
- load the stylesheet via `hic_admin_enqueue_scripts`

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2d0bc5c8832fac3ab6a87c7088d9