### PR TITLE
Fix watchdog success check in diagnostics script

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -560,7 +560,7 @@ jQuery(document).ready(function($) {
                 action: 'hic_trigger_watchdog',
                 nonce: hicDiagnostics.admin_nonce
             }).done(function(response) {
-                if (response.data.success) {
+                if (response.success) {
                     buttonController.setSuccess('Watchdog completato con successo!');
                     $status.text('✓ Watchdog completato').css('color', '#00a32a');
 


### PR DESCRIPTION
## Summary
- read watchdog AJAX response success flag from `response.success`

## Testing
- `composer test`
- `./build-plugin.sh`
- `node - <<'NODE' ...` (verify watchdog completion message)


------
https://chatgpt.com/codex/tasks/task_e_68bf0f462b74832fb3555fd75b50fbd5