### PR TITLE
Document room name attribute and add tests

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -2,7 +2,7 @@
 
 Questo documento elenca tutti gli attributi che devi configurare nel tuo account Brevo per ricevere correttamente i dati dal plugin Hotel in Cloud.
 
-I recenti aggiornamenti introducono gli attributi `LANGUAGE` e `TAGS` per memorizzare rispettivamente la lingua del contatto e l'elenco di tag associati.
+I recenti aggiornamenti introducono gli attributi `LANGUAGE`, `TAGS` e `HIC_ROOM_NAME` per memorizzare rispettivamente la lingua del contatto, l'elenco di tag associati e il nome specifico della camera prenotata.
 
 ## Attributi Contatto (Contact Attributes)
 


### PR DESCRIPTION
## Summary
- Document `HIC_ROOM_NAME` contact attribute in Brevo integration docs
- Add test coverage ensuring room name travels in contact and event payloads

## Testing
- `php tests/test-functions.php`

------
https://chatgpt.com/codex/tasks/task_e_68c0682d2614832fb4f5ae86bb317346