### PR TITLE
Handle empty log file in log manager and diagnostics

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -1405,7 +1405,11 @@ function hic_diagnostics_page() {
                         <h3>📝 Log Recenti</h3>
                         <div class="hic-logs-container">
                             <?php if (empty($recent_logs)): ?>
-                                <p class="hic-no-logs">Nessun log recente disponibile.</p>
+                                <?php if (!empty($execution_stats['log_file_exists']) && (int) $execution_stats['log_file_size'] === 0): ?>
+                                    <p class="hic-no-logs">File di log presente ma vuoto.</p>
+                                <?php else: ?>
+                                    <p class="hic-no-logs">Nessun log recente disponibile.</p>
+                                <?php endif; ?>
                             <?php else: ?>
                                 <?php foreach (array_slice($recent_logs, 0, 8) as $log_entry): ?>
                                     <div class="hic-log-entry"><?php echo esc_html(sprintf('[%s] [%s] [%s] %s', $log_entry['timestamp'], $log_entry['level'], $log_entry['memory'], $log_entry['message'])); ?></div>

--- a/tests/LogManagerTest.php
+++ b/tests/LogManagerTest.php
@@ -71,5 +71,28 @@ final class LogManagerTest extends TestCase {
 
         $this->assertGreaterThan($old_time, get_option('hic_log_created'));
     }
+
+    public function test_get_recent_logs_handles_empty_file(): void {
+        $log_file = sys_get_temp_dir() . '/hic-log-empty.log';
+        update_option('hic_log_file', $log_file);
+        \FpHic\Helpers\hic_clear_option_cache('log_file');
+        file_put_contents($log_file, '');
+
+        $manager = new \HIC_Log_Manager();
+
+        $warnings = [];
+        set_error_handler(function ($severity, $message) use (&$warnings) {
+            if ($severity === E_WARNING) {
+                $warnings[] = $message;
+            }
+            return true;
+        });
+
+        $logs = $manager->get_recent_logs(10);
+        restore_error_handler();
+
+        $this->assertSame([], $logs);
+        $this->assertEmpty($warnings);
+    }
 }
 }


### PR DESCRIPTION
## Summary
- avoid warnings in log tailing by checking file size and fseek results
- show explanatory message in diagnostics when the log file is empty
- test recent log retrieval on empty files

## Testing
- `composer test`
- `php -d auto_prepend_file=tests/preload.php -r '$GLOBALS["hic_test_current_time"] = time(); function wp_date($f,$t=null){return date($f,$t??time());} $wpdb = new class { public $prefix = ""; public function prepare($q, ...$a){ return $q; } public function get_var($q){ return 0; } }; $GLOBALS["wpdb"] = $wpdb; require "tests/bootstrap.php"; function __($t,$d=""){return $t;} function current_user_can($cap){return true;} function esc_html($s){return $s;} function esc_attr($s){return $s;} function wp_nonce_field(){} function wp_get_schedules(){return [];} function human_time_diff($from,$to=null){return "0";} function hic_get_log_manager(){return new class {public function get_recent_logs($n){return [];}};} update_option("hic_log_file", sys_get_temp_dir()."/diag-empty.log"); file_put_contents(sys_get_temp_dir()."/diag-empty.log", ""); require "includes/admin/diagnostics.php"; ob_start(); hic_diagnostics_page(); $out=ob_get_clean(); echo $out;' >/tmp/diag_output.html && grep -n "File di log" /tmp/diag_output.html`

------
https://chatgpt.com/codex/tasks/task_e_68bfbbc75764832f85ceff79fc824552