### PR TITLE
Explicit WP_Error global namespace in helpers

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1,7 +1,7 @@
 <?php declare(strict_types=1);
 namespace FpHic\Helpers {
 
-use WP_Error;
+use \WP_Error;
 
 /**
  * Helper functions for HIC Plugin


### PR DESCRIPTION
## Summary
- ensure global WP_Error import in helpers
- verify continuous and deep check polling update timestamps

## Testing
- `composer test`
- `php /tmp/run_polling_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68c04ffc1228832f8ef0bf9facf68c1f