### PR TITLE
Namepsace API test call in admin settings

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -74,7 +74,7 @@ function hic_ajax_test_api_connection() {
     $password = sanitize_text_field( wp_unslash( $_POST['password'] ?? '' ) );
     
     // Test the API connection
-    $result = hic_test_api_connection($prop_id, $email, $password);
+    $result = \FpHic\hic_test_api_connection($prop_id, $email, $password);
 
     $success = !empty($result['success']);
     unset($result['success']);


### PR DESCRIPTION
## Summary
- ensure AJAX API connection test uses namespaced `\FpHic\hic_test_api_connection`

## Testing
- `php /tmp/test_ajax.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bf176993f0832fb18a6c3e1f620b8d