### PR TITLE
Sanitize HTTP_HOST in local environment check

### DIFF
--- a/includes/config-validator.php
+++ b/includes/config-validator.php
@@ -268,7 +268,7 @@ class HIC_Config_Validator {
      * Check if running in local environment
      */
     private function is_local_environment() {
-        $host = $_SERVER['HTTP_HOST'] ?? '';
+        $host = sanitize_text_field($_SERVER['HTTP_HOST'] ?? '');
         $local_hosts = ['localhost', '127.0.0.1', '::1'];
         
         foreach ($local_hosts as $local_host) {

--- a/tests/LocalEnvironmentTest.php
+++ b/tests/LocalEnvironmentTest.php
@@ -1,0 +1,33 @@
+<?php
+use PHPUnit\Framework\TestCase;
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../includes/config-validator.php';
+
+final class LocalEnvironmentTest extends TestCase
+{
+    public function test_sanitized_host_detects_local_environment()
+    {
+        $original_host = $_SERVER['HTTP_HOST'] ?? null;
+        $_SERVER['HTTP_HOST'] = 'local<script>host';
+
+        $validator = new FpHic\HIC_Config_Validator();
+
+        $ref = new ReflectionClass($validator);
+        $method = $ref->getMethod('is_local_environment');
+        $method->setAccessible(true);
+
+        $result = $method->invoke($validator);
+
+        if ($original_host === null) {
+            unset($_SERVER['HTTP_HOST']);
+        } else {
+            $_SERVER['HTTP_HOST'] = $original_host;
+        }
+
+        $this->assertTrue(
+            $result,
+            'Sanitized host should be recognized as local.'
+        );
+    }
+}
+


### PR DESCRIPTION
## Summary
- Sanitize `$_SERVER['HTTP_HOST']` when checking for local environment
- Add unit test ensuring sanitized host is detected as local

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c008580f80832fbd080e739cd9a868