### PR TITLE
Use fifteen-minute schedule for retry

### DIFF
--- a/includes/helpers-scheduling.php
+++ b/includes/helpers-scheduling.php
@@ -19,7 +19,7 @@ function hic_should_schedule_retry_event() {
     }
 
     $schedules = wp_get_schedules();
-    return isset($schedules['hic_retry_interval']);
+    return isset($schedules['hic_every_fifteen_minutes']);
 }
 
 /* ================= SAFE WORDPRESS CRON HELPERS ================= */

--- a/tests/ShouldScheduleRetryEventTest.php
+++ b/tests/ShouldScheduleRetryEventTest.php
@@ -1,0 +1,31 @@
+<?php
+namespace FpHic\Helpers {
+    if (!function_exists(__NAMESPACE__ . '\\wp_get_schedules')) {
+        function wp_get_schedules() {
+            return [
+                'hic_every_fifteen_minutes' => [
+                    'interval' => 15 * 60,
+                    'display' => 'Every 15 Minutes (HIC Failed Requests)'
+                ],
+            ];
+        }
+    }
+}
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/../includes/functions.php';
+
+    class ShouldScheduleRetryEventTest extends TestCase {
+        protected function setUp(): void {
+            \FpHic\Helpers\hic_clear_option_cache();
+            update_option('hic_realtime_brevo_sync', '1');
+            update_option('hic_brevo_api_key', 'test-key');
+        }
+
+        public function test_returns_true_when_brevo_sync_active(): void {
+            $this->assertTrue(\FpHic\Helpers\hic_should_schedule_retry_event());
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Ensure retry scheduling checks the fifteen-minute interval
- Add unit test confirming retry scheduling when Brevo sync is active

## Testing
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/ShouldScheduleRetryEventTest.php`
- `composer test` *(fails: Cannot redeclare class WP_Error)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e51055dc832fa04ebc37cf155bf1