### PR TITLE
Handle JSON response directly in API test

### DIFF
--- a/assets/js/admin-settings.js
+++ b/assets/js/admin-settings.js
@@ -22,28 +22,22 @@ jQuery(function($){
             password: $('input[name="hic_api_password"]').val()
         };
 
-        $.post(ajaxurl, data, function(response){
+        $.post(ajaxurl, data, function(response) {
             $loading.hide();
             $btn.prop('disabled', false);
 
-            try {
-                var result = typeof response === 'string' ? JSON.parse(response) : response;
-                var resp = result.data || {};
-                var messageClass = result.success ? 'notice-success' : 'notice-error';
-                var icon = result.success ? 'dashicons-yes-alt' : 'dashicons-dismiss';
-                var html = '<div class="notice ' + messageClass + ' inline">' +
-                           '<p><span class="dashicons ' + icon + '"></span> ' + resp.message;
-                if (result.success && resp.data_count !== undefined) {
-                    html += ' (' + resp.data_count + ' prenotazioni trovate negli ultimi 7 giorni)';
-                }
-                html += '</p></div>';
-                $result.html(html).show();
-            } catch (e) {
-                $result.html('<div class="notice notice-error inline">' +
-                             '<p><span class="dashicons dashicons-dismiss"></span> Errore nel parsing della risposta</p>' +
-                             '</div>').show();
+            var resp = response.data || {};
+            var messageClass = response.success ? 'notice-success' : 'notice-error';
+            var icon = response.success ? 'dashicons-yes-alt' : 'dashicons-dismiss';
+            var html = '<div class="notice ' + messageClass + ' inline">' +
+                       '<p><span class="dashicons ' + icon + '"></span> ' + resp.message;
+
+            if (response.success && resp.data_count !== undefined) {
+                html += ' (' + resp.data_count + ' prenotazioni trovate negli ultimi 7 giorni)';
             }
-        }).fail(function(xhr, status, error){
+            html += '</p></div>';
+            $result.html(html).show();
+        }, 'json').fail(function(xhr, status, error) {
             $loading.hide();
             $btn.prop('disabled', false);
             $result.html('<div class="notice notice-error inline">' +


### PR DESCRIPTION
## Summary
- Parse API test responses automatically by requesting JSON via jQuery
- Drop manual JSON.parse and try/catch in admin settings test handler

## Testing
- `composer test`
- `bash build-plugin.sh`
- `node - <<'NODE'
function buildMessage(response) {
  var resp = response.data || {};
  var messageClass = response.success ? 'notice-success' : 'notice-error';
  var icon = response.success ? 'dashicons-yes-alt' : 'dashicons-dismiss';
  var html = '<div class="notice ' + messageClass + ' inline">' +
             '<p><span class="dashicons ' + icon + '"></span> ' + resp.message;
  if (response.success && resp.data_count !== undefined) {
    html += ' (' + resp.data_count + ' prenotazioni trovate negli ultimi 7 giorni)';
  }
  html += '</p></div>';
  return html;
}
console.log('Success HTML:', buildMessage({success:true, data:{message:'OK', data_count:5}}));
console.log('Failure HTML:', buildMessage({success:false, data:{message:'Errore'}}));
NODE`

------
https://chatgpt.com/codex/tasks/task_e_68bf0e0d02a4832fa98f0cdf5c5b67a1