### PR TITLE
Clamp backfill backfill reservation limit

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -203,6 +203,15 @@ jQuery(document).ready(function($) {
                 return;
             }
             
+            // Validate limit range if provided
+            if (limit) {
+                limit = parseInt(limit, 10);
+                if (limit < 1 || limit > 200) {
+                    alert('Il limite deve essere compreso tra 1 e 200.');
+                    return;
+                }
+            }
+
             // Confirmation
             var message = 'Vuoi avviare il backfill delle prenotazioni dal ' + fromDate + ' al ' + toDate + '?';
             if (limit) {
@@ -228,7 +237,7 @@ jQuery(document).ready(function($) {
             };
             
             if (limit) {
-                postData.limit = parseInt(limit);
+                postData.limit = limit;
             }
             
             $.post(ajaxurl, postData, function(response) {

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -738,6 +738,10 @@ function hic_ajax_backfill_reservations() {
     $date_type = sanitize_text_field( wp_unslash( $_POST['date_type'] ?? 'checkin' ) );
     $limit = isset($_POST['limit']) ? intval( wp_unslash( $_POST['limit'] ) ) : null;
 
+    if (null !== $limit) {
+        $limit = min( max( 1, $limit ), 200 );
+    }
+
     // Validate date type (based on API documentation: only checkin, checkout, presence are valid for /reservations endpoint)
     if (!in_array($date_type, array('checkin', 'checkout', 'presence'))) {
         wp_send_json_error( [ 'message' => __( 'Tipo di data non valido. Deve essere "checkin", "checkout" o "presence".', 'hotel-in-cloud' ) ] );
@@ -1439,7 +1443,7 @@ function hic_diagnostics_page() {
                     <div class="hic-advanced-content">
                         <div class="hic-advanced-section">
                             <h3>📦 Backfill Storico</h3>
-                            <p>Recupera prenotazioni da un intervallo temporale specifico.</p>
+                            <p>Recupera prenotazioni da un intervallo temporale specifico. Limite consentito: 1-200 prenotazioni.</p>
                             
                             <div class="hic-backfill-form">
                                 <div class="hic-form-row">
@@ -1456,7 +1460,7 @@ function hic_diagnostics_page() {
                                         <option value="presence">Presenza</option>
                                     </select>
                                     
-                                    <input type="number" id="backfill-limit" placeholder="Limite (opz.)" min="1" max="1000" />
+                                    <input type="number" id="backfill-limit" placeholder="Limite (1-200)" min="1" max="200" />
                                 </div>
                                 
                                 <div class="hic-form-actions">


### PR DESCRIPTION
## Summary
- Clamp backfill reservation limit between 1 and 200
- Document backfill limit range in diagnostics UI
- Validate limit range in diagnostics JavaScript

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfc0753d7c832fb000369cdf724843