### PR TITLE
Handle errors in manual polling and expose results in diagnostics

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -938,17 +938,16 @@ function hic_ajax_force_polling() {
         $stats_after = $poller->get_stats();
 
         // Prepare response
-        $response = array_merge($result, array(
+        $response = array(
+            'polling_result' => $result,
             'diagnostics_before' => $diagnostics_before,
             'stats_after' => $stats_after,
             'force_mode' => $force
-        ));
+        );
 
-        if (!empty($response['success'])) {
-            unset($response['success']);
+        if (!empty($result['success'])) {
             wp_send_json_success($response);
         } else {
-            unset($response['success']);
             wp_send_json_error($response);
         }
     } catch (Exception $e) {

--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -634,14 +634,20 @@ class HIC_Booking_Poller {
         
         try {
             // Execute continuous polling
-            $this->execute_continuous_polling();
-            
+            $result = $this->execute_continuous_polling();
+
+            if (is_wp_error($result) || $result !== true) {
+                $error_message = is_wp_error($result) ? $result->get_error_message() : 'Unexpected polling result';
+                hic_log('Manual polling failed: ' . $error_message);
+                return array('success' => false, 'message' => $error_message);
+            }
+
             $execution_time = round(microtime(true) - $start_time, 2);
             $message = "Manual polling completed in {$execution_time}s";
             hic_log($message);
-            
+
             return array(
-                'success' => true, 
+                'success' => true,
                 'message' => $message,
                 'execution_time' => $execution_time
             );
@@ -675,17 +681,27 @@ class HIC_Booking_Poller {
             }
             
             // Execute continuous polling
-            $this->execute_continuous_polling();
-            
+            $result = $this->execute_continuous_polling();
+
+            if (is_wp_error($result) || $result !== true) {
+                $error_message = is_wp_error($result) ? $result->get_error_message() : 'Unexpected polling result';
+                hic_log('Force manual polling failed: ' . $error_message);
+                return array(
+                    'success' => false,
+                    'message' => $error_message,
+                    'lock_cleared' => $lock_cleared
+                );
+            }
+
             $execution_time = round(microtime(true) - $start_time, 2);
             $message = "Force manual polling completed in {$execution_time}s";
             if ($lock_cleared) {
                 $message .= " (lock was cleared)";
             }
             hic_log($message);
-            
+
             return array(
-                'success' => true, 
+                'success' => true,
                 'message' => $message,
                 'execution_time' => $execution_time,
                 'lock_cleared' => $lock_cleared


### PR DESCRIPTION
## Summary
- Return error when continuous polling fails in manual and forced executions
- Surface manual polling result in diagnostics AJAX handler

## Testing
- `composer lint:syntax`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68bfd64900b4832fa34467b626cfd2a2