### PR TITLE
Handle admin email fallback

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -595,12 +595,15 @@ function hic_brevo_event_endpoint_render() {
 function hic_validate_admin_email($input) {
     // Allow empty value (will fall back to WordPress admin email)
     if (empty($input)) {
+        delete_option('hic_admin_email');
+        \FpHic\Helpers\hic_clear_option_cache('admin_email');
+        add_filter('pre_update_option_hic_admin_email', '__return_false');
         return '';
     }
-    
+
     // Sanitize the email
     $sanitized_email = sanitize_email($input);
-    
+
     // Validate email format
     if (!is_email($sanitized_email)) {
         add_settings_error(
@@ -612,12 +615,12 @@ function hic_validate_admin_email($input) {
         // Return the original value from database
         return \FpHic\Helpers\hic_get_option('admin_email', '');
     }
-    
+
     // Log the email change for transparency
     $old_email = \FpHic\Helpers\hic_get_option('admin_email', '');
     if ($old_email !== $sanitized_email) {
         hic_log('Admin email changed from "' . $old_email . '" to "' . $sanitized_email . '"');
-        
+
         // Show success message
         add_settings_error(
             'hic_admin_email',
@@ -626,6 +629,6 @@ function hic_validate_admin_email($input) {
             'updated'
         );
     }
-    
+
     return $sanitized_email;
 }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -119,7 +119,13 @@ function hic_get_brevo_event_endpoint() {
 function hic_reliable_polling_enabled() { return hic_get_option('reliable_polling_enabled', '1') === '1'; }
 
 // Admin and General Settings
-function hic_get_admin_email() { return hic_get_option('admin_email', get_option('admin_email')); }
+function hic_get_admin_email() {
+    $email = sanitize_email(hic_get_option('admin_email', ''));
+    if ($email === '') {
+        $email = sanitize_email(get_option('admin_email'));
+    }
+    return $email;
+}
 
 // GTM Settings
 function hic_is_gtm_enabled() { return hic_get_option('gtm_enabled', '0') === '1'; }


### PR DESCRIPTION
## Summary
- Use empty default and sanitize fallback for admin email retrieval
- Delete stored admin email when input is cleared to rely on WordPress admin email

## Testing
- `composer test` *(fails: Cannot redeclare class WP_Error in tests/ImprovementsTest.php)*

------
https://chatgpt.com/codex/tasks/task_e_68c7dc4c3b20832f873eb5e55ffde040