### PR TITLE
Sanitize failed request table name

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1284,7 +1284,7 @@ function hic_retry_failed_requests() {
         return;
     }
 
-    $table = $wpdb->prefix . 'hic_failed_requests';
+    $table = esc_sql($wpdb->prefix . 'hic_failed_requests');
     $rows  = $wpdb->get_results("SELECT * FROM $table");
 
     if (empty($rows)) {

--- a/tests/preload.php
+++ b/tests/preload.php
@@ -69,3 +69,8 @@ if (!function_exists('wp_date')) {
         return date($format, $timestamp ?? time());
     }
 }
+if (!function_exists('esc_sql')) {
+    function esc_sql($sql) {
+        return $sql;
+    }
+}


### PR DESCRIPTION
## Summary
- sanitize the hic_failed_requests table name using esc_sql before querying
- add esc_sql stub in test bootstrap

## Testing
- `composer lint:syntax`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c03d99e338832fa1a68c0de86bd349