### PR TITLE
Return polling outcome from continuous poller

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -498,6 +498,7 @@ class HIC_Booking_Poller {
                 \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
             }
         }
+        return $result;
     }
     
     /**


### PR DESCRIPTION
## Summary
- return polling result from `execute_continuous_polling`
- callers continue to evaluate the result for success or failure

## Testing
- `composer install`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfd8fdb4d4832fa5873f54c61572b3