### PR TITLE
Enable shutdown polling check in admin area

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -510,8 +510,8 @@ class HIC_Booking_Poller {
      * Shutdown polling check - very lightweight check on page end
      */
     public function shutdown_polling_check() {
-        // Only run if polling should be active and we're not in admin
-        if (!$this->should_poll() || is_admin()) {
+        // Only run if polling should be active
+        if (!$this->should_poll()) {
             return;
         }
         


### PR DESCRIPTION
## Summary
- Allow `shutdown_polling_check` to run regardless of admin context so polling delays are logged on both frontend and backend.

## Testing
- `composer run lint` *(no output)*
- `composer run test` *(fails: Cannot redeclare class WP_Error)*

------
https://chatgpt.com/codex/tasks/task_e_68c77c18a25c832fa6f5e4e95d45340d