### PR TITLE
Ensure Brevo tags sent in both fields

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -4,6 +4,9 @@ Questo documento elenca tutti gli attributi che devi configurare nel tuo account
 
 I recenti aggiornamenti introducono gli attributi `LANGUAGE`, `TAGS` e `HIC_ROOM_NAME` per memorizzare rispettivamente la lingua del contatto, l'elenco di tag associati e il nome specifico della camera prenotata.
 
+> **Nota sui Tag**
+> I tag vengono inviati due volte per massima compatibilità: come array nel campo nativo `tags` di Brevo e come stringa separata da virgole (`TAGS` negli attributi del contatto e `tags` nelle proprietà degli eventi).
+
 ## Attributi Contatto (Contact Attributes)
 
 Il plugin invia i seguenti attributi per ogni contatto creato o aggiornato in Brevo:

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -497,7 +497,7 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
     )
   );
 
-  if (!empty($data['tags']) && is_array($data['tags'])) {
+  if (is_array($data['tags'] ?? null)) {
     $body['tags'] = array_values($data['tags']);
     $body['properties']['tags'] = implode(',', $data['tags']);
   }

--- a/tests/BrevoReservationFieldsTest.php
+++ b/tests/BrevoReservationFieldsTest.php
@@ -117,4 +117,25 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame('+441234567890', $payload['attributes']['WHATSAPP']);
         $this->assertSame('en', $payload['attributes']['LANGUAGE']);
     }
+
+    public function testReservationCreatedEventHandlesEmptyTags() {
+        global $hic_last_request;
+        $hic_last_request = null;
+
+        $reservation = [
+            'email' => 'empty@example.com',
+            'transaction_id' => 'E1',
+            'original_price' => 10,
+            'currency' => 'EUR',
+            'tags' => []
+        ];
+
+        \FpHic\hic_send_brevo_reservation_created_event($reservation);
+
+        $payload = json_decode($hic_last_request['args']['body'], true);
+        $this->assertArrayHasKey('tags', $payload);
+        $this->assertSame([], $payload['tags']);
+        $this->assertArrayHasKey('tags', $payload['properties']);
+        $this->assertSame('', $payload['properties']['tags']);
+    }
 }


### PR DESCRIPTION
## Summary
- Send `tags` array and comma-separated string in reservation_created event even when array is empty
- Test reservation_created event to confirm tags are present in both payload locations
- Document double tag dispatch in Brevo attribute guide

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68c080d24304832f8bdde3e391571492