### PR TITLE
Track msclkid and ttclid across integrations

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -246,7 +246,7 @@ function hic_test_dispatch_functions() {
         // Test GA4
         if (!empty(Helpers\hic_get_measurement_id()) && !empty(Helpers\hic_get_api_secret())) {
             $sid = $test_data['sid'] ?? null;
-            hic_send_to_ga4($test_data, $gclid, $fbclid, $sid);
+            hic_send_to_ga4($test_data, $gclid, $fbclid, '', '', $sid);
             $results['ga4'] = 'Test event sent to GA4';
         } else {
             $results['ga4'] = 'GA4 not configured';
@@ -263,7 +263,7 @@ function hic_test_dispatch_functions() {
         
         // Test Facebook
         if (!empty(Helpers\hic_get_fb_pixel_id()) && !empty(Helpers\hic_get_fb_access_token())) {
-            hic_send_to_fb($test_data, $gclid, $fbclid);
+            hic_send_to_fb($test_data, $gclid, $fbclid, '', '');
             $results['facebook'] = 'Test event sent to Facebook';
         } else {
             $results['facebook'] = 'Facebook not configured';
@@ -271,8 +271,8 @@ function hic_test_dispatch_functions() {
         
         // Test Brevo
         if (Helpers\hic_is_brevo_enabled() && !empty(Helpers\hic_get_brevo_api_key())) {
-            hic_send_brevo_contact($test_data, $gclid, $fbclid);
-            hic_send_brevo_event($test_data, $gclid, $fbclid);
+            hic_send_brevo_contact($test_data, $gclid, $fbclid, '', '');
+            hic_send_brevo_event($test_data, $gclid, $fbclid, '', '');
             $results['brevo'] = 'Test contact and event sent to Brevo';
         } else {
             $results['brevo'] = 'Brevo not configured or disabled';

--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -30,13 +30,17 @@ function hic_process_booking_data($data) {
 
   // Sanitize SID input
   $sid = !empty($data['sid']) ? sanitize_text_field($data['sid']) : null;
-  $gclid  = null;
-  $fbclid = null;
+  $gclid   = null;
+  $fbclid  = null;
+  $msclkid = null;
+  $ttclid  = null;
 
   if ($sid) {
     $tracking = Helpers\hic_get_tracking_ids_by_sid($sid);
-    $gclid = $tracking['gclid'];
-    $fbclid = $tracking['fbclid'];
+    $gclid   = $tracking['gclid'];
+    $fbclid  = $tracking['fbclid'];
+    $msclkid = $tracking['msclkid'];
+    $ttclid  = $tracking['ttclid'];
   }
 
   // Validation for amount if present
@@ -55,7 +59,7 @@ function hic_process_booking_data($data) {
     // GA4 Integration (server-side)
     if (($tracking_mode === 'ga4_only' || $tracking_mode === 'hybrid') && 
         Helpers\hic_get_measurement_id() && Helpers\hic_get_api_secret()) {
-      if (hic_send_to_ga4($data, $gclid, $fbclid, $sid)) {
+      if (hic_send_to_ga4($data, $gclid, $fbclid, $msclkid, $ttclid, $sid)) {
         $success_count++;
       } else {
         $error_count++;
@@ -77,7 +81,7 @@ function hic_process_booking_data($data) {
     
     // Facebook Integration
     if (Helpers\hic_get_fb_pixel_id() && Helpers\hic_get_fb_access_token()) {
-      if (hic_send_to_fb($data, $gclid, $fbclid)) {
+      if (hic_send_to_fb($data, $gclid, $fbclid, $msclkid, $ttclid)) {
         $success_count++;
       } else {
         $error_count++;
@@ -88,7 +92,7 @@ function hic_process_booking_data($data) {
     
     // Brevo Integration - Unified approach to prevent duplicate events
     if (Helpers\hic_is_brevo_enabled() && Helpers\hic_get_brevo_api_key()) {
-      $brevo_success = hic_send_unified_brevo_events($data, $gclid, $fbclid);
+      $brevo_success = hic_send_unified_brevo_events($data, $gclid, $fbclid, $msclkid, $ttclid);
       if ($brevo_success) {
         $success_count++;
       } else {

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -118,4 +118,4 @@ define('HIC_PLUGIN_VERSION', '1.4.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
 define('HIC_MIN_WP_VERSION', '5.0');
-define('HIC_DB_VERSION', '1.2');
+define('HIC_DB_VERSION', '1.3');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -381,13 +381,13 @@ add_filter('wp_privacy_personal_data_erasers', __NAMESPACE__ . '\\hic_register_e
  * Retrieve tracking IDs (gclid and fbclid) for a given SID from database.
  *
  * @param string $sid Session identifier
- * @return array{gclid:?string, fbclid:?string}
- */
+ * @return array{gclid:?string, fbclid:?string, msclkid:?string, ttclid:?string}
+*/
 function hic_get_tracking_ids_by_sid($sid) {
     static $cache = [];
     $sid = sanitize_text_field($sid);
     if (empty($sid)) {
-        return ['gclid' => null, 'fbclid' => null];
+        return ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
     }
 
     if (array_key_exists($sid, $cache)) {
@@ -397,7 +397,7 @@ function hic_get_tracking_ids_by_sid($sid) {
     global $wpdb;
     if (!$wpdb) {
         hic_log('hic_get_tracking_ids_by_sid: wpdb is not available');
-        return $cache[$sid] = ['gclid' => null, 'fbclid' => null];
+        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
     }
 
     $table = $wpdb->prefix . 'hic_gclids';
@@ -406,24 +406,25 @@ function hic_get_tracking_ids_by_sid($sid) {
     $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
     if (!$table_exists) {
         hic_log('hic_get_tracking_ids_by_sid: Table does not exist: ' . $table);
-        return $cache[$sid] = ['gclid' => null, 'fbclid' => null];
+        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
     }
-
-    $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $sid));
+    $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid, msclkid, ttclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $sid));
 
     if ($wpdb->last_error) {
-        hic_log('hic_get_tracking_ids_by_sid: Database error retrieving gclid/fbclid: ' . $wpdb->last_error);
-        return $cache[$sid] = ['gclid' => null, 'fbclid' => null];
+        hic_log('hic_get_tracking_ids_by_sid: Database error retrieving tracking IDs: ' . $wpdb->last_error);
+        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
     }
 
     if ($row) {
         return $cache[$sid] = [
             'gclid' => $row->gclid,
             'fbclid' => $row->fbclid,
+            'msclkid' => $row->msclkid,
+            'ttclid' => $row->ttclid,
         ];
     }
 
-    return $cache[$sid] = ['gclid' => null, 'fbclid' => null];
+    return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
 }
 
 /**

--- a/tests/TrackingIdsTest.php
+++ b/tests/TrackingIdsTest.php
@@ -57,20 +57,20 @@ final class TrackingIdsTest extends TestCase
     {
         global $wpdb;
         $wpdb = new MockWpdb();
-        $wpdb->exec("CREATE TABLE wp_hic_gclids (id INTEGER PRIMARY KEY AUTOINCREMENT, gclid TEXT, fbclid TEXT, sid TEXT);");
-        $wpdb->exec("INSERT INTO wp_hic_gclids (gclid, fbclid, sid) VALUES ('g1', 'f1', 'SID123');");
+        $wpdb->exec("CREATE TABLE wp_hic_gclids (id INTEGER PRIMARY KEY AUTOINCREMENT, gclid TEXT, fbclid TEXT, msclkid TEXT, ttclid TEXT, sid TEXT);");
+        $wpdb->exec("INSERT INTO wp_hic_gclids (gclid, fbclid, msclkid, ttclid, sid) VALUES ('g1', 'f1', 'm1', 't1', 'SID123');");
     }
 
     public function testRetrievesTrackingIds()
     {
         $result = Helpers\hic_get_tracking_ids_by_sid('SID123');
-        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1'], $result);
+        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1', 'msclkid' => 'm1', 'ttclid' => 't1'], $result);
     }
 
     public function testSanitizesSid()
     {
         $result = Helpers\hic_get_tracking_ids_by_sid('<script>SID123</script>');
-        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1'], $result);
+        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1', 'msclkid' => 'm1', 'ttclid' => 't1'], $result);
     }
 
     public function testReturnsNullWhenNotFound()
@@ -78,5 +78,7 @@ final class TrackingIdsTest extends TestCase
         $result = Helpers\hic_get_tracking_ids_by_sid('UNKNOWN');
         $this->assertNull($result['gclid']);
         $this->assertNull($result['fbclid']);
+        $this->assertNull($result['msclkid']);
+        $this->assertNull($result['ttclid']);
     }
 }

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -151,7 +151,7 @@ class HICFunctionsTest {
         // GA4 room name + SID usage
         $data = ['room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
         $sid = 'sid123';
-        \FpHic\hic_send_to_ga4($data, null, null, $sid);
+        \FpHic\hic_send_to_ga4($data, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Camera Deluxe', 'GA4 should use room name');
         assert($payload['client_id'] === $sid, 'GA4 should use SID as client_id');
@@ -159,31 +159,31 @@ class HICFunctionsTest {
 
         // GA4 accommodation_name fallback
         $data = ['accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_ga4($data, null, null, $sid);
+        \FpHic\hic_send_to_ga4($data, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Suite', 'GA4 should use accommodation name');
 
         // GA4 default
         $data = ['currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_ga4($data, null, null, $sid);
+        \FpHic\hic_send_to_ga4($data, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Prenotazione', 'GA4 should default to Prenotazione');
 
         // FB room name
         $data = ['email' => 'user@example.com', 'room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_fb($data, null, null);
+        \FpHic\hic_send_to_fb($data, null, null, null, null);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Camera Deluxe', 'FB should use room name');
 
         // FB accommodation_name fallback
         $data = ['email' => 'user@example.com', 'accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_fb($data, null, null);
+        \FpHic\hic_send_to_fb($data, null, null, null, null);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Suite', 'FB should use accommodation name');
 
         // FB default
         $data = ['email' => 'user@example.com', 'currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_fb($data, null, null);
+        \FpHic\hic_send_to_fb($data, null, null, null, null);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Prenotazione', 'FB should default to Prenotazione');
 


### PR DESCRIPTION
## Summary
- store `msclkid` and `ttclid` alongside existing tracking ids
- expose new ids in helper and forward them to GA4, Facebook and Brevo integrations
- bump database schema and tests for the additional fields

## Testing
- `composer lint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc1c65f3c832f9c741ea0d0ae188e