### PR TITLE
Add WP-CLI cleanup command

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,9 @@ wp hic reset --confirm
 
 # Visualizza la coda degli eventi
 wp hic queue --limit=10 --status=pending
+
+# Esegui le routine di pulizia
+wp hic cleanup --logs --gclids --booking-events
 ```
 
 ### Gestione manuale degli eventi


### PR DESCRIPTION
## Summary
- add `wp hic cleanup` command with options for logs, gclid identifiers, and booking events
- document cleanup command in README

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bc2da4cf88832f88de4b7a9e89efb7