### PR TITLE
Add valid and relocation fields to Brevo reservation sync

### DIFF
--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -2,7 +2,7 @@
 
 Questo documento elenca tutti gli attributi che devi configurare nel tuo account Brevo per ricevere correttamente i dati dal plugin Hotel in Cloud.
 
-I recenti aggiornamenti introducono gli attributi `LANGUAGE`, `TAGS` e `HIC_ROOM_NAME` per memorizzare rispettivamente la lingua del contatto, l'elenco di tag associati e il nome specifico della camera prenotata.
+I recenti aggiornamenti introducono gli attributi `LANGUAGE`, `TAGS`, `HIC_ROOM_NAME`, `HIC_VALID` e `HIC_RELOCATIONS` per memorizzare rispettivamente la lingua del contatto, l'elenco di tag associati, il nome specifico della camera prenotata, la validità della prenotazione e gli eventuali spostamenti.
 
 > **Nota sui Tag**
 > I tag vengono inviati due volte per massima compatibilità: come array nel campo nativo `tags` di Brevo e come stringa separata da virgole (`TAGS` negli attributi del contatto e `tags` nelle proprietà degli eventi).
@@ -34,6 +34,8 @@ Il sistema di polling API moderno (versione attuale) invia **ENTRAMBI** i set di
 | `HIC_PRICE` | Numero | Prezzo originale della prenotazione | `price` dalla prenotazione |
 | `HIC_PRESENCE` | Numero (0/1) | Indica se il cliente ha effettuato il check-in | `presence` dalla prenotazione |
 | `HIC_BALANCE` | Numero | Saldo non pagato della prenotazione | `unpaid_balance` dalla prenotazione |
+| `HIC_VALID` | Numero (0/1) | Indica se la prenotazione è valida | `valid` dalla prenotazione |
+| `HIC_RELOCATIONS` | Testo | Elenco di spostamenti serializzato in JSON | `relocations` dalla prenotazione |
 | `TAGS` | Testo | Elenco di tag associati al contatto, separati da virgola (inviati anche nel campo `tags` nativo) | Array `tags` dalla prenotazione |
 
 #### Attributi Legacy (Compatibilità)
@@ -98,6 +100,8 @@ Il plugin invia anche eventi personalizzati a Brevo con le seguenti proprietà:
 | `guest_last_name` | Testo | Cognome ospite |
 | `presence` | Numero | Indica se l'ospite è presente |
 | `unpaid_balance` | Numero | Saldo non pagato |
+| `valid` | Numero | Indica se la prenotazione è valida |
+| `relocations` | Testo | Elenco di spostamenti serializzato in JSON |
 | `tags` | Testo | Tag separati da virgola (inviati anche come array `tags`) |
 | `bucket` | Testo | Categoria di attribuzione |
 | `vertical` | Testo | Verticale (es. hotel) |
@@ -126,6 +130,8 @@ HIC_OFFER - Tipo: Testo
 HIC_PRICE - Tipo: Numero (decimale)
 HIC_PRESENCE - Tipo: Numero
 HIC_BALANCE - Tipo: Numero (decimale)
+HIC_VALID - Tipo: Numero
+HIC_RELOCATIONS - Tipo: Testo
 TAGS - Tipo: Testo
 ```
 

--- a/tests/BrevoReservationFieldsTest.php
+++ b/tests/BrevoReservationFieldsTest.php
@@ -26,7 +26,9 @@ final class BrevoReservationFieldsTest extends TestCase {
             'accommodation_id' => 'A1',
             'room_id' => 'R1',
             'room_name' => 'Room 1',
-            'offer' => 'OFF1'
+            'offer' => 'OFF1',
+            'valid' => 1,
+            'relocations' => [['from' => '2024-01-01', 'to' => '2024-01-05']]
         ];
 
         \FpHic\hic_dispatch_brevo_reservation($data);
@@ -40,6 +42,8 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame('R1', $payload['attributes']['HIC_ROOM_ID']);
         $this->assertSame('Room 1', $payload['attributes']['HIC_ROOM_NAME']);
         $this->assertSame('OFF1', $payload['attributes']['HIC_OFFER']);
+        $this->assertSame(1, $payload['attributes']['HIC_VALID']);
+        $this->assertSame(json_encode($data['relocations']), $payload['attributes']['HIC_RELOCATIONS']);
     }
 
     public function testReservationCreatedEventSendsFields() {
@@ -60,7 +64,9 @@ final class BrevoReservationFieldsTest extends TestCase {
             'room_name' => 'Room 1',
             'offer' => 'OFF1',
             'guest_first_name' => 'Mario',
-            'guest_last_name' => 'Rossi'
+            'guest_last_name' => 'Rossi',
+            'valid' => 1,
+            'relocations' => [['from' => '2024-01-01', 'to' => '2024-01-05']]
         ];
 
         \FpHic\hic_send_brevo_reservation_created_event($reservation);
@@ -77,6 +83,8 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame('OFF1', $payload['properties']['offer']);
         $this->assertSame('Mario', $payload['properties']['guest_first_name']);
         $this->assertSame('Rossi', $payload['properties']['guest_last_name']);
+        $this->assertSame(1, $payload['properties']['valid']);
+        $this->assertSame(json_encode($reservation['relocations']), $payload['properties']['relocations']);
     }
 
     public function testPhoneAndWhatsappSeparated() {


### PR DESCRIPTION
## Summary
- include reservation validity and relocations data in Brevo contact and reservation_created event payloads
- document HIC_VALID and HIC_RELOCATIONS attributes
- test Brevo dispatcher and event emitter for new fields

## Testing
- `composer test`
- `vendor/bin/parallel-lint includes/ FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php`


------
https://chatgpt.com/codex/tasks/task_e_68c083511784832f9671cbbe14c70869