### PR TITLE
feat: allow reservation tracking to be filtered

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ Il plugin utilizza un cookie denominato `hic_sid` per collegare le prenotazioni 
 
 Quando un visitatore arriva sul sito con parametri UTM nella URL, il plugin salva `utm_source`, `utm_medium`, `utm_campaign`, `utm_content` e `utm_term` nella tabella `hic_gclids`, collegandoli al cookie `hic_sid`. Questi valori vengono poi inclusi automaticamente negli eventi inviati a GA4, Facebook/Meta, Google Tag Manager e Brevo per permettere un'analisi completa delle campagne di marketing.
 
+## Filtri
+
+### `hic_should_track_reservation`
+
+Permette di bloccare l'invio degli eventi per una specifica prenotazione prima che raggiunga le integrazioni esterne.
+
+```php
+add_filter('hic_should_track_reservation', function ($should_track, $reservation) {
+    if (isset($reservation['email']) && strpos($reservation['email'], 'test@') !== false) {
+        return false; // salta la prenotazione
+    }
+    return $should_track;
+}, 10, 2);
+```
+
+Nell'esempio sopra vengono escluse dal tracciamento le prenotazioni che contengono `test@` nell'indirizzo email.
+
 📖 **Documentazione Completa**:
 - [Come Funziona il Plugin](PLUGIN_FUNZIONAMENTO.md) - Spiegazione dettagliata
 - [Architettura Tecnica](ARCHITETTURA_TECNICA.md) - Diagrammi e flussi

--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -51,6 +51,11 @@ function hic_process_booking_data($data) {
   $status = strtolower($data['status'] ?? ($data['presence'] ?? ''));
   $is_refund = in_array($status, ['cancelled', 'canceled', 'refunded'], true);
 
+  // Allow developers to conditionally skip tracking
+  if (!apply_filters('hic_should_track_reservation', true, $data)) {
+    return false;
+  }
+
   // Invii with error handling
   $success_count = 0;
   $error_count = 0;


### PR DESCRIPTION
## Summary
- add `hic_should_track_reservation` filter to skip sending events to integrations
- document the new filter with example

## Testing
- `composer lint` *(no output)*
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bdcb8e3eb8832fac7c80924b7ca43f