### PR TITLE
Ensure WhatsApp attribute falls back to normalized phone

### DIFF
--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -23,11 +23,14 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
   $phone_data = Helpers\hic_detect_phone_language($data['phone'] ?? ($data['whatsapp'] ?? ''));
   if (!empty($phone_data['phone'])) {
     if (isset($data['phone'])) { $data['phone'] = $phone_data['phone']; }
-    if (isset($data['whatsapp'])) { $data['whatsapp'] = $phone_data['phone']; }
+    if (empty($data['whatsapp'])) { $data['whatsapp'] = $phone_data['phone']; }
   }
   if (!empty($phone_data['language'])) {
     $lang = $phone_data['language'];
   }
+
+  // Normalized phone value for attributes
+  $normalized_phone = $data['phone'] ?? ($data['whatsapp'] ?? '');
 
   $list_ids = array();
   if (strtolower($lang) === 'it') {
@@ -44,7 +47,7 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
     'attributes' => array(
       'FIRSTNAME' => isset($data['guest_first_name']) ? $data['guest_first_name'] : '',
       'LASTNAME'  => isset($data['guest_last_name']) ? $data['guest_last_name'] : '',
-      'PHONE'     => $data['phone'] ?? '',
+      'PHONE'     => $normalized_phone,
       'RESVID'    => isset($data['reservation_id']) ? $data['reservation_id'] : (isset($data['id']) ? $data['id'] : ''),
       'GCLID'     => isset($gclid) ? $gclid : '',
       'FBCLID'    => isset($fbclid) ? $fbclid : '',
@@ -53,7 +56,7 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
       'DATE'      => isset($data['date']) ? $data['date'] : wp_date('Y-m-d'),
       'AMOUNT'    => isset($data['amount']) ? Helpers\hic_normalize_price($data['amount']) : 0,
       'CURRENCY'  => isset($data['currency']) ? $data['currency'] : 'EUR',
-      'WHATSAPP'  => isset($data['whatsapp']) ? $data['whatsapp'] : '',
+      'WHATSAPP'  => $normalized_phone,
       'LANGUAGE'  => $lang,
       // Legacy alias for LANGUAGE
       'LINGUA'    => $lang

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -182,6 +182,17 @@ class HICFunctionsTest {
         assert($payload['attributes']['FIRSTNAME'] === 'Mario', 'Guest first name should map to FIRSTNAME');
         assert($payload['attributes']['LASTNAME'] === 'Rossi', 'Guest last name should map to LASTNAME');
 
+        // Contact with phone only should populate WHATSAPP
+        $hic_last_request = null;
+        \FpHic\hic_send_brevo_contact([
+            'email' => 'onlyphone@example.com',
+            'phone' => '+39 3331234567',
+            'lingua' => 'en'
+        ], '', '');
+        $payload = json_decode($hic_last_request['args']['body'], true);
+        assert($payload['attributes']['PHONE'] === '+393331234567', 'Phone should be normalized');
+        assert($payload['attributes']['WHATSAPP'] === '+393331234567', 'WhatsApp should fall back to phone');
+
         // Contact with foreign phone
         $hic_last_request = null;
         \FpHic\hic_send_brevo_contact([


### PR DESCRIPTION
## Summary
- normalize Brevo contact numbers and fill missing WhatsApp field with normalized phone
- map both PHONE and WHATSAPP attributes to the normalized value
- test that contacts without an explicit WhatsApp number still populate the WHATSAPP attribute

## Testing
- `php tests/test-functions.php`


------
https://chatgpt.com/codex/tasks/task_e_68c121f5e684832fa31941bdd145e8fa