### PR TITLE
Add default list for Brevo API test and improve diagnostics feedback

### DIFF
--- a/BREVO_QUICK_SETUP.md
+++ b/BREVO_QUICK_SETUP.md
@@ -71,3 +71,9 @@ add_filter('hic_brevo_event', function( $event_data, $reservation ) {
 
 - `$event_data`: array dell'evento inviato a Brevo
 - `$reservation`: dati originali della prenotazione
+
+## Test API e Diagnostica
+
+Il pulsante **Test API** della diagnosi crea temporaneamente un contatto di prova
+utilizzando la lista italiana predefinita. Il contatto viene eliminato subito dopo
+il test per mantenere pulite le liste reali.

--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -786,11 +786,26 @@ jQuery(document).ready(function($) {
                 action: 'hic_test_brevo_connectivity',
                 nonce: hicDiagnostics.admin_nonce
             }).done(function(response) {
-                if (response.success) {
+                if (!response.success) {
+                    showToast('Brevo API test failed: ' + response.data.message, 'error');
+                    return;
+                }
+
+                var contactOk = response.data.contact_api && response.data.contact_api.success;
+                var eventOk   = response.data.event_api && response.data.event_api.success;
+
+                if (contactOk && eventOk) {
                     $btn.removeClass('button-secondary').addClass('button-primary');
                     showToast('Brevo API test successful!', 'success');
                 } else {
-                    showToast('Brevo API test failed: ' + response.data.message, 'error');
+                    var message = 'Brevo API test failed:';
+                    if (!contactOk) {
+                        message += ' Contact API - ' + response.data.contact_api.message + '.';
+                    }
+                    if (!eventOk) {
+                        message += ' Event API - ' + response.data.event_api.message + '.';
+                    }
+                    showToast(message, 'error');
                 }
             }).fail(function() {
                 showToast('Communication error during Brevo API test', 'error');

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -750,14 +750,16 @@ function hic_transform_webhook_data_for_brevo($webhook_data) {
  */
 function hic_test_brevo_contact_api() {
   $test_email = 'test-' . current_time('timestamp') . '@example.com';
-  
+  // Use default Italian list for the test contact to ensure a valid payload
+  $list_id = intval(Helpers\hic_get_brevo_list_it());
+
   $body = array(
     'email' => $test_email,
     'attributes' => array(
       'FIRSTNAME' => 'Test',
       'LASTNAME' => 'Connectivity'
     ),
-    'listIds' => array(), // Empty list to avoid adding test contact to real lists
+    'listIds' => array($list_id),
     'updateEnabled' => false // Don't update if exists
   );
   
@@ -775,6 +777,17 @@ function hic_test_brevo_contact_api() {
     'test_email' => $test_email,
     'endpoint' => 'https://api.brevo.com/v3/contacts'
   ));
+
+  // Remove the test contact to keep the Brevo list clean
+  if ($result['success']) {
+    Helpers\hic_http_request('https://api.brevo.com/v3/contacts/' . rawurlencode($test_email), array(
+      'method'  => 'DELETE',
+      'headers' => array(
+        'accept'  => 'application/json',
+        'api-key' => Helpers\hic_get_brevo_api_key()
+      )
+    ));
+  }
   
   return array(
     'success' => $result['success'],


### PR DESCRIPTION
## Summary
- use Italian list for Brevo contact API tests and remove test contact afterward
- document diagnostic test behavior for Brevo
- show detailed result of Brevo quick API test in diagnostics

## Testing
- `composer lint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb27d8904832f8fd079717db563a8