### PR TITLE
Add license metadata to plugin header

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -8,6 +8,8 @@
  * Requires PHP: 7.4
  * Text Domain: hotel-in-cloud
  * Domain Path: /languages
+ * License: GPLv2 or later
+ * License URI: https://www.gnu.org/licenses/gpl-2.0.html
  */
 
 namespace FpHic;


### PR DESCRIPTION
## Summary
- add GPL license fields to plugin metadata

## Testing
- `composer lint`
- `composer test`
- `php -r '$file="FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php"; $data=file_get_contents($file); $fields=["Plugin Name","License","License URI"]; foreach($fields as $field){ if(preg_match("/^ \* $field:\s*(.+)$/m", $data, $m)){ echo "$field: {$m[1]}\n"; } }'`


------
https://chatgpt.com/codex/tasks/task_e_68bdc01835cc832f8d7e8748ea449dc8