### PR TITLE
Add manual helper includes for non-composer environments

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -40,7 +40,10 @@ require_once __DIR__ . '/includes/automated-reporting.php';
 require_once __DIR__ . '/includes/google-ads-enhanced.php';
 require_once __DIR__ . '/includes/circuit-breaker.php';
 require_once __DIR__ . '/includes/enterprise-management-suite.php';
+require_once __DIR__ . '/includes/helpers-logging.php';
+require_once __DIR__ . '/includes/helpers-tracking.php';
 require_once __DIR__ . '/includes/helpers-scheduling.php';
+require_once __DIR__ . '/includes/database.php';
 
 // Log vendor autoloader status after all includes are loaded
 if (!$vendor_available) {


### PR DESCRIPTION
## Summary
- ensure helper and database modules are required when Composer autoloader is unavailable
- verified plugin can load without `vendor/autoload.php`

## Testing
- `php -l FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php`
- `php /tmp/test-no-vendor.php`
- `composer test` *(fails: Cannot redeclare class WP_Error)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e6700c68832f8b6ac5e74022c868