### PR TITLE
Handle WhatsApp numbers separately in Brevo reservation dispatch

### DIFF
--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -237,10 +237,14 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
   // Determine list based on language and alias status
   $language = isset($data['language']) ? $data['language'] : '';
 
-  // Detect language from phone prefix
-  $phone_data = Helpers\hic_detect_phone_language($data['phone'] ?? '');
+  // Detect language from phone or WhatsApp prefix
+  $is_whatsapp_source = empty($data['phone']) && !empty($data['whatsapp']);
+  $phone_data = Helpers\hic_detect_phone_language($data['phone'] ?? ($data['whatsapp'] ?? ''));
   if (!empty($phone_data['phone'])) {
     $data['phone'] = $phone_data['phone'];
+    if ($is_whatsapp_source) {
+      $data['whatsapp'] = $phone_data['phone'];
+    }
   }
   if (!empty($phone_data['language'])) {
     $language = $phone_data['language'];
@@ -309,7 +313,7 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     'DATE' => isset($data['from_date']) ? $data['from_date'] : wp_date('Y-m-d'),
     'AMOUNT' => isset($data['original_price']) ? Helpers\hic_normalize_price($data['original_price']) : 0,
     'CURRENCY' => isset($data['currency']) ? $data['currency'] : 'EUR',
-    'WHATSAPP' => isset($data['phone']) ? $data['phone'] : '',
+    'WHATSAPP' => isset($data['whatsapp']) ? $data['whatsapp'] : '',
     'LINGUA' => $language
   );
 

--- a/tests/BrevoReservationFieldsTest.php
+++ b/tests/BrevoReservationFieldsTest.php
@@ -72,4 +72,43 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame('Mario', $payload['properties']['guest_first_name']);
         $this->assertSame('Rossi', $payload['properties']['guest_last_name']);
     }
+
+    public function testPhoneAndWhatsappSeparated() {
+        global $hic_last_request;
+        $hic_last_request = null;
+
+        $data = [
+            'email' => 'both@example.com',
+            'transaction_id' => 'TB',
+            'phone' => '+39 333 1234567',
+            'whatsapp' => '+44 1234567890',
+            'language' => 'en'
+        ];
+
+        \FpHic\hic_dispatch_brevo_reservation($data);
+
+        $payload = json_decode($hic_last_request['args']['body'], true);
+        $this->assertSame('+393331234567', $payload['attributes']['PHONE']);
+        $this->assertSame('+44 1234567890', $payload['attributes']['WHATSAPP']);
+        $this->assertSame('it', $payload['attributes']['LANGUAGE']);
+    }
+
+    public function testWhatsappOnlyFallback() {
+        global $hic_last_request;
+        $hic_last_request = null;
+
+        $data = [
+            'email' => 'wa@example.com',
+            'transaction_id' => 'TW',
+            'whatsapp' => '+44 1234567890',
+            'language' => 'it'
+        ];
+
+        \FpHic\hic_dispatch_brevo_reservation($data);
+
+        $payload = json_decode($hic_last_request['args']['body'], true);
+        $this->assertSame('+441234567890', $payload['attributes']['PHONE']);
+        $this->assertSame('+441234567890', $payload['attributes']['WHATSAPP']);
+        $this->assertSame('en', $payload['attributes']['LANGUAGE']);
+    }
 }


### PR DESCRIPTION
## Summary
- Detect language from the reservation's phone or WhatsApp number, normalizing WhatsApp when it is the source.
- Send WhatsApp number in dedicated Brevo attribute while keeping PHONE for the standard contact number.
- Test reservations with separate phone and WhatsApp numbers and WhatsApp-only fallback.

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c064652e68832f8e7c646cc3c88c2b