### PR TITLE
Rename Brevo reservation event accommodation property

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -84,7 +84,7 @@ Il plugin invia anche eventi personalizzati a Brevo con le seguenti proprietà:
 | `from_date` | Data | Data di check-in |
 | `to_date` | Data | Data di check-out |
 | `guests` | Numero | Numero di ospiti |
-| `accommodation` | Testo | Nome alloggio |
+| `accommodation_name` | Testo | Nome alloggio |
 | `accommodation_id` | Testo | ID dell'alloggio |
 | `room_id` | Testo | ID della camera |
 | `room_name` | Testo | Nome della camera |

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -478,7 +478,7 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
       'from_date' => isset($data['from_date']) ? $data['from_date'] : '',
       'to_date' => isset($data['to_date']) ? $data['to_date'] : '',
       'guests' => isset($data['guests']) ? $data['guests'] : '',
-      'accommodation' => $data['accommodation_name'] ?? '',
+      'accommodation_name' => $data['accommodation_name'] ?? '',
       'accommodation_id' => $data['accommodation_id'] ?? '',
       'room_id' => $data['room_id'] ?? '',
       'room_name' => $data['room_name'] ?? '',

--- a/tests/BrevoReservationFieldsTest.php
+++ b/tests/BrevoReservationFieldsTest.php
@@ -54,6 +54,7 @@ final class BrevoReservationFieldsTest extends TestCase {
             'presence' => 1,
             'unpaid_balance' => 50.5,
             'tags' => ['vip', 'promo'],
+            'accommodation_name' => 'Hotel Test',
             'accommodation_id' => 'A1',
             'room_id' => 'R1',
             'room_name' => 'Room 1',
@@ -69,6 +70,7 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame('vip,promo', $payload['properties']['tags']);
         $this->assertSame(1, $payload['properties']['presence']);
         $this->assertSame(50.5, $payload['properties']['unpaid_balance']);
+        $this->assertSame('Hotel Test', $payload['properties']['accommodation_name']);
         $this->assertSame('A1', $payload['properties']['accommodation_id']);
         $this->assertSame('R1', $payload['properties']['room_id']);
         $this->assertSame('Room 1', $payload['properties']['room_name']);


### PR DESCRIPTION
## Summary
- rename `accommodation` field in Brevo `reservation_created` event to `accommodation_name`
- add test coverage for `accommodation_name` event property
- document new `accommodation_name` property in Brevo attributes

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c08017b898832f93181d3453f2f4f0