### PR TITLE
Gestione tag Brevo per contatti ed eventi

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -23,6 +23,7 @@ Il sistema di polling API moderno (versione attuale) invia **ENTRAMBI** i set di
 | `HIC_GUESTS` | Numero | Numero di ospiti | `guests` dalla prenotazione |
 | `HIC_ROOM` | Testo | Nome dell'alloggio/camera | `accommodation_name` dalla prenotazione |
 | `HIC_PRICE` | Numero | Prezzo originale della prenotazione | `price` dalla prenotazione |
+| `TAGS` | Testo (JSON) | Elenco di tag associati al contatto | Array `tags` dalla prenotazione |
 
 #### Attributi Legacy (Compatibilità)
 Il sistema moderno invia **ANCHE** questi attributi legacy per garantire la retrocompatibilità:
@@ -80,6 +81,7 @@ HIC_TO - Tipo: Data
 HIC_GUESTS - Tipo: Numero
 HIC_ROOM - Tipo: Testo
 HIC_PRICE - Tipo: Numero (decimale)
+TAGS - Tipo: Testo
 ```
 
 #### Attributi Opzionali (Compatibilità Legacy)

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -106,6 +106,10 @@ function hic_send_brevo_event($reservation, $gclid, $fbclid, $msclkid = '', $ttc
     )
   );
 
+  if (isset($reservation['tags']) && is_array($reservation['tags'])) {
+    $event_data['tags'] = array_values($reservation['tags']);
+  }
+
   // Attach UTM parameters if SID available
   if (!empty($reservation['sid'])) {
     $utm = Helpers\hic_get_utm_params_by_sid($reservation['sid']);
@@ -290,6 +294,10 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     'LINGUA' => $language
   );
 
+  if (isset($data['tags']) && is_array($data['tags'])) {
+    $attributes['TAGS'] = wp_json_encode(array_values($data['tags']));
+  }
+
   // Populate UTM attributes if available
   if (!empty($data['transaction_id'])) {
     $utm = Helpers\hic_get_utm_params_by_sid($data['transaction_id']);
@@ -315,6 +323,10 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     'listIds' => $list_ids,
     'updateEnabled' => true
   );
+
+  if (isset($data['tags']) && is_array($data['tags'])) {
+    $body['tags'] = array_values($data['tags']);
+  }
 
   // Add marketing opt-in only if not alias and default is enabled, or if enrichment is happening and double opt-in is enabled
   if (!$is_alias) {

--- a/tests/BrevoTagsTest.php
+++ b/tests/BrevoTagsTest.php
@@ -1,0 +1,50 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/functions.php';
+require_once __DIR__ . '/../includes/integrations/brevo.php';
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) { return json_encode($data); }
+}
+
+final class BrevoTagsTest extends TestCase {
+    protected function setUp(): void {
+        update_option('hic_brevo_api_key', 'test-key');
+    }
+
+    public function testDispatchReservationSendsTags() {
+        global $hic_last_request;
+        $hic_last_request = null;
+
+        $data = [
+            'email' => 'tag@example.com',
+            'transaction_id' => 'T1',
+            'tags' => ['vip', 'promo']
+        ];
+
+        \FpHic\hic_dispatch_brevo_reservation($data);
+
+        $payload = json_decode($hic_last_request['args']['body'], true);
+        $this->assertSame(['vip', 'promo'], $payload['tags']);
+        $this->assertSame(['vip', 'promo'], json_decode($payload['attributes']['TAGS'], true));
+    }
+
+    public function testEventSendsTags() {
+        global $hic_last_request;
+        $hic_last_request = null;
+
+        $reservation = [
+            'email' => 'tag@example.com',
+            'reservation_id' => 'R1',
+            'amount' => 100,
+            'currency' => 'EUR',
+            'tags' => ['vip', 'promo']
+        ];
+
+        \FpHic\hic_send_brevo_event($reservation, null, null);
+
+        $payload = json_decode($hic_last_request['args']['body'], true);
+        $this->assertSame(['vip', 'promo'], $payload['tags']);
+    }
+}


### PR DESCRIPTION
## Summary
- Popola l'attributo Brevo `TAGS` e invia l'array `tags` sia nel contatto che nell'evento
- Documentato il nuovo attributo `TAGS`
- Aggiunti test per la trasmissione dei tag

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c055485888832f8f012ad945deb277