### PR TITLE
Ensure error log download handles missing file

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -1506,8 +1506,13 @@ function hic_ajax_download_error_logs() {
 
     $log_file = hic_get_log_file();
 
-    if (!file_exists($log_file) || !is_readable($log_file)) {
-        wp_die( __( 'File di log non trovato o non leggibile', 'hotel-in-cloud' ) );
+    if (!file_exists($log_file)) {
+        wp_mkdir_p(dirname($log_file));
+        touch($log_file);
+    }
+
+    if (!is_readable($log_file)) {
+        wp_die(__('File di log non leggibile', 'hotel-in-cloud'));
     }
     
     // Set headers for file download


### PR DESCRIPTION
## Summary
- Create missing log file when downloading diagnostics logs
- Fail gracefully if log file isn't readable

## Testing
- `composer test`
- `bash build-plugin.sh`
- manual check that `hic_ajax_download_error_logs` creates an empty log file and outputs no error


------
https://chatgpt.com/codex/tasks/task_e_68bf128c45b8832fad46b0dd144969bc