### PR TITLE
Show validation errors on HIC settings page

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -285,6 +285,7 @@ function hic_admin_enqueue_scripts($hook) {
 function hic_options_page() {
     ?>
     <div class="wrap">
+        <?php settings_errors(); ?>
         <h1>Hotel in Cloud - Monitoraggio Conversioni</h1>
         <form action='options.php' method='post'>
             <?php


### PR DESCRIPTION
## Summary
- Display validation messages by calling `settings_errors()` before the settings page heading

## Testing
- `php /tmp/test_invalid_option.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdbc743bd8832f8cf0d8d3f8d63c70