### PR TITLE
Allow opt-in HTTP requests via filter and use safe WP request

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -583,8 +583,11 @@ function hic_http_request($url, $args = []) {
         return new WP_Error('invalid_url', 'URL non valido');
     }
     if ('https' !== parse_url($validated_url, PHP_URL_SCHEME)) {
-        hic_log('HTTP request rifiutata: solo HTTPS consentito ' . $url, HIC_LOG_LEVEL_ERROR);
-        return new WP_Error('invalid_url', 'Solo HTTPS consentito');
+        $allow_insecure = apply_filters('hic_allow_insecure_http', false, $validated_url, $args);
+        if (!$allow_insecure) {
+            hic_log('HTTP request rifiutata: solo HTTPS consentito ' . $url, HIC_LOG_LEVEL_ERROR);
+            return new WP_Error('invalid_url', 'Solo HTTPS consentito');
+        }
     }
     $url = $validated_url;
 

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -163,6 +163,8 @@ if (!function_exists('wp_remote_post')) {
 
 if (!function_exists('wp_safe_remote_request')) {
     function wp_safe_remote_request($url, $args = array()) {
+        global $hic_last_request;
+        $hic_last_request = ['url' => $url, 'args' => $args];
         return array('body' => '{}', 'response' => array('code' => 200));
     }
 }

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -126,13 +126,6 @@ class HICFunctionsTest {
         if (!function_exists('wp_json_encode')) {
             function wp_json_encode($data) { return json_encode($data); }
         }
-        if (!function_exists('wp_remote_request')) {
-            function wp_remote_request($url, $args) {
-                global $hic_last_request;
-                $hic_last_request = ['url' => $url, 'args' => $args];
-                return ['response' => ['code' => 200], 'body' => '{}'];
-            }
-        }
         if (!function_exists('wp_remote_retrieve_response_code')) {
             function wp_remote_retrieve_response_code($res) { return $res['response']['code'] ?? 0; }
         }


### PR DESCRIPTION
## Summary
- Use `wp_safe_remote_request` in `hic_http_request`
- Add `hic_allow_insecure_http` filter to permit non-HTTPS calls explicitly
- Adjust tests to intercept safe remote requests

## Testing
- `composer test`
- `composer lint`

------
https://chatgpt.com/codex/tasks/task_e_68bdbe7ac2dc832f9bddc2fa9f3d0221