### PR TITLE
Add UTM tracking support across analytics integrations

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -118,4 +118,4 @@ define('HIC_PLUGIN_VERSION', '1.4.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
 define('HIC_MIN_WP_VERSION', '5.0');
-define('HIC_DB_VERSION', '1.1');
+define('HIC_DB_VERSION', '1.2');

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -39,6 +39,14 @@ function hic_send_brevo_contact($data, $gclid, $fbclid){
     'updateEnabled' => true
   );
 
+  // Populate UTM attributes if SID available
+  if (!empty($data['sid'])) {
+    $utm = Helpers\hic_get_utm_params_by_sid($data['sid']);
+    if (!empty($utm['utm_source']))   { $body['attributes']['UTM_SOURCE']   = $utm['utm_source']; }
+    if (!empty($utm['utm_medium']))   { $body['attributes']['UTM_MEDIUM']   = $utm['utm_medium']; }
+    if (!empty($utm['utm_campaign'])) { $body['attributes']['UTM_CAMPAIGN'] = $utm['utm_campaign']; }
+  }
+
   $res = Helpers\hic_http_request('https://api.brevo.com/v3/contacts', array(
     'method'  => 'POST',
     'headers' => array(
@@ -80,6 +88,14 @@ function hic_send_brevo_event($reservation, $gclid, $fbclid){
       'vertical'       => 'hotel'
     )
   );
+
+  // Attach UTM parameters if SID available
+  if (!empty($reservation['sid'])) {
+    $utm = Helpers\hic_get_utm_params_by_sid($reservation['sid']);
+    if (!empty($utm['utm_source']))   { $event_data['properties']['utm_source']   = $utm['utm_source']; }
+    if (!empty($utm['utm_medium']))   { $event_data['properties']['utm_medium']   = $utm['utm_medium']; }
+    if (!empty($utm['utm_campaign'])) { $event_data['properties']['utm_campaign'] = $utm['utm_campaign']; }
+  }
 
   $event_data = apply_filters('hic_brevo_event', $event_data, $reservation);
 
@@ -180,6 +196,14 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     'WHATSAPP' => isset($data['phone']) ? $data['phone'] : '',
     'LINGUA' => $language
   );
+
+  // Populate UTM attributes if available
+  if (!empty($data['transaction_id'])) {
+    $utm = Helpers\hic_get_utm_params_by_sid($data['transaction_id']);
+    if (!empty($utm['utm_source']))   { $attributes['UTM_SOURCE']   = $utm['utm_source']; }
+    if (!empty($utm['utm_medium']))   { $attributes['UTM_MEDIUM']   = $utm['utm_medium']; }
+    if (!empty($utm['utm_campaign'])) { $attributes['UTM_CAMPAIGN'] = $utm['utm_campaign']; }
+  }
 
   // Remove empty values but keep valid zeros for numeric fields
   $attributes = array_filter($attributes, function($value, $key) {
@@ -324,6 +348,14 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
       'created_at' => current_time('mysql')
     )
   );
+
+  // Add UTM parameters if available
+  if (!empty($data['transaction_id'])) {
+    $utm = Helpers\hic_get_utm_params_by_sid($data['transaction_id']);
+    if (!empty($utm['utm_source']))   { $body['properties']['utm_source']   = $utm['utm_source']; }
+    if (!empty($utm['utm_medium']))   { $body['properties']['utm_medium']   = $utm['utm_medium']; }
+    if (!empty($utm['utm_campaign'])) { $body['properties']['utm_campaign'] = $utm['utm_campaign']; }
+  }
 
   // Debug log the exact payload structure being sent
   Helpers\hic_log(array('Brevo trackEvent payload debug' => array(

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -55,6 +55,14 @@ function hic_send_to_ga4($data, $gclid, $fbclid) {
   if (!empty($gclid))  { $params['gclid']  = sanitize_text_field($gclid); }
   if (!empty($fbclid)) { $params['fbclid'] = sanitize_text_field($fbclid); }
 
+  // Append UTM parameters if available
+  if (!empty($data['sid'])) {
+    $utm = Helpers\hic_get_utm_params_by_sid($data['sid']);
+    if (!empty($utm['utm_source']))   { $params['utm_source']   = sanitize_text_field($utm['utm_source']); }
+    if (!empty($utm['utm_medium']))   { $params['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
+    if (!empty($utm['utm_campaign'])) { $params['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
+  }
+
   $payload = [
     'client_id' => $client_id,
     'events'    => [[
@@ -166,6 +174,12 @@ function hic_dispatch_ga4_reservation($data) {
     'bucket' => $bucket,             // Use normalized bucket based on attribution
     'vertical' => 'hotel'
   ];
+
+  // Attach UTM parameters if available
+  $utm = Helpers\hic_get_utm_params_by_sid($transaction_id);
+  if (!empty($utm['utm_source']))   { $params['utm_source']   = sanitize_text_field($utm['utm_source']); }
+  if (!empty($utm['utm_medium']))   { $params['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
+  if (!empty($utm['utm_campaign'])) { $params['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
 
   // Add optional item_category only if room_name is available
   if (!empty($data['room_name'])) {

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -66,6 +66,14 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid) {
         $gtm_data['fbclid'] = sanitize_text_field($fbclid);
     }
 
+    // Include UTM parameters if available
+    if (!empty($data['sid'])) {
+        $utm = Helpers\hic_get_utm_params_by_sid($data['sid']);
+        if (!empty($utm['utm_source']))   { $gtm_data['utm_source']   = sanitize_text_field($utm['utm_source']); }
+        if (!empty($utm['utm_medium']))   { $gtm_data['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
+        if (!empty($utm['utm_campaign'])) { $gtm_data['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
+    }
+
     // Store the data to be pushed to dataLayer on next page load
     hic_queue_gtm_event($gtm_data);
 


### PR DESCRIPTION
## Summary
- store `utm_source`, `utm_medium` and `utm_campaign` with session IDs
- expose helper to fetch UTM params for a SID
- include UTM parameters in GA4, GTM, Facebook and Brevo payloads

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bd20b09d54832f925e279ba63f3827