### PR TITLE
Add workflow to build plugin artifact

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,0 +1,33 @@
+name: Build Plugin
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.1'
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-dev --optimize-autoloader --prefer-dist --no-progress
+
+      - name: Run build script
+        run: ./build-plugin.sh
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-zip
+          path: build/*.zip

--- a/build-plugin.sh
+++ b/build-plugin.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PLUGIN_SLUG="fp-hotel-in-cloud-monitoraggio-conversioni"
+BUILD_DIR="build/${PLUGIN_SLUG}"
+
+echo "Cleaning and preparing build directory"
+rm -rf build
+mkdir -p "$BUILD_DIR"
+
+# Copy plugin files excluding development and meta files
+rsync -av \
+  --exclude='.git*' \
+  --exclude='.github/' \
+  --exclude='tests/' \
+  --exclude='docs/' \
+  --exclude='phpunit.xml' \
+  --exclude='phpstan.neon' \
+  --exclude='phpcs.xml' \
+  --exclude='phpmd.xml' \
+  --exclude='phpstan-stubs/' \
+  --exclude='composer.json' \
+  --exclude='composer.lock' \
+  --exclude='qa-runner.php' \
+  --exclude='demo-*' \
+  --exclude='*.md' \
+  --exclude='.phpunit.result.cache' \
+  --exclude='build/' \
+  --exclude='build-plugin.sh' \
+  ./ "$BUILD_DIR/"
+
+cd build
+ZIP_NAME="${PLUGIN_SLUG}.zip"
+
+echo "Creating ZIP archive: $ZIP_NAME"
+zip -r "$ZIP_NAME" "$PLUGIN_SLUG"
+
+echo "Build complete: build/$ZIP_NAME"


### PR DESCRIPTION
## Summary
- add build-plugin workflow for tag builds and manual runs
- add build-plugin.sh packaging script

## Testing
- `bash -n build-plugin.sh`
- `./build-plugin.sh`
- `composer validate`


------
https://chatgpt.com/codex/tasks/task_e_68beb709e3ec832f9cc01f9e1831919c