### PR TITLE
Load admin files during plugin initialization

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -152,9 +152,7 @@ function hic_activate($network_wide)
 
 // Load admin functionality only in dashboard
 if (\is_admin()) {
-    \add_action('admin_init', function () {
-        require_once __DIR__ . '/includes/admin/admin-settings.php';
-        require_once __DIR__ . '/includes/admin/diagnostics.php';
-        require_once __DIR__ . '/includes/site-health.php';
-    });
+    require_once __DIR__ . '/includes/admin/admin-settings.php';
+    require_once __DIR__ . '/includes/admin/diagnostics.php';
+    require_once __DIR__ . '/includes/site-health.php';
 }


### PR DESCRIPTION
## Summary
- Load admin settings, diagnostics, and site health directly when plugin runs in admin context

## Testing
- `composer test`
- `./build-plugin.sh`


------
https://chatgpt.com/codex/tasks/task_e_68beffe1a1c8832f83ab7421811b61c9