### PR TITLE
Use namespaced booking data processor in CLI resend command

### DIFF
--- a/includes/cli.php
+++ b/includes/cli.php
@@ -1,4 +1,5 @@
 <?php declare(strict_types=1);
+use function FpHic\hic_process_booking_data;
 /**
  * WP-CLI commands for HIC Plugin
  */


### PR DESCRIPTION
## Summary
- import `FpHic\hic_process_booking_data` in CLI commands
- ensure `hic resend` checks for and calls the namespaced function

## Testing
- `composer run lint:syntax`
- `composer run lint`
- `composer test`
- `wp hic resend 123` *(fails: command not found: wp)*

------
https://chatgpt.com/codex/tasks/task_e_68bf288913d0832fb33a72d652c45889