### PR TITLE
feat(brevo): send extra reservation fields and tag handling

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -65,11 +65,35 @@ Il plugin invia anche eventi personalizzati a Brevo con le seguenti proprietà:
 | `amount` | Numero | Importo della prenotazione |
 | `currency` | Testo | Valuta |
 | `date` | Data | Data della prenotazione |
-| `whatsapp` | Testo | Numero WhatsApp |
-| `lingua` | Testo | Lingua |
-| `firstname` | Testo | Nome |
-| `lastname` | Testo | Cognome |
+| `phone` | Testo | Numero di telefono |
+| `language` | Testo | Lingua |
+| `guest_first_name` | Testo | Nome |
+| `guest_last_name` | Testo | Cognome |
 | `bucket` | Testo | Categoria di attribuzione (Direct, Google, Facebook, etc.) |
+
+### Evento "reservation_created"
+| Proprietà | Tipo | Descrizione |
+|-----------|------|-------------|
+| `reservation_id` | Testo | ID della prenotazione |
+| `reservation_code` | Testo | Codice prenotazione |
+| `amount` | Numero | Importo originale della prenotazione |
+| `currency` | Testo | Valuta |
+| `from_date` | Data | Data di check-in |
+| `to_date` | Data | Data di check-out |
+| `guests` | Numero | Numero di ospiti |
+| `accommodation` | Testo | Nome alloggio |
+| `accommodation_id` | Testo | ID dell'alloggio |
+| `room_id` | Testo | ID della camera |
+| `offer` | Testo | Offerta associata |
+| `phone` | Testo | Numero di telefono |
+| `language` | Testo | Lingua |
+| `guest_first_name` | Testo | Nome ospite |
+| `guest_last_name` | Testo | Cognome ospite |
+| `presence` | Numero | Indica se l'ospite è presente |
+| `unpaid_balance` | Numero | Saldo non pagato |
+| `tags` | Testo | Tag separati da virgola (inviati anche come array `tags`) |
+| `bucket` | Testo | Categoria di attribuzione |
+| `vertical` | Testo | Verticale (es. hotel) |
 
 ## Configurazione Raccomandata in Brevo
 

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -477,11 +477,10 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
       'offer' => isset($data['offer']) ? $data['offer'] : '',
       'phone' => isset($data['phone']) ? $data['phone'] : '',
       'language' => isset($data['language']) ? $data['language'] : '',
-      'firstname' => isset($data['guest_first_name']) ? $data['guest_first_name'] : '',
-      'lastname' => isset($data['guest_last_name']) ? $data['guest_last_name'] : '',
+      'guest_first_name' => isset($data['guest_first_name']) ? $data['guest_first_name'] : '',
+      'guest_last_name' => isset($data['guest_last_name']) ? $data['guest_last_name'] : '',
       'presence' => isset($data['presence']) ? $data['presence'] : '',
       'unpaid_balance' => isset($data['unpaid_balance']) ? Helpers\hic_normalize_price($data['unpaid_balance']) : 0,
-      'tags' => isset($data['tags']) && is_array($data['tags']) ? implode(',', $data['tags']) : '',
       'bucket' => $bucket,
       'vertical' => 'hotel',
       'msclkid' => $msclkid,
@@ -489,6 +488,11 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
       'created_at' => current_time('mysql')
     )
   );
+
+  if (!empty($data['tags']) && is_array($data['tags'])) {
+    $body['tags'] = array_values($data['tags']);
+    $body['properties']['tags'] = implode(',', $data['tags']);
+  }
 
   // Add UTM parameters if available
   if (!empty($data['transaction_id'])) {

--- a/tests/BrevoReservationFieldsTest.php
+++ b/tests/BrevoReservationFieldsTest.php
@@ -54,17 +54,22 @@ final class BrevoReservationFieldsTest extends TestCase {
             'tags' => ['vip', 'promo'],
             'accommodation_id' => 'A1',
             'room_id' => 'R1',
-            'offer' => 'OFF1'
+            'offer' => 'OFF1',
+            'guest_first_name' => 'Mario',
+            'guest_last_name' => 'Rossi'
         ];
 
         \FpHic\hic_send_brevo_reservation_created_event($reservation);
 
         $payload = json_decode($hic_last_request['args']['body'], true);
+        $this->assertSame(['vip', 'promo'], $payload['tags']);
+        $this->assertSame('vip,promo', $payload['properties']['tags']);
         $this->assertSame(1, $payload['properties']['presence']);
         $this->assertSame(50.5, $payload['properties']['unpaid_balance']);
-        $this->assertSame('vip,promo', $payload['properties']['tags']);
         $this->assertSame('A1', $payload['properties']['accommodation_id']);
         $this->assertSame('R1', $payload['properties']['room_id']);
         $this->assertSame('OFF1', $payload['properties']['offer']);
+        $this->assertSame('Mario', $payload['properties']['guest_first_name']);
+        $this->assertSame('Rossi', $payload['properties']['guest_last_name']);
     }
 }


### PR DESCRIPTION
## Summary
- rename reservation_created guest property keys and expose tags array
- cover new reservation fields in tests
- document reservation_created event and purchase field updates

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c063b670c0832f82deb89e89f3f7c6