### PR TITLE
Schedule failed request tasks on plugin load

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -40,11 +40,15 @@ require_once __DIR__ . '/includes/automated-reporting.php';
 require_once __DIR__ . '/includes/google-ads-enhanced.php';
 require_once __DIR__ . '/includes/circuit-breaker.php';
 require_once __DIR__ . '/includes/enterprise-management-suite.php';
+require_once __DIR__ . '/includes/helpers-scheduling.php';
 
 // Log vendor autoloader status after all includes are loaded
 if (!$vendor_available) {
     Helpers\hic_log('HIC Plugin: vendor/autoload.php non trovato, utilizzando caricamento manuale.', HIC_LOG_LEVEL_WARNING);
 }
+
+// Initialize helper hooks immediately after loading core files
+Helpers\hic_init_helper_hooks();
 
 // Plugin activation handler
 function hic_activate($network_wide)
@@ -178,9 +182,6 @@ function hic_activate($network_wide)
     require_once __DIR__ . '/includes/performance-monitor.php';
     require_once __DIR__ . '/includes/health-monitor.php';
 
-    // Initialize helper action hooks
-    Helpers\hic_init_helper_hooks();
-    
     // Initialize log manager
     \hic_get_log_manager();
 

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -86,8 +86,11 @@ function hic_init_helper_hooks() {
         add_filter('wp_privacy_personal_data_exporters', __NAMESPACE__ . '\\hic_register_exporter');
         add_filter('wp_privacy_personal_data_erasers', __NAMESPACE__ . '\\hic_register_eraser');
         add_filter('cron_schedules', __NAMESPACE__ . '\\hic_add_failed_request_schedule');
-        add_action('init', __NAMESPACE__ . '\\hic_schedule_failed_request_retry');
-        add_action('init', __NAMESPACE__ . '\\hic_schedule_failed_request_cleanup');
+
+        // Schedule cron events immediately
+        hic_schedule_failed_request_retry();
+        hic_schedule_failed_request_cleanup();
+
         add_action('hic_retry_failed_requests', __NAMESPACE__ . '\\hic_retry_failed_requests');
         add_action('hic_cleanup_failed_requests', __NAMESPACE__ . '\\hic_cleanup_failed_requests');
     }


### PR DESCRIPTION
## Summary
- Invoke helper hooks and cron scheduling at plugin load instead of waiting for `init`
- Call retry and cleanup schedulers directly so events are registered immediately

## Testing
- `composer test` *(fails: Cannot redeclare class WP_Error)*
- `wp cron event list` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e345fd28832f9079f56b497d37e4