### PR TITLE
Load admin functionality only in dashboard

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -128,3 +128,11 @@ function hic_activate($network_wide)
         );
     }
 });
+
+// Load admin functionality only in dashboard
+if (\is_admin()) {
+    \add_action('admin_init', function () {
+        require_once __DIR__ . '/includes/admin/admin-settings.php';
+        require_once __DIR__ . '/includes/admin/diagnostics.php';
+    });
+}

--- a/composer.json
+++ b/composer.json
@@ -17,9 +17,7 @@
             "includes/integrations/brevo.php",
             "includes/api/webhook.php",
             "includes/api/polling.php",
-            "includes/cli.php",
-            "includes/admin/admin-settings.php",
-            "includes/admin/diagnostics.php"
+            "includes/cli.php"
         ]
     },
     "require-dev": {

--- a/tests/AdminSettingsSanitizationTest.php
+++ b/tests/AdminSettingsSanitizationTest.php
@@ -1,6 +1,7 @@
 <?php
 use PHPUnit\Framework\TestCase;
 require_once __DIR__ . '/bootstrap.php';
+require_once dirname(__DIR__) . '/includes/admin/admin-settings.php';
 
 if (!function_exists('register_setting')) {
     $GLOBALS['hic_registered_settings'] = [];


### PR DESCRIPTION
## Summary
- stop autoloading admin settings and diagnostics from composer
- load admin files conditionally via `admin_init` hook
- adjust tests to include admin settings manually

## Testing
- `composer dump-autoload`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdb9c8d9b8832f82ac6fe55ebf973e