### PR TITLE
Fix WP_Error reference in polling and helper functions

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -1,5 +1,7 @@
 <?php declare(strict_types=1);
 namespace FpHic;
+
+use WP_Error;
 /**
  * API Polling Handler - Core API Functions Only
  * Note: WP-Cron scheduling removed in favor of internal scheduler (booking-poller.php)

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,6 +1,8 @@
 <?php declare(strict_types=1);
 namespace FpHic\Helpers {
 
+use WP_Error;
+
 /**
  * Helper functions for HIC Plugin
  */


### PR DESCRIPTION
## Summary
- import WP_Error in polling API file to avoid undefined class in namespace
- import WP_Error in helpers namespace

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c04230a33c832fb376446bdc916891