### PR TITLE
Clamp reservation backfill limit and document range

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ Parametri:
 - `date_type`: Tipo di data (`checkin`, `checkout`) - default: `checkin`
 - `from_date`: Data inizio (formato Y-m-d)
 - `to_date`: Data fine (formato Y-m-d)  
-- `limit`: Numero massimo di risultati (opzionale)
+- `limit`: Numero massimo di risultati (opzionale, 1-200)
 
 ### Diagnostici e Test
 

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -1443,7 +1443,7 @@ function hic_diagnostics_page() {
                     <div class="hic-advanced-content">
                         <div class="hic-advanced-section">
                             <h3>📦 Backfill Storico</h3>
-                            <p>Recupera prenotazioni da un intervallo temporale specifico. Limite consentito: 1-200 prenotazioni.</p>
+                            <p>Recupera prenotazioni da un intervallo temporale specifico. Il limite deve essere compreso tra 1 e 200 prenotazioni; valori fuori da questo intervallo verranno adattati automaticamente.</p>
                             
                             <div class="hic-backfill-form">
                                 <div class="hic-form-row">

--- a/tests/BackfillLimitTest.php
+++ b/tests/BackfillLimitTest.php
@@ -1,0 +1,72 @@
+<?php
+namespace FpHic {
+    function hic_backfill_reservations($from_date, $to_date, $date_type, $limit) {
+        $GLOBALS['backfill_params'] = compact('from_date', 'to_date', 'date_type', 'limit');
+        return [
+            'success' => true,
+            'stats' => [
+                'total_found' => 0,
+                'total_processed' => 0,
+                'total_skipped' => 0,
+                'total_errors' => 0,
+                'execution_time' => 0,
+            ],
+            'message' => 'ok',
+        ];
+    }
+}
+namespace {
+    use PHPUnit\Framework\TestCase;
+    require_once __DIR__ . '/bootstrap.php';
+
+    if (!function_exists('check_ajax_referer')) {
+        function check_ajax_referer($action, $arg = false, $die = true) {
+            return true;
+        }
+    }
+    if (!function_exists('__')) {
+        function __($text, $domain = null) {
+            return $text;
+        }
+    }
+    if (!function_exists('wp_unslash')) {
+        function wp_unslash($value) {
+            return $value;
+        }
+    }
+    if (!function_exists('wp_send_json_error')) {
+        function wp_send_json_error($data) {
+            $GLOBALS['ajax_response'] = ['success' => false, 'data' => $data];
+        }
+    }
+    if (!function_exists('wp_send_json_success')) {
+        function wp_send_json_success($data) {
+            $GLOBALS['ajax_response'] = ['success' => true, 'data' => $data];
+        }
+    }
+
+    require_once dirname(__DIR__) . '/includes/admin/diagnostics.php';
+
+    final class BackfillLimitTest extends TestCase {
+        protected function setUp(): void {
+            $GLOBALS['ajax_response'] = null;
+            $GLOBALS['backfill_params'] = null;
+        }
+
+        public function test_limit_clamped_to_valid_range(): void {
+            $_POST = [
+                'nonce' => 'abc',
+                'from_date' => '2024-01-01',
+                'to_date' => '2024-01-05',
+                'date_type' => 'checkin',
+                'limit' => '500',
+            ];
+            hic_ajax_backfill_reservations();
+            $this->assertSame(200, $GLOBALS['backfill_params']['limit']);
+
+            $_POST['limit'] = '0';
+            hic_ajax_backfill_reservations();
+            $this->assertSame(1, $GLOBALS['backfill_params']['limit']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Clarify backfill limit in diagnostics UI and README
- Add unit test covering limit clamping

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfca91f1f0832f8211ff02b1eec0f2