### PR TITLE
Use hic_sid as user identifier for analytics

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,10 @@ Il tutto avviene **automaticamente** tramite un **sistema interno di scheduling*
 
 Il file JavaScript che aggiunge il parametro SID ai link di prenotazione viene caricato solo quando la modalità di tracciamento è impostata su `gtm_only`. Per disabilitarlo è sufficiente selezionare una modalità differente nelle impostazioni del plugin; per riattivarlo ripristinare `gtm_only`.
 
+### Identificatore utente `hic_sid`
+
+Il plugin utilizza un cookie denominato `hic_sid` per collegare le prenotazioni agli utenti. Se presente, questo valore viene inviato come `client_id` e `transaction_id` a GA4 e come `transaction_id` nel dataLayer di GTM, consentendo un tracciamento coerente dell'utente tra le piattaforme.
+
 📖 **Documentazione Completa**:
 - [Come Funziona il Plugin](PLUGIN_FUNZIONAMENTO.md) - Spiegazione dettagliata
 - [Architettura Tecnica](ARCHITETTURA_TECNICA.md) - Diagrammi e flussi

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -245,7 +245,8 @@ function hic_test_dispatch_functions() {
         
         // Test GA4
         if (!empty(Helpers\hic_get_measurement_id()) && !empty(Helpers\hic_get_api_secret())) {
-            hic_send_to_ga4($test_data, $gclid, $fbclid);
+            $sid = $test_data['sid'] ?? null;
+            hic_send_to_ga4($test_data, $gclid, $fbclid, $sid);
             $results['ga4'] = 'Test event sent to GA4';
         } else {
             $results['ga4'] = 'GA4 not configured';
@@ -253,7 +254,8 @@ function hic_test_dispatch_functions() {
         
         // Test GTM
         if (Helpers\hic_is_gtm_enabled() && !empty(Helpers\hic_get_gtm_container_id())) {
-            hic_send_to_gtm_datalayer($test_data, $gclid, $fbclid);
+            $sid = $test_data['sid'] ?? null;
+            hic_send_to_gtm_datalayer($test_data, $gclid, $fbclid, $sid);
             $results['gtm'] = 'Test event queued for GTM DataLayer';
         } else {
             $results['gtm'] = 'GTM not configured or disabled';

--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -55,7 +55,7 @@ function hic_process_booking_data($data) {
     // GA4 Integration (server-side)
     if (($tracking_mode === 'ga4_only' || $tracking_mode === 'hybrid') && 
         Helpers\hic_get_measurement_id() && Helpers\hic_get_api_secret()) {
-      if (hic_send_to_ga4($data, $gclid, $fbclid)) {
+      if (hic_send_to_ga4($data, $gclid, $fbclid, $sid)) {
         $success_count++;
       } else {
         $error_count++;
@@ -66,7 +66,7 @@ function hic_process_booking_data($data) {
     
     // GTM Integration (client-side via dataLayer)
     if (($tracking_mode === 'gtm_only' || $tracking_mode === 'hybrid') && Helpers\hic_is_gtm_enabled()) {
-      if (hic_send_to_gtm_datalayer($data, $gclid, $fbclid)) {
+      if (hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $sid)) {
         $success_count++;
       } else {
         $error_count++;

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -155,21 +155,24 @@ class HICFunctionsTest {
 
         global $hic_last_request;
 
-        // GA4 room name
+        // GA4 room name + SID usage
         $data = ['room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_ga4($data, null, null);
+        $sid = 'sid123';
+        \FpHic\hic_send_to_ga4($data, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Camera Deluxe', 'GA4 should use room name');
+        assert($payload['client_id'] === $sid, 'GA4 should use SID as client_id');
+        assert($payload['events'][0]['params']['transaction_id'] === $sid, 'GA4 should use SID as transaction_id');
 
         // GA4 accommodation_name fallback
         $data = ['accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_ga4($data, null, null);
+        \FpHic\hic_send_to_ga4($data, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Suite', 'GA4 should use accommodation name');
 
         // GA4 default
         $data = ['currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_ga4($data, null, null);
+        \FpHic\hic_send_to_ga4($data, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Prenotazione', 'GA4 should default to Prenotazione');
 


### PR DESCRIPTION
## Summary
- pass SID from booking processor to GA4 and GTM integrations
- allow GA4 and GTM dispatchers to accept SID and map it to client_id/transaction_id
- document hic_sid usage and extend tests for SID handling

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bda297fe5c832f8a5496c329ed6fc2