### PR TITLE
Refactor polling hooks to use namespaced functions

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -289,9 +289,9 @@ class HIC_Booking_Poller {
                 $recent_timestamp = current_time('timestamp') - HIC_WATCHDOG_THRESHOLD; // 5 minutes ago for polling timestamps
                 
                 // Validate timestamps before using them (if hic_validate_api_timestamp is available)
-                if (function_exists('hic_validate_api_timestamp')) {
-                    $safe_timestamp = hic_validate_api_timestamp($safe_timestamp, 'Recovery data timestamp reset');
-                    $recent_timestamp = hic_validate_api_timestamp($recent_timestamp, 'Recovery polling timestamp reset');
+                if (function_exists('\\FpHic\\hic_validate_api_timestamp')) {
+                    $safe_timestamp = \FpHic\hic_validate_api_timestamp($safe_timestamp, 'Recovery data timestamp reset');
+                    $recent_timestamp = \FpHic\hic_validate_api_timestamp($recent_timestamp, 'Recovery polling timestamp reset');
                 }
                 
                 update_option('hic_last_updates_since', $safe_timestamp, false);
@@ -483,11 +483,11 @@ class HIC_Booking_Poller {
         update_option('hic_last_continuous_poll', current_time('timestamp'), false);
         \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
         
-        if (function_exists('hic_api_poll_bookings_continuous')) {
-            hic_api_poll_bookings_continuous();
-        } elseif (function_exists('hic_api_poll_bookings')) {
+        if (function_exists('\\FpHic\\hic_api_poll_bookings_continuous')) {
+            \FpHic\hic_api_poll_bookings_continuous();
+        } elseif (function_exists('\\FpHic\\hic_api_poll_bookings')) {
             // Fallback to existing function if new one doesn't exist yet
-            hic_api_poll_bookings();
+            \FpHic\hic_api_poll_bookings();
         }
     }
     
@@ -502,8 +502,8 @@ class HIC_Booking_Poller {
         update_option('hic_last_deep_check', current_time('timestamp'), false);
         \FpHic\Helpers\hic_clear_option_cache('hic_last_deep_check');
         
-        if (function_exists('hic_api_poll_bookings_deep_check')) {
-            hic_api_poll_bookings_deep_check();
+        if (function_exists('\\FpHic\\hic_api_poll_bookings_deep_check')) {
+            \FpHic\hic_api_poll_bookings_deep_check();
         } else {
             // Fallback implementation
             $this->fallback_deep_check();
@@ -527,8 +527,8 @@ class HIC_Booking_Poller {
         hic_log("Deep check: Searching for reservations from $from_date to $to_date (property: $prop_id)");
         
         // Check by check-in date to catch manual bookings and any missed ones
-        if (function_exists('hic_fetch_reservations_raw')) {
-            $reservations = hic_fetch_reservations_raw($prop_id, 'checkin', $from_date, $to_date, 200);
+        if (function_exists('\\FpHic\\hic_fetch_reservations_raw')) {
+            $reservations = \FpHic\hic_fetch_reservations_raw($prop_id, 'checkin', $from_date, $to_date, 200);
             if (!is_wp_error($reservations) && is_array($reservations)) {
                 $count = count($reservations);
                 hic_log("Deep check: Found $count reservations in " . HIC_DEEP_CHECK_LOOKBACK_DAYS . "-day lookback period");

--- a/tests/BookingPollerSchedulerTest.php
+++ b/tests/BookingPollerSchedulerTest.php
@@ -1,0 +1,44 @@
+<?php
+namespace FpHic {
+    function hic_validate_api_timestamp($timestamp, $context = 'api_request') {
+        $GLOBALS['poll_calls'][] = 'validate';
+        return $timestamp;
+    }
+    function hic_api_poll_bookings_continuous() {
+        $GLOBALS['poll_calls'][] = 'continuous';
+    }
+    function hic_api_poll_bookings() {
+        $GLOBALS['poll_calls'][] = 'fallback';
+    }
+    function hic_api_poll_bookings_deep_check() {
+        $GLOBALS['poll_calls'][] = 'deep';
+    }
+    function hic_fetch_reservations_raw($prop_id, $mode, $from_date, $to_date, $limit) {
+        $GLOBALS['poll_calls'][] = 'fetch';
+        return [];
+    }
+}
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/../includes/booking-poller.php';
+
+    class BookingPollerSchedulerTest extends TestCase {
+        protected function setUp(): void {
+            $GLOBALS['poll_calls'] = [];
+        }
+
+        public function test_execute_continuous_polling_calls_namespaced_function(): void {
+            $poller = new \HIC_Booking_Poller();
+            $poller->execute_continuous_polling();
+            $this->assertContains('continuous', $GLOBALS['poll_calls']);
+        }
+
+        public function test_execute_deep_check_calls_namespaced_function(): void {
+            $poller = new \HIC_Booking_Poller();
+            $poller->execute_deep_check();
+            $this->assertContains('deep', $GLOBALS['poll_calls']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- call polling functions using the `\FpHic` namespace and update `function_exists` checks
- add unit test verifying scheduler executes namespaced polling functions

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bf21a95554832fbe31811f3fb86acf