### PR TITLE
Add Brevo language attribute and list fallback

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -43,7 +43,9 @@ Il sistema moderno invia **ANCHE** questi attributi legacy per garantire la retr
 | `CURRENCY` | Testo | Valuta (es. "EUR", "USD") | `currency` dalla prenotazione |
 | `PHONE` | Testo | Numero di telefono | `phone` dalla prenotazione |
 | `WHATSAPP` | Testo | Numero WhatsApp | Mappato da `phone` |
-| `LINGUA` | Testo | Lingua | Mappato da `language` |
+| `LINGUA` | Testo | Lingua (alias legacy di `LANGUAGE`) | Mappato da `language` |
+> **Nota:** l'attributo `LANGUAGE` viene sempre inviato insieme a `LINGUA` per garantire la retro-compatibilità.
+>
 
 **\*Nota sui tracking ID**: Nel sistema API moderno, `GCLID` e `FBCLID` sono disponibili solo se la prenotazione è stata originariamente tracciata attraverso il sito web con parametri di tracking. Se la prenotazione è stata creata direttamente in Hotel in Cloud senza passare dal sito web, questi campi saranno vuoti.
 
@@ -112,7 +114,7 @@ Il plugin gestisce automaticamente l'assegnazione ai seguenti tipi di liste:
 
 - **Lista Italiana**: Per contatti con lingua "it"
 - **Lista Inglese**: Per contatti con lingua "en"  
-- **Lista Default**: Per altre lingue
+- **Lista Default**: Fallback per lingue mancanti o diverse da "it" e "en"
 - **Lista Alias**: Per email temporanee di OTA (Booking.com, Airbnb, etc.)
 
 Configura gli ID di queste liste nel pannello admin del plugin WordPress.

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -30,13 +30,13 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
   }
 
   $list_ids = array();
-  if (strtolower($lang) === 'en') {
+  if (strtolower($lang) === 'it') {
+    $list_ids[] = intval(Helpers\hic_get_brevo_list_it());
+  } elseif (strtolower($lang) === 'en') {
     $list_ids[] = intval(Helpers\hic_get_brevo_list_en());
   } else {
-    $list_ids[] = intval(Helpers\hic_get_brevo_list_it());
+    $list_ids[] = intval(Helpers\hic_get_brevo_list_default());
   }
-
-  // Remove empty list IDs (e.g., 0)
   $list_ids = array_filter($list_ids);
 
   $body = array(
@@ -54,6 +54,7 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
       'AMOUNT'    => isset($data['amount']) ? Helpers\hic_normalize_price($data['amount']) : 0,
       'CURRENCY'  => isset($data['currency']) ? $data['currency'] : 'EUR',
       'WHATSAPP'  => isset($data['whatsapp']) ? $data['whatsapp'] : '',
+      'LANGUAGE'  => $lang,
       'LINGUA'    => $lang
     ),
     'listIds'       => $list_ids,


### PR DESCRIPTION
## Summary
- include LANGUAGE and legacy LINGUA attributes when sending Brevo contacts
- use default Brevo list when language is missing or unrecognized
- document LANGUAGE attribute and default list fallback

## Testing
- `composer test`
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68c05fce657c832fb571c5878795c475