### PR TITLE
Handle WP_Error in continuous polling result

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -489,6 +489,10 @@ class HIC_Booking_Poller {
             } else {
                 $result = null;
             }
+            if (is_wp_error($result)) {
+                hic_log('Continuous polling error: ' . $result->get_error_message(), HIC_LOG_LEVEL_ERROR);
+                $this->increment_failure_counter('hic_continuous_poll_failures');
+            }
         } catch (\Throwable $e) {
             hic_log('Continuous polling error: ' . $e->getMessage(), HIC_LOG_LEVEL_ERROR);
             $this->increment_failure_counter('hic_continuous_poll_failures');


### PR DESCRIPTION
## Summary
- check continuous poll result for WP_Error and log/increment failure counter

## Testing
- `php -l includes/booking-poller.php`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68bfdaee3590832f866724e28bf5a7bf