### PR TITLE
Optimize hic_log manager initialization

### DIFF
--- a/includes/helpers-logging.php
+++ b/includes/helpers-logging.php
@@ -115,7 +115,11 @@ if (function_exists('add_filter')) {
 }
 
 function hic_log($msg, $level = HIC_LOG_LEVEL_INFO, $context = []) {
-    $log_manager = function_exists('\\hic_get_log_manager') ? \hic_get_log_manager() : null;
+    static $log_manager = null;
+
+    if (null === $log_manager && function_exists('\\hic_get_log_manager')) {
+        $log_manager = \hic_get_log_manager();
+    }
 
     if ($log_manager) {
         return $log_manager->log($msg, $level, $context);


### PR DESCRIPTION
## Summary
- Cache log manager instance in `hic_log` using a static variable and only initialize when available

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68c1d4089ff0832fa844d75318758426