### PR TITLE
Remove obsolete deep check fallback and document WP-Cron scheduling

### DIFF
--- a/ARCHITETTURA_TECNICA.md
+++ b/ARCHITETTURA_TECNICA.md
@@ -26,7 +26,7 @@
 │  │ v1/conversion   │    │  • Controlla ogni 1-5 minuti                │   │
 │  └─────────┬───────┘    │  • Lock anti-overlap                        │   │
 │            │            │  • Watchdog system                          │   │
-│            │            │  • Indipendente da WP-Cron                  │   │
+│            │            │  • Basato su WP-Cron con watchdog           │   │
 │            │            └──────────────────┬───────────────────────────┘   │
 │            │                               │                               │
 │            └───────────┬───────────────────┘                               │

--- a/FAQ.md
+++ b/FAQ.md
@@ -40,8 +40,8 @@
 **R**: **Sì, esatto!** Il plugin include un sistema di scheduling interno ottimizzato (`HIC_Booking_Poller`) che:
 
 - ⏰ **Polling continuo ogni 30 secondi** per prenotazioni recenti e manuali (quasi real-time)
-- 🚀 **Deep check disabilitato** - il polling continuo ogni 30 secondi è sufficiente per la copertura totale
-- 🔒 **Non dipende da WordPress cron** (più affidabile)
+- 🚀 **Deep check attivo ogni 30 minuti** per verificare le ultime prenotazioni
+- 🔒 **Basato su WP-Cron** con meccanismi di watchdog e fallback
 - 🛡️ **Ha protezioni anti-overlap** (lock e watchdog)
 - 📋 **Cattura TUTTE le prenotazioni** (online + manuali dello staff)
 - 🎯 **È completamente automatico** una volta configurato

--- a/GUIDA_CONFIGURAZIONE.md
+++ b/GUIDA_CONFIGURAZIONE.md
@@ -69,7 +69,7 @@ Il nuovo sistema è **già ottimizzato** e non richiede configurazioni aggiuntiv
 
 - ✅ **Polling Continuo**: Ogni minuto controlla prenotazioni recenti e manuali
 - ✅ **Deep Check**: Ogni 30 minuti controlla le ultime 5 prenotazioni per verificare che nulla venga perso  
-- ✅ **Non dipende da WP-Cron**: Utilizza WordPress Heartbeat API (più affidabile)
+- ✅ **Basato su WP-Cron** con watchdog e fallback per maggiore affidabilità
 - ✅ **Cattura prenotazioni manuali**: Include automaticamente le prenotazioni inserite manualmente dallo staff
 
 **Non sono più necessarie** le configurazioni cron esterne!

--- a/MANUAL_POLLING_GUIDE.md
+++ b/MANUAL_POLLING_GUIDE.md
@@ -72,9 +72,9 @@ Each condition must be ✅ (green checkmark) for automatic polling to work:
 **Solution**: Use "Forza Polling Ora" to clear the lock and restart polling
 
 ### Issue: "Il timestamp è troppo vecchio (oltre 7 giorni)" - Polling Stops
-**Symptoms**: 
+**Symptoms**:
 - Logs show "HTTP 400 - Il timestamp è troppo vecchio (oltre 7 giorni)"
-- Diagnostics show "Polling Continuo (1 min): Mai" and "Deep Check (10 min): Mai"
+- Diagnostics show "Polling Continuo (1 min): Mai" and "Deep Check (30 min): Mai"
 - Status shows "Prossimo continuo: In attesa di avvio"
 
 **Automatic Solution**: 

--- a/PLUGIN_FUNZIONAMENTO.md
+++ b/PLUGIN_FUNZIONAMENTO.md
@@ -18,7 +18,7 @@ Quando arriva una nuova prenotazione su Hotel in Cloud, il plugin può intercett
 
 #### Modalità B: API Polling (Raccomandato)
 - WordPress controlla autonomamente HIC ogni 1-5 minuti
-- Sistema di polling interno **indipendente da WordPress cron**
+- Sistema di polling interno basato su **WP-Cron** con controlli di watchdog
 - **Vantaggio**: Più affidabile, cattura anche prenotazioni manuali
 - **Svantaggio**: Leggero ritardo (1-5 minuti)
 
@@ -39,7 +39,7 @@ Il plugin include un **sistema di scheduling interno** (`HIC_Booking_Poller`) ch
 - 🔒 **Lock anti-overlap**: Previene esecuzioni sovrapposte
 - 🐕 **Watchdog**: Monitora e riavvia automaticamente se necessario
 - 📊 **Logging strutturato**: Traccia tutte le operazioni
-- 🚫 **Indipendente da WP-Cron**: Funziona anche se WP-Cron è disabilitato
+- 🕒 **Basato su WP-Cron** con fallback automatico in caso di malfunzionamenti
 
 ### 3. Elaborazione della Prenotazione
 
@@ -165,13 +165,13 @@ Pannello admin completo per:
 
 ✅ **Corretto!** Il plugin ha un **sistema di scheduling interno** che:
 - Controlla HIC ogni 1-5 minuti per nuove prenotazioni
-- Non dipende da WordPress cron
+- Utilizza WP-Cron con meccanismi di watchdog
 - È più affidabile del webhook
 - Cattura anche prenotazioni inserite manualmente in HIC
 
 ## Vantaggi del Sistema
 
-1. **Affidabilità**: Sistema interno indipendente da WordPress
+1. **Affidabilità**: Sistema interno integrato in WordPress con controlli dedicati
 2. **Completezza**: Cattura tutte le prenotazioni (anche manuali)
 3. **Multi-canale**: Invia contemporaneamente a GA4, Meta e Brevo
 4. **Attribution**: Traccia fonte della conversione (Google Ads, Facebook, organico)

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Plugin WordPress per il monitoraggio avanzato delle conversioni da Hotel in Clou
 4. 📱 **La invia a Meta** (evento Purchase per Facebook Ads)
 5. ♻️ **Traccia eventuali rimborsi** (evento refund con valore negativo, attivabile dalle impostazioni)
 
-Il tutto avviene **automaticamente** tramite un **sistema interno di scheduling** indipendente da WordPress cron.
+Il tutto avviene **automaticamente** tramite un **sistema interno di scheduling** basato su WP-Cron con meccanismi di watchdog e fallback.
 
 ### Modalità di Funzionamento
 

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -499,7 +499,7 @@ function hic_polling_interval_render() {
     echo '<option value="hic_poll_interval"' . selected($interval, 'hic_poll_interval', false) . '>Ogni 5 minuti (compatibilità)</option>';
     echo '<option value="hic_reliable_interval"' . selected($interval, 'hic_reliable_interval', false) . '>Ogni 5 minuti (affidabile)</option>';
     echo '</select>';
-    echo '<p class="description">Frequenza del polling API per prenotazioni quasi real-time. "Affidabile" non dipende da WP-Cron.</p>';
+    echo '<p class="description">Frequenza del polling API per prenotazioni quasi real-time. "Affidabile" utilizza WP-Cron con watchdog.</p>';
 }
 
 function hic_reliable_polling_enabled_render() {
@@ -508,7 +508,7 @@ function hic_reliable_polling_enabled_render() {
     echo '<input type="checkbox" name="hic_reliable_polling_enabled" value="1"' . checked($enabled, true, false) . ' />';
     echo ' Attiva sistema polling affidabile';
     echo '</label>';
-    echo '<p class="description">Sistema interno con watchdog e recupero automatico, indipendente da WP-Cron. <strong>Raccomandato per hosting condiviso.</strong></p>';
+    echo '<p class="description">Sistema interno con watchdog e recupero automatico basato su WP-Cron. <strong>Raccomandato per hosting condiviso.</strong></p>';
 }
 
 // Extended HIC Integration render functions

--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -4,7 +4,7 @@ namespace FpHic;
 use \WP_Error;
 /**
  * API Polling Handler - Core API Functions Only
- * Note: WP-Cron scheduling removed in favor of internal scheduler (booking-poller.php)
+ * Note: Scheduling is handled by booking-poller.php via WP-Cron; this file focuses on API polling logic
  */
 
 if (!defined('ABSPATH')) exit;
@@ -117,7 +117,7 @@ function hic_handle_api_response($response, $context = 'API call') {
 }
 
 /* ============ Core API Functions ============ */
-// Note: WP-Cron scheduling has been removed in favor of the internal scheduler 
+// Note: WP-Cron scheduling is managed by the booking-poller
 // in booking-poller.php. This file now contains only core API functions.
 
 /**


### PR DESCRIPTION
## Summary
- drop unused `fallback_deep_check` and reschedule deep checks through WP-Cron
- report active deep check status in heartbeat and stats
- refresh docs and admin UI to note WP-Cron-based polling with 30‑minute deep check

## Testing
- `composer lint:syntax`
- `composer test` *(fails: Cannot redeclare class WP_Error in tests)*

------
https://chatgpt.com/codex/tasks/task_e_68c780287064832fa0864592137c2a46