### PR TITLE
Use UTC timestamps for polling stats

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -825,7 +825,7 @@ function hic_api_poll_updates(){
     hic_log('Internal Scheduler: hic_api_poll_updates execution started');
     
     // Always update execution timestamp regardless of results
-    update_option('hic_last_api_poll', current_time('timestamp'), false);
+    update_option('hic_last_api_poll', time(), false);
     Helpers\hic_clear_option_cache('hic_last_api_poll');
     
     $prop = Helpers\hic_get_property_id();

--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -746,9 +746,9 @@ class HIC_Booking_Poller {
             'last_continuous_human' => $last_continuous > 0 ? human_time_diff($last_continuous) . ' fa' : 'Mai',
             'last_deep_check' => $last_deep,
             'last_deep_human' => $last_deep > 0 ? human_time_diff($last_deep) . ' fa' : 'Mai',
-            'lag_seconds' => $last_general > 0 ? current_time('timestamp') - $last_general : 0,
-            'continuous_lag' => $last_continuous > 0 ? current_time('timestamp') - $last_continuous : 0,
-            'deep_lag' => $last_deep > 0 ? current_time('timestamp') - $last_deep : 0,
+            'lag_seconds' => $last_general > 0 ? time() - $last_general : 0,
+            'continuous_lag' => $last_continuous > 0 ? time() - $last_continuous : 0,
+            'deep_lag' => $last_deep > 0 ? time() - $last_deep : 0,
             'polling_active' => $should_poll,
             'polling_interval' => HIC_CONTINUOUS_POLLING_INTERVAL,
             'deep_check_interval' => HIC_DEEP_CHECK_INTERVAL


### PR DESCRIPTION
## Summary
- store API polling timestamps in UTC
- calculate lag values using UTC timestamps

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfb1d457e8832fba18c22c3f158df4