### PR TITLE
Replace blocking sleeps in booking poller with async WP-Cron

### DIFF
--- a/tests/preload.php
+++ b/tests/preload.php
@@ -44,6 +44,12 @@ if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled(...$args
 if (!function_exists('wp_schedule_event')) { function wp_schedule_event(...$args) { return true; } }
 if (!function_exists('wp_unschedule_event')) { function wp_unschedule_event(...$args) { return true; } }
 if (!function_exists('wp_clear_scheduled_hook')) { function wp_clear_scheduled_hook(...$args) { return true; } }
+if (!function_exists('wp_schedule_single_event')) {
+    function wp_schedule_single_event(...$args) {
+        $GLOBALS['wp_scheduled_events'][] = $args;
+        return true;
+    }
+}
 if (!function_exists('is_admin')) { function is_admin() { return false; } }
 if (!function_exists('admin_url')) { function admin_url($path = '') { return $path; } }
 if (!function_exists('wp_enqueue_script')) { function wp_enqueue_script(...$args) {} }


### PR DESCRIPTION
## Summary
- replace `sleep(1)` in booking poller with asynchronous scheduler restart using `wp_schedule_single_event`
- add helper to schedule restart and hook `hic_scheduler_restart`
- update test preload stubs for single-event scheduling

## Testing
- `composer lint:syntax`
- `composer test` *(fails: Cannot redeclare class WP_Error)*
- `php /tmp/manual_test.php`

------
https://chatgpt.com/codex/tasks/task_e_68c77e499c78832f9e89e8a5824c9f67