### PR TITLE
Handle continuous polling result

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -479,22 +479,20 @@ class HIC_Booking_Poller {
      */
     public function execute_continuous_polling() {
         hic_log("Scheduler: Executing continuous polling (1-minute interval)");
-        $success = false;
+        $result = false;
         try {
-            if (function_exists('\\FpHic\\hic_api_poll_bookings_continuous')) {
+            if (function_exists('\FpHic\hic_api_poll_bookings_continuous')) {
                 $result = \FpHic\hic_api_poll_bookings_continuous();
-            } elseif (function_exists('\\FpHic\\hic_api_poll_bookings')) {
+            } elseif (function_exists('\FpHic\hic_api_poll_bookings')) {
                 // Fallback to existing function if new one doesn't exist yet
                 $result = \FpHic\hic_api_poll_bookings();
             } else {
                 $result = null;
             }
-
-            $success = !is_wp_error($result);
         } catch (\Throwable $e) {
             throw $e;
         } finally {
-            if ($success) {
+            if ($result === true) {
                 update_option('hic_last_continuous_poll', time(), false);
                 \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
             }


### PR DESCRIPTION
## Summary
- Return boolean/WP_Error from continuous polling and treat lock/property issues as failures
- Only refresh last continuous poll timestamp on success
- Add tests ensuring timestamps don't advance when polling errors or is skipped

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfbd95d19c832fbccb08b97d76ed34