### PR TITLE
Load health monitor during plugin init

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -119,6 +119,7 @@ function hic_activate($network_wide)
     require_once __DIR__ . '/includes/cli.php';
     require_once __DIR__ . '/includes/config-validator.php';
     require_once __DIR__ . '/includes/performance-monitor.php';
+    require_once __DIR__ . '/includes/health-monitor.php';
 
     // Initialize helper action hooks
     Helpers\hic_init_helper_hooks();


### PR DESCRIPTION
## Summary
- include health monitor file during initialization to ensure health monitoring hooks are available

## Testing
- `php qa-runner.php`
- `bash build-plugin.sh`


------
https://chatgpt.com/codex/tasks/task_e_68beed1e18b0832f8a02759e857b2651