### PR TITLE
Validate webhook content type

### DIFF
--- a/includes/api/webhook.php
+++ b/includes/api/webhook.php
@@ -35,6 +35,12 @@ function hic_webhook_handler(WP_REST_Request $request) {
     return new WP_Error('invalid_token','Token non valido',['status'=>403]);
   }
 
+  // Validate Content-Type header
+  $content_type = $request->get_header('content-type');
+  if ( stripos($content_type, 'application/json') === false ) {
+    return new WP_Error('invalid_content_type', 'Content-Type non supportato', ['status' => 415]);
+  }
+
   // Get raw body and validate size
   $raw = file_get_contents('php://input');
   if (strlen($raw) > HIC_WEBHOOK_MAX_PAYLOAD_SIZE) {


### PR DESCRIPTION
## Summary
- ensure webhook handler only processes JSON payloads
- return 415 when Content-Type is unsupported

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bda43d2ec8832fb6d8a0b1e3d8a560