### PR TITLE
Detect Italian phone numbers without prefix

### DIFF
--- a/BREVO_QUICK_SETUP.md
+++ b/BREVO_QUICK_SETUP.md
@@ -43,6 +43,7 @@ Nel pannello admin WordPress (Impostazioni > HIC Monitoring), sezione "Brevo Set
 6. Il prefisso telefonico, se presente, ha priorità sul campo `language`:
    - numeri con prefisso `+39` o `0039` vengono forzati sulla lista italiana;
    - numeri con altri prefissi vengono assegnati alla lista inglese;
+   - numeri senza prefisso, lunghi 9-10 cifre e che iniziano con `3` o `0` vengono trattati come italiani;
    - se il numero non è riconoscibile si utilizza il valore del campo `language` o, se assente, la lista di default.
 
 ## Evento "purchase"

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -686,7 +686,14 @@ function hic_detect_phone_language($phone) {
         $normalized = '+' . substr($normalized, 2);
     }
 
-    if (strlen($normalized) <= 1 || strpos($normalized, '+') !== 0) {
+    if (strlen($normalized) <= 1) {
+        return ['phone' => $normalized, 'language' => null];
+    }
+
+    if (strpos($normalized, '+') !== 0) {
+        if ((strlen($normalized) >= 9 && strlen($normalized) <= 10) && ($normalized[0] === '3' || $normalized[0] === '0')) {
+            return ['phone' => $normalized, 'language' => 'it'];
+        }
         return ['phone' => $normalized, 'language' => null];
     }
 

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -128,7 +128,11 @@ class HICFunctionsTest {
         assert($res['phone'] === '+441234567890', 'Should normalize foreign phone');
 
         $res = Helpers\hic_detect_phone_language('3331234567');
-        assert($res['language'] === null, 'Should not detect language without prefix');
+        assert($res['language'] === 'it', 'Should detect Italian mobile without prefix');
+        assert($res['phone'] === '3331234567', 'Should keep phone without prefix');
+
+        $res = Helpers\hic_detect_phone_language('031234567');
+        assert($res['language'] === 'it', 'Should detect Italian landline without prefix');
 
         echo "✅ Phone language detection tests passed\n";
     }


### PR DESCRIPTION
## Summary
- treat 9–10 digit numbers starting with 3 or 0 as Italian
- document routing rule for phone numbers without prefix
- cover Italian numbers without prefix in tests

## Testing
- `php tests/test-functions.php`

------
https://chatgpt.com/codex/tasks/task_e_68c05e217838832faf12c2969b5509e9