### PR TITLE
Validate health check level and document diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,16 @@ Per monitorare lo stato del plugin dall'esterno è disponibile un endpoint pubbl
 
 Il token deve corrispondere al valore salvato nell'opzione `hic_health_token`.
 
+#### Livelli diagnostici
+
+È possibile specificare il livello di diagnostica tramite il parametro opzionale `level`:
+
+- `basic` (`HIC_DIAGNOSTIC_BASIC`, predefinito)
+- `detailed` (`HIC_DIAGNOSTIC_DETAILED`)
+- `full` (`HIC_DIAGNOSTIC_FULL`)
+
+Se viene passato un valore non valido, il plugin esegue automaticamente il livello base.
+
 ## Esportazione o cancellazione dei dati
 
 Il plugin supporta gli strumenti di privacy nativi di WordPress. Gli utenti possono richiedere l'esportazione o la cancellazione dei dati di tracciamento associati al proprio indirizzo email tramite:

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -471,6 +471,16 @@ class HIC_Health_Monitor {
         }
 
         $level = sanitize_text_field( wp_unslash( $_GET['level'] ?? HIC_DIAGNOSTIC_BASIC ) );
+        $allowed_levels = [
+            HIC_DIAGNOSTIC_BASIC,
+            HIC_DIAGNOSTIC_DETAILED,
+            HIC_DIAGNOSTIC_FULL,
+        ];
+
+        if ( ! in_array( $level, $allowed_levels, true ) ) {
+            $level = HIC_DIAGNOSTIC_BASIC;
+        }
+
         $health_data = $this->check_health($level);
 
         wp_send_json($health_data);
@@ -498,13 +508,22 @@ class HIC_Health_Monitor {
      * REST API health check
      */
     public function rest_health_check($request) {
-        $level = $request->get_param('level') ?: HIC_DIAGNOSTIC_BASIC;
-        
+        $level = sanitize_text_field( $request->get_param('level') ?? HIC_DIAGNOSTIC_BASIC );
+        $allowed_levels = [
+            HIC_DIAGNOSTIC_BASIC,
+            HIC_DIAGNOSTIC_DETAILED,
+            HIC_DIAGNOSTIC_FULL,
+        ];
+
+        if ( ! in_array( $level, $allowed_levels, true ) ) {
+            $level = HIC_DIAGNOSTIC_BASIC;
+        }
+
         // Public endpoint only returns basic info
         if (!current_user_can('hic_manage')) {
             $level = HIC_DIAGNOSTIC_BASIC;
         }
-        
+
         return $this->check_health($level);
     }
     


### PR DESCRIPTION
## Summary
- Restrict health check `level` to known diagnostic constants and default to basic when invalid
- Document available health check levels in README

## Testing
- `composer lint`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc0db19a0832f9d9536b1bb0afb7a