### PR TITLE
Include performance monitor module

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -118,6 +118,7 @@ function hic_activate($network_wide)
     require_once __DIR__ . '/includes/api/polling.php';
     require_once __DIR__ . '/includes/cli.php';
     require_once __DIR__ . '/includes/config-validator.php';
+    require_once __DIR__ . '/includes/performance-monitor.php';
 
     // Initialize helper action hooks
     Helpers\hic_init_helper_hooks();


### PR DESCRIPTION
## Summary
- load `includes/performance-monitor.php` during init so `hic_get_performance_monitor()` is defined

## Testing
- `composer test`
- `./build-plugin.sh`
- `php -d auto_prepend_file=tests/preload.php -r 'require "FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php"; hic_get_performance_monitor();'`


------
https://chatgpt.com/codex/tasks/task_e_68bedbf966dc832f96ceabd5cde0f632