### PR TITLE
Handle Brevo connectivity test failures

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -743,8 +743,14 @@ jQuery(document).ready(function($) {
             }).done(function(response) {
                 var html = '';
 
-                if (response.success) {
-                    html += '<div class="notice notice-success inline"><p><strong>Test Connettività Brevo Completato</strong></p>';
+                if (response.data && response.data.contact_api && response.data.event_api) {
+                    var noticeClass = response.success ? 'notice-success' : 'notice-error';
+                    html += '<div class="notice ' + noticeClass + ' inline">';
+                    if (response.success) {
+                        html += '<p><strong>Test Connettività Brevo Completato</strong></p>';
+                    } else {
+                        html += '<p><strong>Test Fallito:</strong> ' + response.data.message + '</p>';
+                    }
 
                     // Contact API results
                     html += '<h4>API Contatti:</h4>';
@@ -768,7 +774,7 @@ jQuery(document).ready(function($) {
                 }
 
                 $results.html(html).show();
-                
+
             }).fail(function() {
                 $results.html('<div class="notice notice-error inline"><p><strong>Errore di comunicazione con il server</strong></p></div>').show();
             }).always(function() {
@@ -787,7 +793,25 @@ jQuery(document).ready(function($) {
                 nonce: hicDiagnostics.admin_nonce
             }).done(function(response) {
                 if (!response.success) {
-                    showToast('Brevo API test failed: ' + response.data.message, 'error');
+                    var message = 'Brevo API test failed:';
+                    if (response.data.contact_api) {
+                        if (response.data.contact_api.success) {
+                            message += ' Contact API OK.';
+                        } else {
+                            message += ' Contact API - ' + response.data.contact_api.message + '.';
+                        }
+                    }
+                    if (response.data.event_api) {
+                        if (response.data.event_api.success) {
+                            message += ' Event API OK.';
+                        } else {
+                            message += ' Event API - ' + response.data.event_api.message + '.';
+                        }
+                    }
+                    if (!response.data.contact_api && !response.data.event_api && response.data.message) {
+                        message += ' ' + response.data.message;
+                    }
+                    showToast(message, 'error');
                     return;
                 }
 

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -1567,10 +1567,18 @@ function hic_ajax_test_brevo_connectivity() {
     // Test event API
     $event_test = hic_test_brevo_event_api();
 
+    if ( ! ( $contact_test['success'] && $event_test['success'] ) ) {
+        wp_send_json_error( array(
+            'message'     => __( 'Test connettività Brevo fallito', 'hotel-in-cloud' ),
+            'contact_api' => $contact_test,
+            'event_api'   => $event_test,
+        ) );
+    }
+
     wp_send_json_success( array(
-        'message' => __( 'Test connettività Brevo completato', 'hotel-in-cloud' ),
+        'message'     => __( 'Test connettività Brevo completato', 'hotel-in-cloud' ),
         'contact_api' => $contact_test,
-        'event_api' => $event_test
+        'event_api'   => $event_test,
     ) );
 }
 


### PR DESCRIPTION
## Summary
- Fail Brevo connectivity test when either API check fails and return detailed results
- Display Brevo test errors in diagnostics UI and toast messages

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb4725574832fb226f4747f042247