### PR TITLE
Add log viewing capability and guard diagnostics logs

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -44,16 +44,26 @@ function hic_activate($network_wide)
             \switch_to_blog($site->blog_id);
             \hic_maybe_upgrade_db();
             $role = \get_role('administrator');
-            if ($role && !$role->has_cap('hic_manage')) {
-                $role->add_cap('hic_manage');
+            if ($role) {
+                if (!$role->has_cap('hic_manage')) {
+                    $role->add_cap('hic_manage');
+                }
+                if (!$role->has_cap('hic_view_logs')) {
+                    $role->add_cap('hic_view_logs');
+                }
             }
             \restore_current_blog();
         }
     } else {
         \hic_maybe_upgrade_db();
         $role = \get_role('administrator');
-        if ($role && !$role->has_cap('hic_manage')) {
-            $role->add_cap('hic_manage');
+        if ($role) {
+            if (!$role->has_cap('hic_manage')) {
+                $role->add_cap('hic_manage');
+            }
+            if (!$role->has_cap('hic_view_logs')) {
+                $role->add_cap('hic_view_logs');
+            }
         }
     }
 

--- a/README.md
+++ b/README.md
@@ -40,18 +40,19 @@ Il plugin utilizza un cookie denominato `hic_sid` per collegare le prenotazioni 
 
 ### Permessi
 
-Durante l'attivazione il plugin assegna automaticamente la capability `hic_manage` agli amministratori.  
-Per concedere l'accesso ad altri ruoli è possibile utilizzare un plugin di gestione ruoli oppure aggiungere una semplice funzione personalizzata:
+Durante l'attivazione il plugin assegna automaticamente le capability `hic_manage` e `hic_view_logs` agli amministratori.
+Per concedere queste capability ad altri ruoli è possibile utilizzare un plugin di gestione ruoli oppure aggiungere una semplice funzione personalizzata:
 
 ```php
 add_action('init', function () {
     if ($role = get_role('editor')) {
         $role->add_cap('hic_manage');
+        $role->add_cap('hic_view_logs');
     }
 });
 ```
 
-Il ruolo scelto otterrà così i permessi per configurare il plugin e visualizzare le pagine di amministrazione.
+Il ruolo scelto otterrà così i permessi per configurare il plugin e visualizzare le pagine di amministrazione e i log diagnostici.
 
 ## Configurazione API
 

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -609,7 +609,7 @@ function hic_ajax_refresh_diagnostics() {
             'scheduler_status' => hic_get_internal_scheduler_status(),
             'credentials_status' => hic_get_credentials_status(),
             'execution_stats' => hic_get_execution_stats(),
-            'recent_logs' => hic_get_log_manager()->get_recent_logs(20),
+            'recent_logs' => current_user_can('hic_view_logs') ? hic_get_log_manager()->get_recent_logs(20) : array(),
             'error_stats' => hic_get_error_stats()
         );
 
@@ -1072,7 +1072,7 @@ function hic_diagnostics_page() {
     $scheduler_status = hic_get_internal_scheduler_status();
     $credentials_status = hic_get_credentials_status();
     $execution_stats = hic_get_execution_stats();
-    $recent_logs = hic_get_log_manager()->get_recent_logs(20);
+    $recent_logs = current_user_can('hic_view_logs') ? hic_get_log_manager()->get_recent_logs(20) : array();
     $schedules = wp_get_schedules();
     $error_stats = hic_get_error_stats();
     
@@ -1199,6 +1199,7 @@ function hic_diagnostics_page() {
                         </button>
                     </div>
                     
+                    <?php if (current_user_can('hic_view_logs')): ?>
                     <div class="hic-action-group">
                         <h3>Logs & Export</h3>
                         <button class="button button-secondary" id="download-error-logs">
@@ -1206,6 +1207,7 @@ function hic_diagnostics_page() {
                             Scarica Log
                         </button>
                     </div>
+                    <?php endif; ?>
                 </div>
                 
                 <div id="quick-results" class="hic-results-container" style="display: none;">
@@ -1385,6 +1387,7 @@ function hic_diagnostics_page() {
                         </table>
                     </div>
                     
+                    <?php if (current_user_can('hic_view_logs')): ?>
                     <div class="hic-activity-section">
                         <h3>📝 Log Recenti</h3>
                         <div class="hic-logs-container">
@@ -1400,6 +1403,7 @@ function hic_diagnostics_page() {
                             <?php endif; ?>
                         </div>
                     </div>
+                    <?php endif; ?>
                 </div>
             </div>
             
@@ -1491,7 +1495,7 @@ function hic_diagnostics_page() {
  * AJAX handler for downloading error logs
  */
 function hic_ajax_download_error_logs() {
-    if ( ! current_user_can('hic_manage') ) {
+    if ( ! current_user_can('hic_view_logs') ) {
         wp_die( __( 'Permessi insufficienti', 'hotel-in-cloud' ) );
     }
 


### PR DESCRIPTION
## Summary
- grant `hic_view_logs` to administrators on plugin activation
- require `hic_view_logs` to view or download diagnostics logs
- document capability assignment for custom roles

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bdb04b2498832f923f142ad87602b1