### PR TITLE
Add config validation WP-CLI command

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,6 +193,9 @@ wp hic queue --limit=10 --status=pending
 
 # Esegui le routine di pulizia
 wp hic cleanup --logs --gclids --booking-events
+
+# Valida la configurazione del plugin
+wp hic validate-config
 ```
 
 ### Gestione manuale degli eventi

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -227,7 +227,45 @@ if (defined('WP_CLI') && WP_CLI) {
                 'id', 'booking_id', 'processed', 'poll_timestamp', 'processed_at', 'process_attempts', 'last_error'
             ));
         }
-        
+
+        /**
+         * Validate plugin configuration
+         *
+         * ## EXAMPLES
+         *
+         *     wp hic validate-config
+         *
+         * @param array $args
+         * @param array $assoc_args
+         */
+        public function validate_config($args, $assoc_args) {
+            $validator = function_exists('hic_get_config_validator') ? hic_get_config_validator() : null;
+            if (!$validator) {
+                WP_CLI::error('Config validator not available');
+                return;
+            }
+
+            $result = $validator->validate_all_config();
+
+            foreach ($result['warnings'] as $warning) {
+                WP_CLI::warning($warning);
+            }
+
+            foreach ($result['errors'] as $error) {
+                WP_CLI::error($error, false);
+            }
+
+            if (!empty($result['errors'])) {
+                WP_CLI::halt(1);
+            }
+
+            if (!empty($result['warnings'])) {
+                WP_CLI::success('Configuration valid with warnings');
+            } else {
+                WP_CLI::success('Configuration valid');
+            }
+        }
+
         /**
          * Force poll execution bypassing lock using public poller methods
          */


### PR DESCRIPTION
## Summary
- add `wp hic validate-config` command to run plugin configuration checks
- document config validation command in CLI section

## Testing
- `composer lint` (no output)
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bdbd9016b0832f8deae329e555e313