### PR TITLE
Send phone number in Brevo contact attribute

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -36,6 +36,7 @@ Il sistema moderno invia **ANCHE** questi attributi legacy per garantire la retr
 | `DATE` | Data | Data della prenotazione | Mappato da `from_date` |
 | `AMOUNT` | Numero | Importo della prenotazione | Mappato da `original_price` |
 | `CURRENCY` | Testo | Valuta (es. "EUR", "USD") | `currency` dalla prenotazione |
+| `PHONE` | Testo | Numero di telefono | `phone` dalla prenotazione |
 | `WHATSAPP` | Testo | Numero WhatsApp | Mappato da `phone` |
 | `LINGUA` | Testo | Lingua | Mappato da `language` |
 

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -37,6 +37,7 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
     'attributes' => array(
       'FIRSTNAME' => isset($data['guest_first_name']) ? $data['guest_first_name'] : '',
       'LASTNAME'  => isset($data['guest_last_name']) ? $data['guest_last_name'] : '',
+      'PHONE'     => $data['phone'] ?? '',
       'RESVID'    => isset($data['reservation_id']) ? $data['reservation_id'] : (isset($data['id']) ? $data['id'] : ''),
       'GCLID'     => isset($gclid) ? $gclid : '',
       'FBCLID'    => isset($fbclid) ? $fbclid : '',

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -164,6 +164,7 @@ class HICFunctionsTest {
         $hic_last_request = null;
         \FpHic\hic_send_brevo_contact([
             'email' => 'c@example.com',
+            'phone' => '+39 3331234567',
             'whatsapp' => '+39 3331234567',
             'lang' => 'en',
             'guest_first_name' => 'Mario',
@@ -171,15 +172,22 @@ class HICFunctionsTest {
         ], '', '');
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['attributes']['LINGUA'] === 'it', 'Contact Italian phone forces language it');
+        assert($payload['attributes']['PHONE'] === '+393331234567', 'Phone should be normalized');
         assert($payload['attributes']['WHATSAPP'] === '+393331234567', 'WhatsApp should be normalized');
         assert($payload['attributes']['FIRSTNAME'] === 'Mario', 'Guest first name should map to FIRSTNAME');
         assert($payload['attributes']['LASTNAME'] === 'Rossi', 'Guest last name should map to LASTNAME');
 
         // Contact with foreign phone
         $hic_last_request = null;
-        \FpHic\hic_send_brevo_contact(['email' => 'c2@example.com', 'whatsapp' => '+44 3331234567', 'lingua' => 'it'], '', '');
+        \FpHic\hic_send_brevo_contact([
+            'email' => 'c2@example.com',
+            'phone' => '+44 3331234567',
+            'whatsapp' => '+44 3331234567',
+            'lingua' => 'it'
+        ], '', '');
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['attributes']['LINGUA'] === 'en', 'Contact foreign phone forces language en');
+        assert($payload['attributes']['PHONE'] === '+443331234567', 'Phone should be normalized');
 
         echo "✅ Brevo phone language override tests passed\n";
     }


### PR DESCRIPTION
## Summary
- include `PHONE` attribute when sending Brevo contact payloads
- document `PHONE` as a legacy contact attribute
- test that contacts send normalized phone numbers in the `PHONE` field

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c05658dd64832f89b3a966c70068c6