### PR TITLE
Add Site Health checks for GA4 config and webhook

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -136,5 +136,6 @@ if (\is_admin()) {
     \add_action('admin_init', function () {
         require_once __DIR__ . '/includes/admin/admin-settings.php';
         require_once __DIR__ . '/includes/admin/diagnostics.php';
+        require_once __DIR__ . '/includes/site-health.php';
     });
 }

--- a/README.md
+++ b/README.md
@@ -167,6 +167,15 @@ Il token deve corrispondere al valore salvato nell'opzione `hic_health_token`.
 
 Se viene passato un valore non valido, il plugin esegue automaticamente il livello base.
 
+### Site Health Tests
+
+Nel menu **Strumenti → Salute del sito** il plugin aggiunge due verifiche dedicate:
+
+- **Configurazione GA4** (test diretto): controlla che Measurement ID e API Secret siano impostati. Se mancano uno o entrambi i parametri, lo stato risulta *critico*.
+- **Ping Webhook** (test asincrono): invia una richiesta all'endpoint `/wp-json/hic/v1/health` utilizzando il token configurato. Se la risposta non è valida, lo stato viene segnato come *critico*.
+
+Queste verifiche aiutano a individuare rapidamente problemi di configurazione o connettività.
+
 ## Esportazione o cancellazione dei dati
 
 Il plugin supporta gli strumenti di privacy nativi di WordPress. Gli utenti possono richiedere l'esportazione o la cancellazione dei dati di tracciamento associati al proprio indirizzo email tramite:

--- a/includes/site-health.php
+++ b/includes/site-health.php
@@ -1,0 +1,80 @@
+<?php declare(strict_types=1);
+namespace FpHic;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Register Site Health tests for the plugin.
+ */
+function hic_register_site_health_tests(array $tests): array
+{
+    $tests['direct']['hic_ga4_config'] = [
+        'label' => __('Configurazione GA4', 'hotel-in-cloud'),
+        'test'  => __NAMESPACE__ . '\\hic_site_health_ga4_config',
+    ];
+
+    $tests['async']['hic_webhook_ping'] = [
+        'label' => __('Ping Webhook', 'hotel-in-cloud'),
+        'test'  => __NAMESPACE__ . '\\hic_site_health_webhook_ping',
+    ];
+
+    return $tests;
+}
+
+/**
+ * Direct test: verify GA4 configuration.
+ */
+function hic_site_health_ga4_config(): array
+{
+    $configured = !empty(Helpers\hic_get_measurement_id()) && !empty(Helpers\hic_get_api_secret());
+
+    if ($configured) {
+        $status = 'good';
+        $message = __('La configurazione GA4 è completa.', 'hotel-in-cloud');
+    } else {
+        $status = 'critical';
+        $message = __('GA4 non è configurato correttamente.', 'hotel-in-cloud');
+    }
+
+    return [
+        'label'       => __('Configurazione GA4', 'hotel-in-cloud'),
+        'status'      => $status,
+        'description' => $message,
+        'test'        => 'hic_site_health_ga4_config',
+    ];
+}
+
+/**
+ * Async test: ping webhook/health endpoint.
+ *
+ * @param array $result Default test result.
+ * @return array Updated test result.
+ */
+function hic_site_health_webhook_ping(array $result): array
+{
+    $result['label'] = __('Ping Webhook', 'hotel-in-cloud');
+
+    $token = get_option('hic_health_token');
+    if (empty($token)) {
+        $result['status']      = 'recommended';
+        $result['description'] = __('Token health non configurato.', 'hotel-in-cloud');
+        return $result;
+    }
+
+    $url      = rest_url('hic/v1/health?token=' . urlencode($token));
+    $response = wp_remote_get($url, ['timeout' => 10]);
+
+    if (!is_wp_error($response) && 200 === (int) wp_remote_retrieve_response_code($response)) {
+        $result['status']      = 'good';
+        $result['description'] = __('Webhook risponde correttamente.', 'hotel-in-cloud');
+    } else {
+        $result['status']      = 'critical';
+        $result['description'] = __('Webhook non raggiungibile o token non valido.', 'hotel-in-cloud');
+    }
+
+    return $result;
+}
+
+add_filter('site_status_tests', __NAMESPACE__ . '\\hic_register_site_health_tests');


### PR DESCRIPTION
## Summary
- add Site Health direct and async tests for GA4 configuration and webhook ping
- load Site Health tests on `admin_init`
- document Site Health tests in README

## Testing
- `composer lint`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bdc6c0db10832f83e0ca0cfce15dde