### PR TITLE
Fix cron helper references in performance monitor

### DIFF
--- a/includes/performance-monitor.php
+++ b/includes/performance-monitor.php
@@ -443,8 +443,8 @@ class HIC_Performance_Monitor {
      */
     private function schedule_cleanup() {
         // Use safe WordPress cron functions
-        if (!Helpers\hic_safe_wp_next_scheduled('hic_performance_cleanup')) {
-            Helpers\hic_safe_wp_schedule_event(time(), 'daily', 'hic_performance_cleanup');
+        if (!\FpHic\Helpers\hic_safe_wp_next_scheduled('hic_performance_cleanup')) {
+            \FpHic\Helpers\hic_safe_wp_schedule_event(time(), 'daily', 'hic_performance_cleanup');
         }
     }
     


### PR DESCRIPTION
## Summary
- use fully qualified helper calls when scheduling performance cleanup

## Testing
- `composer test`
- `vendor/bin/parallel-lint includes/ FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php`
- `bash build-plugin.sh`
- `php -r "define('ABSPATH', __DIR__); require 'includes/constants.php'; require 'includes/functions.php'; require 'includes/performance-monitor.php'; hic_get_performance_monitor(); echo 'done';"`

------
https://chatgpt.com/codex/tasks/task_e_68bedf5bd78c832fbf449716c18aa21e