### PR TITLE
Add log message filter with sensitive data masking

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,6 +442,23 @@ Il parametro `bucket` viene inviato in tutti gli eventi di conversione per:
 3. **Automazioni Brevo**: Trigger diversi in base alla fonte
 4. **Analisi Performance**: Confrontare ROI tra canali di acquisizione
 
+### Filtro `hic_log_message`
+
+Il plugin espone il filtro WordPress `hic_log_message` per permettere la
+personalizzazione dei messaggi di log. Il filtro riceve il messaggio originale
+e il livello di log e deve restituire la stringa che verrà salvata nel file.
+
+Per impostazione predefinita viene applicato l'helper `hic_mask_sensitive_data`
+che offusca email, numeri di telefono e token sensibili.
+
+Esempio di utilizzo:
+
+```php
+add_filter('hic_log_message', function($message, $level) {
+    return strtoupper($message);
+}, 10, 2);
+```
+
 ### Test e Validazione
 
 Il sistema include test completi per tutte le combinazioni:

--- a/includes/log-manager.php
+++ b/includes/log-manager.php
@@ -47,7 +47,19 @@ class HIC_Log_Manager {
 
         // Rotate log if needed
         $this->rotate_if_needed();
-        
+
+        /**
+         * Filters the log message before it is formatted and written.
+         *
+         * Developers can use this hook to modify or sanitize log messages.
+         * The default implementation applies the {@see hic_mask_sensitive_data}
+         * helper to hide common sensitive information.
+         *
+         * @param string $message Original log message.
+         * @param string $level   Log level for the message.
+         */
+        $message = apply_filters('hic_log_message', $message, $level);
+
         // Format log entry
         $formatted_message = $this->format_log_entry($message, $level, $context);
         

--- a/tests/LogMessageFilterTest.php
+++ b/tests/LogMessageFilterTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace {
+use PHPUnit\Framework\TestCase;
+use FpHic\Helpers;
+
+require_once __DIR__ . '/../includes/log-manager.php';
+
+final class LogMessageFilterTest extends TestCase {
+    protected function setUp(): void {
+        parent::setUp();
+        $log_file = sys_get_temp_dir() . '/hic-log-filter.log';
+        update_option('hic_log_file', $log_file);
+        if (file_exists($log_file)) {
+            unlink($log_file);
+        }
+    }
+
+    public function test_default_filter_masks_sensitive_data(): void {
+        $manager = new \HIC_Log_Manager();
+        $manager->info('contact john.doe@example.com phone 1234567890 token=abcdef');
+
+        $log_file = Helpers\hic_get_log_file();
+        $this->assertFileExists($log_file);
+        $contents = file_get_contents($log_file);
+        $this->assertStringNotContainsString('john.doe@example.com', $contents);
+        $this->assertStringNotContainsString('1234567890', $contents);
+        $this->assertStringNotContainsString('abcdef', $contents);
+        $this->assertStringContainsString('[masked-email]', $contents);
+    }
+}
+}

--- a/tests/preload.php
+++ b/tests/preload.php
@@ -11,7 +11,33 @@ if (!function_exists('add_action')) {
         $GLOBALS['hic_test_hooks'][$hook][] = $callback;
     }
 }
-if (!function_exists('add_filter')) { function add_filter(...$args) {} }
+// Basic filter system for testing
+if (!function_exists('add_filter')) {
+    function add_filter($hook, $callback, $priority = 10, $accepted_args = 1) {
+        $GLOBALS['hic_test_filters'][$hook][$priority][] = [
+            'function' => $callback,
+            'accepted_args' => $accepted_args
+        ];
+    }
+}
+if (!function_exists('apply_filters')) {
+    function apply_filters($hook, $value, ...$args) {
+        if (empty($GLOBALS['hic_test_filters'][$hook])) {
+            return $value;
+        }
+
+        ksort($GLOBALS['hic_test_filters'][$hook]);
+
+        foreach ($GLOBALS['hic_test_filters'][$hook] as $callbacks) {
+            foreach ($callbacks as $cb) {
+                $params = array_merge([$value], array_slice($args, 0, $cb['accepted_args'] - 1));
+                $value = \call_user_func_array($cb['function'], $params);
+            }
+        }
+
+        return $value;
+    }
+}
 if (!function_exists('register_activation_hook')) { function register_activation_hook(...$args) {} }
 if (!function_exists('register_deactivation_hook')) { function register_deactivation_hook(...$args) {} }
 if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled(...$args) { return false; } }


### PR DESCRIPTION
## Summary
- allow customization of log messages via new `hic_log_message` filter
- mask emails, phone numbers and tokens with `hic_mask_sensitive_data`
- document `hic_log_message` filter and cover with tests

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bda8806a98832f8ba128f600af104b