### PR TITLE
Use manage_options capability for admin menu

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -90,7 +90,7 @@ function hic_add_admin_menu() {
     add_menu_page(
         'HIC Monitoring Settings',
         'HIC Monitoring',
-        'hic_manage',
+        'manage_options',
         'hic-monitoring',
         'hic_options_page'
     );
@@ -100,7 +100,7 @@ function hic_add_admin_menu() {
         'hic-monitoring',
         'Diagnostics',
         'Diagnostics',
-        'hic_manage',
+        'manage_options',
         'hic-diagnostics',
         'hic_diagnostics_page'
     );


### PR DESCRIPTION
## Summary
- Switch admin menu capability from custom `hic_manage` to WordPress' standard `manage_options`

## Testing
- `vendor/bin/parallel-lint includes/ FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php`
- `composer test`
- `php wp-cli.phar plugin deactivate FP-Hotel-In-Cloud-Monitoraggio-Conversioni --allow-root` *(fails: not a WordPress installation)*
- `php wp-cli.phar plugin activate FP-Hotel-In-Cloud-Monitoraggio-Conversioni --allow-root` *(fails: not a WordPress installation)*


------
https://chatgpt.com/codex/tasks/task_e_68bef5e8d7e0832faf025876ee3a9a90