### PR TITLE
Record successful polling times

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -1657,9 +1657,15 @@ function hic_api_poll_bookings_continuous() {
         Helpers\hic_clear_option_cache('hic_last_continuous_poll_count');
         update_option('hic_last_continuous_poll_duration', $execution_time, false);
         Helpers\hic_clear_option_cache('hic_last_continuous_poll_duration');
-        
+
+        // Update last successful poll timestamp if polling had no errors or found new bookings
+        if ($total_errors === 0 || $total_new > 0) {
+            update_option('hic_last_successful_poll', $current_time, false);
+            Helpers\hic_clear_option_cache('hic_last_successful_poll');
+        }
+
         hic_log("Continuous Polling: Completed in {$execution_time}ms - New: $total_new, Skipped: $total_skipped, Errors: $total_errors");
-        
+
     } finally {
         Helpers\hic_release_polling_lock();
     }

--- a/tests/BookingPollerSchedulerTest.php
+++ b/tests/BookingPollerSchedulerTest.php
@@ -9,6 +9,7 @@ namespace FpHic {
         if (!empty($GLOBALS['simulate_continuous_error'])) {
             return new \WP_Error('poll_error', 'Simulated error');
         }
+        update_option('hic_last_successful_poll', time());
         return true;
     }
     function hic_api_poll_bookings() {
@@ -31,6 +32,7 @@ namespace {
     class BookingPollerSchedulerTest extends TestCase {
         protected function setUp(): void {
             $GLOBALS['poll_calls'] = [];
+            update_option('hic_last_successful_poll', 0);
         }
 
         public function test_execute_continuous_polling_calls_namespaced_function(): void {
@@ -52,18 +54,23 @@ namespace {
             $poller->execute_continuous_polling();
 
             $this->assertNotEquals(0, get_option('hic_last_continuous_poll'));
+            $this->assertNotEquals(0, get_option('hic_last_successful_poll'));
         }
 
         public function test_watchdog_detects_polling_failure(): void {
             $poller = new \HIC_Booking_Poller();
             $old = time() - (HIC_WATCHDOG_THRESHOLD + 10);
+            $old_success = time();
             update_option('hic_last_continuous_poll', $old);
+            update_option('hic_last_successful_poll', $old_success);
 
             $GLOBALS['simulate_continuous_error'] = true;
             $poller->execute_continuous_polling();
             $this->assertSame($old, get_option('hic_last_continuous_poll'));
+            $this->assertSame($old_success, get_option('hic_last_successful_poll'));
 
             $poller->run_watchdog_check();
+            $this->assertSame($old_success, get_option('hic_last_successful_poll'));
             $continuous = array_filter(
                 $GLOBALS['poll_calls'],
                 function ($call) { return $call === 'continuous'; }


### PR DESCRIPTION
## Summary
- Track the time of the last successful continuous poll when no errors occur or new reservations are found
- Ensure scheduler tests cover `hic_last_successful_poll` updates for diagnostics

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfbae0e4e0832fb0260e170d3015f1