### PR TITLE
Add privacy exporter and eraser for tracking data

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,15 @@ Per monitorare lo stato del plugin dall'esterno è disponibile un endpoint pubbl
 
 Il token deve corrispondere al valore salvato nell'opzione `hic_health_token`.
 
+## Esportazione o cancellazione dei dati
+
+Il plugin supporta gli strumenti di privacy nativi di WordPress. Gli utenti possono richiedere l'esportazione o la cancellazione dei dati di tracciamento associati al proprio indirizzo email tramite:
+
+1. **Strumenti → Esporta dati personali**
+2. **Strumenti → Cancella dati personali**
+
+L'amministratore del sito approverà la richiesta e il sistema includerà i dati presenti nella tabella `hic_gclids`.
+
 ## Cron & CLI
 
 ### Hook Cron principali

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -185,6 +185,157 @@ function hic_should_schedule_retry_event() {
     return isset($schedules['hic_retry_interval']);
 }
 
+/* ============ Privacy Exporter/Eraser ============ */
+
+function hic_register_exporter($exporters) {
+    $exporters['hic-tracking-data'] = [
+        'exporter_friendly_name' => __('Dati di tracciamento HIC', 'hotel-in-cloud'),
+        'callback' => __NAMESPACE__ . '\\hic_export_tracking_data',
+    ];
+    return $exporters;
+}
+
+function hic_register_eraser($erasers) {
+    $erasers['hic-tracking-data'] = [
+        'eraser_friendly_name' => __('Dati di tracciamento HIC', 'hotel-in-cloud'),
+        'callback' => __NAMESPACE__ . '\\hic_erase_tracking_data',
+    ];
+    return $erasers;
+}
+
+/**
+ * Export tracking data associated with an email address.
+ */
+function hic_export_tracking_data($email_address, $page = 1) {
+    global $wpdb;
+
+    if (!$wpdb) {
+        return ['data' => [], 'done' => true];
+    }
+
+    $table = $wpdb->prefix . 'hic_gclids';
+    $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
+    if (!$table_exists) {
+        return ['data' => [], 'done' => true];
+    }
+
+    $email = sanitize_email($email_address);
+    if (empty($email)) {
+        return ['data' => [], 'done' => true];
+    }
+
+    $column_exists = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM $table LIKE %s", 'email'));
+    if (!$column_exists) {
+        return ['data' => [], 'done' => true];
+    }
+
+    $number = 50;
+    $offset = ($page - 1) * $number;
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT id, gclid, fbclid, sid, utm_source, utm_medium, utm_campaign, created_at FROM $table WHERE email = %s ORDER BY id ASC LIMIT %d OFFSET %d",
+            $email,
+            $number,
+            $offset
+        )
+    );
+
+    $data = [];
+    foreach ($rows as $row) {
+        $item = [];
+        if ($row->gclid !== null) {
+            $item[] = ['name' => 'gclid', 'value' => $row->gclid];
+        }
+        if ($row->fbclid !== null) {
+            $item[] = ['name' => 'fbclid', 'value' => $row->fbclid];
+        }
+        if ($row->sid !== null) {
+            $item[] = ['name' => 'sid', 'value' => $row->sid];
+        }
+        if ($row->utm_source !== null) {
+            $item[] = ['name' => 'utm_source', 'value' => $row->utm_source];
+        }
+        if ($row->utm_medium !== null) {
+            $item[] = ['name' => 'utm_medium', 'value' => $row->utm_medium];
+        }
+        if ($row->utm_campaign !== null) {
+            $item[] = ['name' => 'utm_campaign', 'value' => $row->utm_campaign];
+        }
+        if ($row->created_at !== null) {
+            $item[] = ['name' => 'created_at', 'value' => $row->created_at];
+        }
+
+        $data[] = [
+            'group_id'    => 'hic_tracking_data',
+            'group_label' => __('Dati di tracciamento HIC', 'hotel-in-cloud'),
+            'item_id'     => 'tracking-' . $row->id,
+            'data'        => $item,
+        ];
+    }
+
+    $done = count($rows) < $number;
+
+    return ['data' => $data, 'done' => $done];
+}
+
+/**
+ * Erase tracking data associated with an email address.
+ */
+function hic_erase_tracking_data($email_address, $page = 1) {
+    global $wpdb;
+
+    if (!$wpdb) {
+        return ['items_removed' => false, 'items_retained' => false, 'messages' => [], 'done' => true];
+    }
+
+    $table = $wpdb->prefix . 'hic_gclids';
+    $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
+    if (!$table_exists) {
+        return ['items_removed' => false, 'items_retained' => false, 'messages' => [], 'done' => true];
+    }
+
+    $email = sanitize_email($email_address);
+    if (empty($email)) {
+        return ['items_removed' => false, 'items_retained' => false, 'messages' => [], 'done' => true];
+    }
+
+    $column_exists = $wpdb->get_var($wpdb->prepare("SHOW COLUMNS FROM $table LIKE %s", 'email'));
+    if (!$column_exists) {
+        return ['items_removed' => false, 'items_retained' => false, 'messages' => [], 'done' => true];
+    }
+
+    $number = 50;
+    $offset = ($page - 1) * $number;
+    $rows = $wpdb->get_results(
+        $wpdb->prepare(
+            "SELECT id FROM $table WHERE email = %s ORDER BY id ASC LIMIT %d OFFSET %d",
+            $email,
+            $number,
+            $offset
+        )
+    );
+
+    $items_removed = false;
+    foreach ($rows as $row) {
+        $deleted = $wpdb->delete($table, ['id' => $row->id], ['%d']);
+        if ($deleted) {
+            $items_removed = true;
+        }
+    }
+
+    $done = count($rows) < $number;
+
+    return [
+        'items_removed'  => $items_removed,
+        'items_retained' => false,
+        'messages'       => [],
+        'done'           => $done,
+    ];
+}
+
+add_filter('wp_privacy_personal_data_exporters', __NAMESPACE__ . '\\hic_register_exporter');
+add_filter('wp_privacy_personal_data_erasers', __NAMESPACE__ . '\\hic_register_eraser');
+
 /* ============ New Helper Functions ============ */
 
 /**


### PR DESCRIPTION
## Summary
- register HIC tracking exporter and eraser with WordPress privacy filters
- implement export and erase callbacks for `hic_gclids` table
- document how users can request data export or removal

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bda737d210832f9fccb0ba512a6aff