### PR TITLE
Handle failures in continuous polling timestamp

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -479,16 +479,25 @@ class HIC_Booking_Poller {
      */
     public function execute_continuous_polling() {
         hic_log("Scheduler: Executing continuous polling (1-minute interval)");
-        
-        // Update timestamp first to prevent overlapping executions
-        update_option('hic_last_continuous_poll', time(), false);
-        \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
-        
-        if (function_exists('\\FpHic\\hic_api_poll_bookings_continuous')) {
-            \FpHic\hic_api_poll_bookings_continuous();
-        } elseif (function_exists('\\FpHic\\hic_api_poll_bookings')) {
-            // Fallback to existing function if new one doesn't exist yet
-            \FpHic\hic_api_poll_bookings();
+        $success = false;
+        try {
+            if (function_exists('\\FpHic\\hic_api_poll_bookings_continuous')) {
+                $result = \FpHic\hic_api_poll_bookings_continuous();
+            } elseif (function_exists('\\FpHic\\hic_api_poll_bookings')) {
+                // Fallback to existing function if new one doesn't exist yet
+                $result = \FpHic\hic_api_poll_bookings();
+            } else {
+                $result = null;
+            }
+
+            $success = !is_wp_error($result);
+        } catch (\Throwable $e) {
+            throw $e;
+        } finally {
+            if ($success) {
+                update_option('hic_last_continuous_poll', time(), false);
+                \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
+            }
         }
     }
     


### PR DESCRIPTION
## Summary
- Update continuous poll timestamp only after a successful API polling run
- Add unit tests to cover successful updates and watchdog-triggered retries on failure

## Testing
- `php -l includes/booking-poller.php tests/BookingPollerSchedulerTest.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfb7ddebd8832f9906dc4291608c44