### PR TITLE
Document GA4 payload filter with usage example

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,6 +384,22 @@ Il parametro `vertical` consente di:
 }
 ```
 
+### Filtro `hic_ga4_payload`
+
+Il plugin espone il filtro WordPress `hic_ga4_payload` che permette di modificare il payload inviato a Google Analytics 4 prima che venga codificato in JSON.
+
+**Esempio di utilizzo**
+
+```php
+add_filter('hic_ga4_payload', function ($payload, $data, $gclid, $fbclid) {
+    // Aggiunge un parametro personalizzato all'evento GA4
+    $payload['events'][0]['params']['coupon'] = 'OFFERTA123';
+    return $payload;
+}, 10, 4);
+```
+
+Questo consente di adattare il payload GA4 a esigenze specifiche, come l'aggiunta di campi personalizzati o la modifica dei parametri inviati.
+
 ## Bucket Attribution Normalization
 
 Il plugin implementa un sistema di normalizzazione uniforme per il parametro `bucket` che identifica la fonte di attribuzione della conversione. Questa normalizzazione è applicata coerentemente in tutte le integrazioni (GA4, Meta CAPI, Brevo).

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -63,6 +63,7 @@ function hic_send_to_ga4($data, $gclid, $fbclid) {
     ]]
   ];
 
+  // Allow external modification of the GA4 payload
   $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid);
 
   // Validate JSON encoding
@@ -184,6 +185,7 @@ function hic_dispatch_ga4_reservation($data) {
     ]]
   ];
 
+  // Allow external modification of the GA4 payload
   $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid);
 
   // Validate JSON encoding


### PR DESCRIPTION
## Summary
- clarify GA4 payload filtering with inline comments
- document `hic_ga4_payload` filter and show usage example in README

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd1e3e8c38832f82ae1468ce7746c9