### PR TITLE
Fix missing namespace imports in diagnostics

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -3,6 +3,18 @@
  * HIC Plugin Diagnostics and Monitoring
  */
 
+use function FpHic\hic_send_to_ga4;
+use function FpHic\hic_send_to_gtm_datalayer;
+use function FpHic\hic_send_to_fb;
+use function FpHic\hic_send_brevo_contact;
+use function FpHic\hic_send_brevo_event;
+use function FpHic\hic_api_poll_bookings;
+use function FpHic\hic_fetch_reservations_raw;
+use function FpHic\hic_process_booking_data;
+use function FpHic\hic_backfill_reservations;
+use function FpHic\hic_test_brevo_contact_api;
+use function FpHic\hic_test_brevo_event_api;
+
 if (!defined('ABSPATH')) exit;
 
 \FpHic\Helpers\hic_safe_add_hook(


### PR DESCRIPTION
## Summary
- Import namespaced integration and polling functions in diagnostics to prevent undefined function errors.

## Testing
- `php qa-runner.php`


------
https://chatgpt.com/codex/tasks/task_e_68bf1eec85f4832fbeead1e8b8503fab