### PR TITLE
Add User-Agent header to HTTP requests

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -391,10 +391,16 @@ function hic_http_request($url, $args = []) {
     if (!isset($args['timeout'])) {
         $args['timeout'] = defined('HIC_API_TIMEOUT') ? HIC_API_TIMEOUT : 15;
     }
+
+    $version = defined('HIC_PLUGIN_VERSION') ? HIC_PLUGIN_VERSION : '1.0';
     if (!isset($args['user-agent'])) {
-        $version = defined('HIC_PLUGIN_VERSION') ? HIC_PLUGIN_VERSION : '1.0';
-        $args['user-agent'] = 'HIC/' . $version;
+        $args['user-agent'] = 'HIC-Plugin/' . $version;
     }
+
+    if (!isset($args['headers']) || !is_array($args['headers'])) {
+        $args['headers'] = [];
+    }
+    $args['headers']['User-Agent'] = 'HIC-Plugin/' . $version;
 
     $response = wp_safe_remote_request($url, $args);
 


### PR DESCRIPTION
## Summary
- Ensure all hic_http_request calls include the `HIC-Plugin/<version>` User-Agent header

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bda65aa440832f886cbee72b8a8848