### PR TITLE
Add log file rotation by age

### DIFF
--- a/tests/LogManagerTest.php
+++ b/tests/LogManagerTest.php
@@ -20,6 +20,7 @@ final class LogManagerTest extends TestCase {
         date_default_timezone_set('UTC');
         $log_file = sys_get_temp_dir() . '/hic-log-timezone.log';
         update_option('hic_log_file', $log_file);
+        \FpHic\Helpers\hic_clear_option_cache('log_file');
         if (file_exists($log_file)) {
             unlink($log_file);
         }
@@ -43,6 +44,32 @@ final class LogManagerTest extends TestCase {
         $server_now = new \DateTime('now', new \DateTimeZone('UTC'));
         $logged_server = new \DateTime($timestamp, new \DateTimeZone('UTC'));
         $this->assertGreaterThan(3000, abs($server_now->getTimestamp() - $logged_server->getTimestamp()));
+    }
+
+    public function test_rotates_logs_older_than_default(): void {
+        $log_file = sys_get_temp_dir() . '/hic-log-age.log';
+        update_option('hic_log_file', $log_file);
+        \FpHic\Helpers\hic_clear_option_cache('log_file');
+        foreach (glob($log_file . '*') as $file) {
+            @unlink($file);
+        }
+
+        file_put_contents($log_file, "old line\n");
+        $old_time = time() - (8 * 86400);
+        update_option('hic_log_created', $old_time);
+
+        $manager = new \HIC_Log_Manager();
+        $manager->info('new line');
+
+        $this->assertFileExists($log_file);
+        $contents = file_get_contents($log_file);
+        $this->assertStringContainsString('new line', $contents);
+        $this->assertStringNotContainsString('old line', $contents);
+
+        $rotated = glob($log_file . '.*');
+        $this->assertNotEmpty($rotated);
+
+        $this->assertGreaterThan($old_time, get_option('hic_log_created'));
     }
 }
 }


### PR DESCRIPTION
## Summary
- record log file creation time in option `hic_log_created`
- rotate log file when older than configurable number of days via `hic_log_rotation_days` filter
- add test for age-based rotation and log creation tracking

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb3d89d18832fb647afcd50045de0