### PR TITLE
Wrap fbp cookie read with wp_unslash

### DIFF
--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -59,7 +59,7 @@ function hic_send_to_fb($data, $gclid, $fbclid){
     $user_data['fbc'] = [$fbc];
   }
   if (!empty($_COOKIE['_fbp'])) {
-    $user_data['fbp'] = [sanitize_text_field($_COOKIE['_fbp'])];
+    $user_data['fbp'] = [sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) )];
   }
 
   $custom_data = [
@@ -208,7 +208,7 @@ function hic_dispatch_pixel_reservation($data) {
     $user_data['fbc'] = [$fbc];
   }
   if (!empty($_COOKIE['_fbp'])) {
-    $user_data['fbp'] = [sanitize_text_field($_COOKIE['_fbp'])];
+    $user_data['fbp'] = [sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) )];
   }
   
   $custom_data = [


### PR DESCRIPTION
## Summary
- Wrap `_fbp` cookie with `wp_unslash()` before `sanitize_text_field`
- Confirm other cookie reads already use `wp_unslash`

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb83dcb0c832fa381f730156ddc70