### PR TITLE
Allow diagnostics cards to span full width

### DIFF
--- a/assets/css/diagnostics.css
+++ b/assets/css/diagnostics.css
@@ -29,6 +29,7 @@
             box-shadow: 0 2px 4px rgba(0,0,0,0.04);
             padding: 24px;
             width: 100%;
+            max-width: none;
             box-sizing: border-box;
             transition: all 0.3s ease;
             position: relative;


### PR DESCRIPTION
## Summary
- ensure diagnostic cards can expand to container width by disabling max-width restriction

## Testing
- `composer test`
- `composer lint`

------
https://chatgpt.com/codex/tasks/task_e_68bf030507ac832fb061479733e19ef0