### PR TITLE
Fix webhook handler to call namespaced booking processor

### DIFF
--- a/includes/api/webhook.php
+++ b/includes/api/webhook.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+use function FpHic\hic_process_booking_data;
+
 /**
  * Webhook API Handler
  */


### PR DESCRIPTION
## Summary
- import `FpHic\hic_process_booking_data` in `includes/api/webhook.php`

## Testing
- `php /tmp/run_webhook_test.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bf20152e94832fb47c753c335808a1