### PR TITLE
Load config validator before usage

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -117,7 +117,8 @@ function hic_activate($network_wide)
     require_once __DIR__ . '/includes/api/webhook.php';
     require_once __DIR__ . '/includes/api/polling.php';
     require_once __DIR__ . '/includes/cli.php';
-    
+    require_once __DIR__ . '/includes/config-validator.php';
+
     // Initialize helper action hooks
     Helpers\hic_init_helper_hooks();
     


### PR DESCRIPTION
## Summary
- ensure config validator file is loaded before using `hic_get_config_validator`

## Testing
- `composer lint:syntax`
- `composer test`
- `php -r "define('ABSPATH', __DIR__.'/'); require_once 'includes/config-validator.php'; hic_get_config_validator(); echo \"ok\\n\";"`


------
https://chatgpt.com/codex/tasks/task_e_68bed6af7410832f8ba9ff8c22c79639