### PR TITLE
Guard deep check timestamp from failed or skipped runs

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -518,7 +518,8 @@ class HIC_Booking_Poller {
                 // Fallback implementation
                 $result = $this->fallback_deep_check();
             }
-            $success = !is_wp_error($result);
+            // Only mark success if the check ran and produced a valid result
+            $success = ($result !== null && $result !== false && !is_wp_error($result));
         } catch (\Throwable $e) {
             hic_log('Deep check error: ' . $e->getMessage(), HIC_LOG_LEVEL_ERROR);
             $failures = (int) get_option('hic_deep_check_failures', 0);

--- a/tests/BookingPollerSchedulerTest.php
+++ b/tests/BookingPollerSchedulerTest.php
@@ -29,6 +29,9 @@ namespace FpHic {
         if (!empty($GLOBALS['simulate_deep_error'])) {
             return new \WP_Error('poll_error', 'Simulated error');
         }
+        if (!empty($GLOBALS['simulate_deep_skip'])) {
+            return null;
+        }
         return true;
     }
     function hic_fetch_reservations_raw($prop_id, $mode, $from_date, $to_date, $limit) {
@@ -80,6 +83,18 @@ namespace {
 
             $this->assertSame($old, get_option('hic_last_deep_check'));
             unset($GLOBALS['simulate_deep_error']);
+        }
+
+        public function test_execute_deep_check_skipped_does_not_update_timestamp(): void {
+            $poller = new \HIC_Booking_Poller();
+            $old = time() - 100;
+            update_option('hic_last_deep_check', $old);
+
+            $GLOBALS['simulate_deep_skip'] = true;
+            $poller->execute_deep_check();
+
+            $this->assertSame($old, get_option('hic_last_deep_check'));
+            unset($GLOBALS['simulate_deep_skip']);
         }
 
         public function test_execute_deep_check_exception_is_handled(): void {


### PR DESCRIPTION
## Summary
- ensure deep check timestamp updates only on successful completion
- add test coverage for skipped deep checks

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfcbc72348832f9d0b32dfae564e6f