### PR TITLE
Add Brevo contact tags support

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -28,7 +28,7 @@ Il sistema di polling API moderno (versione attuale) invia **ENTRAMBI** i set di
 | `HIC_PRICE` | Numero | Prezzo originale della prenotazione | `price` dalla prenotazione |
 | `HIC_PRESENCE` | Numero (0/1) | Indica se il cliente ha effettuato il check-in | `presence` dalla prenotazione |
 | `HIC_BALANCE` | Numero | Saldo non pagato della prenotazione | `unpaid_balance` dalla prenotazione |
-| `TAGS` | Testo | Elenco di tag associati al contatto, separati da virgola | Array `tags` dalla prenotazione |
+| `TAGS` | Testo | Elenco di tag associati al contatto, separati da virgola (inviati anche nel campo `tags` nativo) | Array `tags` dalla prenotazione |
 
 #### Attributi Legacy (Compatibilità)
 Il sistema moderno invia **ANCHE** questi attributi legacy per garantire la retrocompatibilità:

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -61,6 +61,11 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
     'updateEnabled' => true
   );
 
+  if (!empty($data['tags']) && is_array($data['tags'])) {
+    $body['tags'] = array_values($data['tags']);
+    $body['attributes']['TAGS'] = implode(',', $data['tags']);
+  }
+
   // Populate UTM attributes if SID available
   if (!empty($data['sid'])) {
     $utm = Helpers\hic_get_utm_params_by_sid($data['sid']);

--- a/tests/BrevoContactTagsTest.php
+++ b/tests/BrevoContactTagsTest.php
@@ -1,0 +1,31 @@
+<?php
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/../includes/functions.php';
+require_once __DIR__ . '/../includes/integrations/brevo.php';
+
+if (!function_exists('wp_json_encode')) {
+    function wp_json_encode($data) { return json_encode($data); }
+}
+
+final class BrevoContactTagsTest extends TestCase {
+    protected function setUp(): void {
+        update_option('hic_brevo_api_key', 'test-key');
+    }
+
+    public function testContactIncludesTags() {
+        global $hic_last_request;
+        $hic_last_request = null;
+
+        $data = [
+            'email' => 'tagtest@example.com',
+            'tags'  => ['vip', 'promo'],
+        ];
+
+        \FpHic\hic_send_brevo_contact($data, '', '');
+
+        $payload = json_decode($hic_last_request['args']['body'], true);
+        $this->assertSame(['vip', 'promo'], $payload['tags']);
+        $this->assertSame('vip,promo', $payload['attributes']['TAGS']);
+    }
+}


### PR DESCRIPTION
## Summary
- Send tags to Brevo contacts and store them in TAGS attribute
- Document TAGS attribute for Brevo contacts
- Test contact tag propagation

## Testing
- `composer lint`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c0610bb110832fb876cae9bdbc260c