### PR TITLE
Enforce typed booking data processing

### DIFF
--- a/includes/api/webhook.php
+++ b/includes/api/webhook.php
@@ -107,9 +107,9 @@ function hic_webhook_handler(WP_REST_Request $request) {
   try {
     // Process booking data with error handling
     $result = hic_process_booking_data($data);
-    
+
     // Mark reservation as processed if successful
-    if ($result !== false && !empty($reservation_id)) {
+    if ($result && !empty($reservation_id)) {
       hic_mark_reservation_processed_by_id($reservation_id);
     }
     
@@ -117,7 +117,7 @@ function hic_webhook_handler(WP_REST_Request $request) {
     update_option('hic_last_webhook_processing', current_time('mysql'), false);
     hic_clear_option_cache('hic_last_webhook_processing');
     
-    if ($result === false) {
+    if (!$result) {
       hic_log('Webhook: elaborazione fallita per dati ricevuti');
       return new WP_REST_Response(['error'=>'processing failed'], 500);
     }

--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -9,12 +9,27 @@ namespace FpHic;
 if (!defined('ABSPATH')) exit;
 
 // Funzione comune per processare i dati di prenotazione (sia webhook che API)
-function hic_process_booking_data($data) {
-  // Validate input data
-  if (!is_array($data)) {
-    hic_log('hic_process_booking_data: dati non validi (non array)');
-    return false;
-  }
+/**
+ * Process booking data by sending tracking events to configured integrations.
+ *
+ * Expected keys in the $data array:
+ * - "email"   (string) Cliente associato alla prenotazione (obbligatorio).
+ * - "sid"     (string|null) Session identifier per recuperare i tracciamenti.
+ * - "amount"  (int|float|string|null) Importo della prenotazione.
+ * - "status"  (string|null) Stato della prenotazione usato per determinare i rimborsi.
+ * - "presence" (string|null) Campo alternativo allo stato proveniente dall'API.
+ *
+ * @param array{
+ *   email: string,
+ *   sid?: string|null,
+ *   amount?: int|float|string|null,
+ *   status?: string|null,
+ *   presence?: string|null
+ * } $data Dati della prenotazione da processare.
+ *
+ * @return bool True se la prenotazione è stata processata con successo, false in caso contrario.
+ */
+function hic_process_booking_data(array $data): bool {
 
   // Validate required fields
   $required_fields = ['email'];

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -280,7 +280,7 @@ if (defined('WP_CLI') && WP_CLI) {
             WP_CLI::log('Resending reservation ' . $reservation_id . '...');
             $result = \FpHic\hic_process_booking_data($data);
 
-            if ($result !== false) {
+            if ($result) {
                 WP_CLI::success('Reservation resent successfully');
             } else {
                 WP_CLI::error('Failed to resend reservation');


### PR DESCRIPTION
## Summary
- type `hic_process_booking_data` to accept array and return bool
- document expected booking keys
- update webhook and CLI calls for boolean results

## Testing
- `composer --verbose analyse`
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d1b0d2c8832fbf2b9054c5f6cfe3