### PR TITLE
Add explicit namespace to booking processor

### DIFF
--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+namespace FpHic;
+
 /**
  * Common booking processing logic
  */


### PR DESCRIPTION
## Summary
- add `FpHic` namespace to `includes/booking-processor.php`

## Testing
- `composer test`
- `php -r "require 'tests/bootstrap.php'; require 'includes/integrations/ga4.php'; require 'includes/integrations/gtm.php'; require 'includes/integrations/facebook.php'; require 'includes/integrations/brevo.php'; \FpHic\hic_process_booking_data(['email'=>'test@example.com']); echo 'done';"`


------
https://chatgpt.com/codex/tasks/task_e_68bed56593e0832fa02826fdff29bef1