### PR TITLE
Add FpHic namespace to config validator

### DIFF
--- a/includes/config-validator.php
+++ b/includes/config-validator.php
@@ -1,7 +1,10 @@
 <?php declare(strict_types=1);
+
+namespace FpHic {
+
 /**
  * Configuration Validation System for HIC Plugin
- * 
+ *
  * Provides comprehensive validation for all plugin settings and configurations.
  */
 
@@ -370,4 +373,11 @@ function hic_get_config_validator() {
         }
     }
     return isset($GLOBALS['hic_config_validator']) ? $GLOBALS['hic_config_validator'] : null;
+}
+}
+
+namespace {
+    function hic_get_config_validator() {
+        return \FpHic\hic_get_config_validator();
+    }
 }


### PR DESCRIPTION
## Summary
- scope config validator under `FpHic` namespace
- provide global wrapper for `hic_get_config_validator`

## Testing
- `php -l includes/config-validator.php`
- `composer run lint:syntax`
- `composer test`
- `./build-plugin.sh`


------
https://chatgpt.com/codex/tasks/task_e_68bee90b0168832fa3726eb4f23f7019