### PR TITLE
Expand name field fallbacks

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -364,13 +364,31 @@ function hic_transform_reservation($reservation) {
 
     // Determine guest name from available fields
     $first = $reservation['guest_first_name']
+        ?? $reservation['guest_firstname']
         ?? $reservation['first_name']
+        ?? $reservation['firstname']
         ?? $reservation['client_first_name']
+        ?? $reservation['customer_first_name']
+        ?? $reservation['customer_firstname']
         ?? '';
     $last = $reservation['guest_last_name']
+        ?? $reservation['guest_lastname']
         ?? $reservation['last_name']
+        ?? $reservation['lastname']
         ?? $reservation['client_last_name']
+        ?? $reservation['customer_last_name']
+        ?? $reservation['customer_lastname']
         ?? '';
+
+    if ((empty($first) || empty($last)) && !empty($reservation['guest_name']) && is_string($reservation['guest_name'])) {
+        $parts = preg_split('/\s+/', trim($reservation['guest_name']), 2);
+        if (empty($first) && isset($parts[0])) {
+            $first = $parts[0];
+        }
+        if (empty($last) && isset($parts[1])) {
+            $last = $parts[1];
+        }
+    }
 
     // Determine primary email from available fields
     $email = $reservation['guest_email']

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -847,7 +847,42 @@ function hic_send_admin_email($data, $gclid, $fbclid, $sid){
   $body  = "Hai ricevuto una nuova prenotazione da $site_name:\n\n";
   $body .= "Reservation ID: " . ($data['reservation_id'] ?? ($data['id'] ?? 'n/a')) . "\n";
   $body .= "Importo: " . (isset($data['amount']) ? hic_normalize_price($data['amount']) : '0') . " " . ($data['currency'] ?? 'EUR') . "\n";
-  $body .= "Nome: " . trim(($data['first_name'] ?? '') . ' ' . ($data['last_name'] ?? '')) . "\n";
+
+  $first = $data['first_name']
+      ?? $data['guest_first_name']
+      ?? $data['guest_firstname']
+      ?? $data['firstname']
+      ?? $data['customer_first_name']
+      ?? $data['customer_firstname']
+      ?? '';
+  $last = $data['last_name']
+      ?? $data['guest_last_name']
+      ?? $data['guest_lastname']
+      ?? $data['lastname']
+      ?? $data['customer_last_name']
+      ?? $data['customer_lastname']
+      ?? '';
+
+  if ((empty($first) || empty($last)) && !empty($data['guest_name']) && is_string($data['guest_name'])) {
+      $parts = preg_split('/\s+/', trim($data['guest_name']), 2);
+      if (empty($first) && isset($parts[0])) {
+          $first = $parts[0];
+      }
+      if (empty($last) && isset($parts[1])) {
+          $last = $parts[1];
+      }
+  }
+  if ((empty($first) || empty($last)) && !empty($data['name']) && is_string($data['name'])) {
+      $parts = preg_split('/\s+/', trim($data['name']), 2);
+      if (empty($first) && isset($parts[0])) {
+          $first = $parts[0];
+      }
+      if (empty($last) && isset($parts[1])) {
+          $last = $parts[1];
+      }
+  }
+
+  $body .= "Nome: " . trim($first . ' ' . $last) . "\n";
   $body .= "Email: " . ($data['email'] ?? 'n/a') . "\n";
   $body .= "Telefono: " . ($data['phone'] ?? 'n/a') . "\n";
   $body .= "Lingua: " . ($data['lingua'] ?? ($data['lang'] ?? 'n/a')) . "\n";

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -739,12 +739,38 @@ function hic_transform_webhook_data_for_brevo($webhook_data) {
   }
   
   // Map webhook field names to modern field names
+  $first = $webhook_data['guest_first_name']
+      ?? $webhook_data['guest_firstname']
+      ?? $webhook_data['first_name']
+      ?? $webhook_data['firstname']
+      ?? $webhook_data['customer_first_name']
+      ?? $webhook_data['customer_firstname']
+      ?? null;
+
+  $last = $webhook_data['guest_last_name']
+      ?? $webhook_data['guest_lastname']
+      ?? $webhook_data['last_name']
+      ?? $webhook_data['lastname']
+      ?? $webhook_data['customer_last_name']
+      ?? $webhook_data['customer_lastname']
+      ?? null;
+
+  if ((empty($first) || empty($last)) && !empty($webhook_data['name']) && is_string($webhook_data['name'])) {
+      $parts = preg_split('/\s+/', trim($webhook_data['name']), 2);
+      if (empty($first) && isset($parts[0])) {
+          $first = $parts[0];
+      }
+      if (empty($last) && isset($parts[1])) {
+          $last = $parts[1];
+      }
+  }
+
   $transformed = array(
     'transaction_id' => Helpers\hic_extract_reservation_id($webhook_data),
     'reservation_code' => isset($webhook_data['reservation_code']) ? $webhook_data['reservation_code'] : '',
     'email' => isset($webhook_data['email']) ? $webhook_data['email'] : '',
-    'guest_first_name' => isset($webhook_data['first_name']) ? $webhook_data['first_name'] : '',
-    'guest_last_name' => isset($webhook_data['last_name']) ? $webhook_data['last_name'] : '',
+    'guest_first_name' => $first ?? '',
+    'guest_last_name' => $last ?? '',
     'phone' => isset($webhook_data['whatsapp']) ? $webhook_data['whatsapp'] : (isset($webhook_data['phone']) ? $webhook_data['phone'] : ''),
     'original_price' => isset($webhook_data['amount']) ? Helpers\hic_normalize_price($webhook_data['amount']) : 0,
     'currency' => isset($webhook_data['currency']) ? $webhook_data['currency'] : 'EUR',


### PR DESCRIPTION
## Summary
- broaden name field detection when transforming reservations
- normalize multiple name variants in Brevo webhook data
- ensure admin emails display available guest names

## Testing
- `composer lint:syntax`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c043fea744832f8c8f182deb22a43d