### PR TITLE
Secure log storage inside uploads directory

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -56,6 +56,20 @@ function hic_activate($network_wide)
             $role->add_cap('hic_manage');
         }
     }
+
+    $log_dir = WP_CONTENT_DIR . '/uploads/hic-logs';
+    if (!file_exists($log_dir)) {
+        if (function_exists('wp_mkdir_p')) {
+            wp_mkdir_p($log_dir);
+        } else {
+            @mkdir($log_dir, 0755, true);
+        }
+    }
+
+    $htaccess = $log_dir . '/.htaccess';
+    if (!file_exists($htaccess)) {
+        file_put_contents($htaccess, "Order allow,deny\nDeny from all\n");
+    }
 }
 
 // Plugin activation hook

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -66,10 +66,13 @@ function hic_reliable_polling_enabled() { return hic_get_option('reliable_pollin
 
 // Admin and General Settings
 function hic_get_admin_email() { return hic_get_option('admin_email', get_option('admin_email')); }
-function hic_get_log_file() { return hic_get_option('log_file', WP_CONTENT_DIR . '/hic-log.txt'); }
+function hic_get_log_file() {
+    return hic_get_option('log_file', WP_CONTENT_DIR . '/uploads/hic-logs/hic-log.txt');
+}
 
 function hic_validate_log_path($path) {
-    $default = WP_CONTENT_DIR . '/hic-log.txt';
+    $base_dir = WP_CONTENT_DIR . '/uploads/hic-logs/';
+    $default = $base_dir . 'hic-log.txt';
 
     $path = sanitize_text_field($path);
     if (empty($path)) {
@@ -77,9 +80,9 @@ function hic_validate_log_path($path) {
     }
 
     $normalized_path = str_replace('\\', '/', $path);
-    $base_path = rtrim(str_replace('\\', '/', WP_CONTENT_DIR), '/') . '/';
+    $normalized_base = rtrim(str_replace('\\', '/', $base_dir), '/') . '/';
 
-    if (strpos($normalized_path, '..') !== false || strpos($normalized_path, $base_path) !== 0) {
+    if (strpos($normalized_path, '..') !== false || strpos($normalized_path, $normalized_base) !== 0) {
         return $default;
     }
 

--- a/tests/LogPathValidationTest.php
+++ b/tests/LogPathValidationTest.php
@@ -1,0 +1,16 @@
+<?php
+use PHPUnit\Framework\TestCase;
+use FpHic\Helpers;
+
+final class LogPathValidationTest extends TestCase {
+    public function test_outside_path_returns_default() {
+        $result = Helpers\hic_validate_log_path('/etc/passwd');
+        $this->assertEquals(WP_CONTENT_DIR . '/uploads/hic-logs/hic-log.txt', $result);
+    }
+
+    public function test_inside_path_is_accepted() {
+        $path = WP_CONTENT_DIR . '/uploads/hic-logs/custom.log';
+        $result = Helpers\hic_validate_log_path($path);
+        $this->assertEquals(str_replace('\\', '/', $path), $result);
+    }
+}


### PR DESCRIPTION
## Summary
- Default log file now lives under `wp-content/uploads/hic-logs` and validation only permits paths within this folder
- Plugin activation creates `hic-logs` directory and locks it down with `.htaccess`
- Add tests to cover log path validation

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bdaf750df4832f99468e7a63318c48