### PR TITLE
Add support for utm_content and utm_term tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,10 @@ Il file JavaScript che aggiunge il parametro SID ai link di prenotazione viene c
 
 Il plugin utilizza un cookie denominato `hic_sid` per collegare le prenotazioni agli utenti. Se presente, questo valore viene inviato come `client_id` e `transaction_id` a GA4 e come `transaction_id` nel dataLayer di GTM, consentendo un tracciamento coerente dell'utente tra le piattaforme.
 
+### Parametri UTM
+
+Quando un visitatore arriva sul sito con parametri UTM nella URL, il plugin salva `utm_source`, `utm_medium`, `utm_campaign`, `utm_content` e `utm_term` nella tabella `hic_gclids`, collegandoli al cookie `hic_sid`. Questi valori vengono poi inclusi automaticamente negli eventi inviati a GA4, Facebook/Meta, Google Tag Manager e Brevo per permettere un'analisi completa delle campagne di marketing.
+
 📖 **Documentazione Completa**:
 - [Come Funziona il Plugin](PLUGIN_FUNZIONAMENTO.md) - Spiegazione dettagliata
 - [Architettura Tecnica](ARCHITETTURA_TECNICA.md) - Diagrammi e flussi

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -118,4 +118,4 @@ define('HIC_PLUGIN_VERSION', '1.4.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
 define('HIC_MIN_WP_VERSION', '5.0');
-define('HIC_DB_VERSION', '1.3');
+define('HIC_DB_VERSION', '1.4');

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -47,6 +47,8 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
     if (!empty($utm['utm_source']))   { $body['attributes']['UTM_SOURCE']   = $utm['utm_source']; }
     if (!empty($utm['utm_medium']))   { $body['attributes']['UTM_MEDIUM']   = $utm['utm_medium']; }
     if (!empty($utm['utm_campaign'])) { $body['attributes']['UTM_CAMPAIGN'] = $utm['utm_campaign']; }
+    if (!empty($utm['utm_content']))  { $body['attributes']['UTM_CONTENT']  = $utm['utm_content']; }
+    if (!empty($utm['utm_term']))     { $body['attributes']['UTM_TERM']     = $utm['utm_term']; }
   }
 
   $res = Helpers\hic_http_request('https://api.brevo.com/v3/contacts', array(
@@ -99,6 +101,8 @@ function hic_send_brevo_event($reservation, $gclid, $fbclid, $msclkid = '', $ttc
     if (!empty($utm['utm_source']))   { $event_data['properties']['utm_source']   = $utm['utm_source']; }
     if (!empty($utm['utm_medium']))   { $event_data['properties']['utm_medium']   = $utm['utm_medium']; }
     if (!empty($utm['utm_campaign'])) { $event_data['properties']['utm_campaign'] = $utm['utm_campaign']; }
+    if (!empty($utm['utm_content']))  { $event_data['properties']['utm_content']  = $utm['utm_content']; }
+    if (!empty($utm['utm_term']))     { $event_data['properties']['utm_term']     = $utm['utm_term']; }
   }
 
   $event_data = apply_filters('hic_brevo_event', $event_data, $reservation);
@@ -211,6 +215,8 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     if (!empty($utm['utm_source']))   { $attributes['UTM_SOURCE']   = $utm['utm_source']; }
     if (!empty($utm['utm_medium']))   { $attributes['UTM_MEDIUM']   = $utm['utm_medium']; }
     if (!empty($utm['utm_campaign'])) { $attributes['UTM_CAMPAIGN'] = $utm['utm_campaign']; }
+    if (!empty($utm['utm_content']))  { $attributes['UTM_CONTENT']  = $utm['utm_content']; }
+    if (!empty($utm['utm_term']))     { $attributes['UTM_TERM']     = $utm['utm_term']; }
   }
 
   // Remove empty values but keep valid zeros for numeric fields
@@ -367,6 +373,8 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
     if (!empty($utm['utm_source']))   { $body['properties']['utm_source']   = $utm['utm_source']; }
     if (!empty($utm['utm_medium']))   { $body['properties']['utm_medium']   = $utm['utm_medium']; }
     if (!empty($utm['utm_campaign'])) { $body['properties']['utm_campaign'] = $utm['utm_campaign']; }
+    if (!empty($utm['utm_content']))  { $body['properties']['utm_content']  = $utm['utm_content']; }
+    if (!empty($utm['utm_term']))     { $body['properties']['utm_term']     = $utm['utm_term']; }
   }
 
   // Debug log the exact payload structure being sent

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -82,6 +82,8 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''){
     if (!empty($utm['utm_source']))   { $custom_data['utm_source']   = sanitize_text_field($utm['utm_source']); }
     if (!empty($utm['utm_medium']))   { $custom_data['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
     if (!empty($utm['utm_campaign'])) { $custom_data['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
+    if (!empty($utm['utm_content']))  { $custom_data['utm_content']  = sanitize_text_field($utm['utm_content']); }
+    if (!empty($utm['utm_term']))     { $custom_data['utm_term']     = sanitize_text_field($utm['utm_term']); }
   }
 
   $payload = [
@@ -240,6 +242,8 @@ function hic_dispatch_pixel_reservation($data) {
   if (!empty($utm['utm_source']))   { $custom_data['utm_source']   = sanitize_text_field($utm['utm_source']); }
   if (!empty($utm['utm_medium']))   { $custom_data['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
   if (!empty($utm['utm_campaign'])) { $custom_data['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
+  if (!empty($utm['utm_content']))  { $custom_data['utm_content']  = sanitize_text_field($utm['utm_content']); }
+  if (!empty($utm['utm_term']))     { $custom_data['utm_term']     = sanitize_text_field($utm['utm_term']); }
 
   // Add contents array if value > 0
   if ($value > 0) {

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -68,6 +68,8 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $s
     if (!empty($utm['utm_source']))   { $params['utm_source']   = sanitize_text_field($utm['utm_source']); }
     if (!empty($utm['utm_medium']))   { $params['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
     if (!empty($utm['utm_campaign'])) { $params['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
+    if (!empty($utm['utm_content']))  { $params['utm_content']  = sanitize_text_field($utm['utm_content']); }
+    if (!empty($utm['utm_term']))     { $params['utm_term']     = sanitize_text_field($utm['utm_term']); }
   }
 
   $payload = [
@@ -196,6 +198,8 @@ function hic_dispatch_ga4_reservation($data) {
   if (!empty($utm['utm_source']))   { $params['utm_source']   = sanitize_text_field($utm['utm_source']); }
   if (!empty($utm['utm_medium']))   { $params['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
   if (!empty($utm['utm_campaign'])) { $params['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
+  if (!empty($utm['utm_content']))  { $params['utm_content']  = sanitize_text_field($utm['utm_content']); }
+  if (!empty($utm['utm_term']))     { $params['utm_term']     = sanitize_text_field($utm['utm_term']); }
 
   // Add optional item_category only if room_name is available
   if (!empty($data['room_name'])) {

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -79,6 +79,8 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $sid = null) {
         if (!empty($utm['utm_source']))   { $gtm_data['utm_source']   = sanitize_text_field($utm['utm_source']); }
         if (!empty($utm['utm_medium']))   { $gtm_data['utm_medium']   = sanitize_text_field($utm['utm_medium']); }
         if (!empty($utm['utm_campaign'])) { $gtm_data['utm_campaign'] = sanitize_text_field($utm['utm_campaign']); }
+        if (!empty($utm['utm_content']))  { $gtm_data['utm_content']  = sanitize_text_field($utm['utm_content']); }
+        if (!empty($utm['utm_term']))     { $gtm_data['utm_term']     = sanitize_text_field($utm['utm_term']); }
     }
 
     // Store the data to be pushed to dataLayer on next page load

--- a/tests/TrackingIdsTest.php
+++ b/tests/TrackingIdsTest.php
@@ -57,8 +57,9 @@ final class TrackingIdsTest extends TestCase
     {
         global $wpdb;
         $wpdb = new MockWpdb();
-        $wpdb->exec("CREATE TABLE wp_hic_gclids (id INTEGER PRIMARY KEY AUTOINCREMENT, gclid TEXT, fbclid TEXT, msclkid TEXT, ttclid TEXT, sid TEXT);");
+        $wpdb->exec("CREATE TABLE wp_hic_gclids (id INTEGER PRIMARY KEY AUTOINCREMENT, gclid TEXT, fbclid TEXT, msclkid TEXT, ttclid TEXT, sid TEXT, utm_source TEXT, utm_medium TEXT, utm_campaign TEXT, utm_content TEXT, utm_term TEXT);");
         $wpdb->exec("INSERT INTO wp_hic_gclids (gclid, fbclid, msclkid, ttclid, sid) VALUES ('g1', 'f1', 'm1', 't1', 'SID123');");
+        $wpdb->exec("INSERT INTO wp_hic_gclids (sid, utm_source, utm_medium, utm_campaign, utm_content, utm_term) VALUES ('SIDUTM', 'google', 'cpc', 'camp', 'content', 'term');");
     }
 
     public function testRetrievesTrackingIds()
@@ -80,5 +81,17 @@ final class TrackingIdsTest extends TestCase
         $this->assertNull($result['fbclid']);
         $this->assertNull($result['msclkid']);
         $this->assertNull($result['ttclid']);
+    }
+
+    public function testRetrievesUtmParams()
+    {
+        $result = Helpers\hic_get_utm_params_by_sid('SIDUTM');
+        $this->assertSame([
+            'utm_source'   => 'google',
+            'utm_medium'   => 'cpc',
+            'utm_campaign' => 'camp',
+            'utm_content'  => 'content',
+            'utm_term'     => 'term',
+        ], $result);
     }
 }


### PR DESCRIPTION
## Summary
- store `utm_content` and `utm_term` in `hic_gclids`
- persist and expose new UTM parameters across GA4, GTM, Facebook and Brevo integrations
- document all supported UTM parameters

## Testing
- `composer lint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdc41151cc832f99551345353e27ca