### PR TITLE
Gestisce errore nella creazione di .htaccess per i log

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -83,7 +83,9 @@ function hic_activate($network_wide)
 
     $htaccess = $log_dir . '/.htaccess';
     if (!file_exists($htaccess)) {
-        file_put_contents($htaccess, "Order allow,deny\nDeny from all\n");
+        if (false === @file_put_contents($htaccess, "Order allow,deny\nDeny from all\n")) {
+            \hic_log('Impossibile creare .htaccess nella cartella dei log');
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- registra un errore se la creazione del file `.htaccess` nella cartella dei log fallisce

## Testing
- `composer test`
- Manuale: eseguito script di prova che tenta di scrivere `.htaccess` in percorso non valido e verifica del messaggio nei log

------
https://chatgpt.com/codex/tasks/task_e_68c00fc5e4b4832fb25895c57cdb6789