### PR TITLE
Use namespaced deactivation hook

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -153,7 +153,7 @@ function hic_activate($network_wide)
 
 // Plugin activation hook
 \register_activation_hook(__FILE__, __NAMESPACE__ . '\\hic_activate');
-\register_deactivation_hook(__FILE__, 'hic_deactivate');
+\register_deactivation_hook(__FILE__, __NAMESPACE__ . '\\hic_deactivate');
 \add_action('plugins_loaded', '\\hic_maybe_upgrade_db');
 
 // Add settings link in plugin list

--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -1,4 +1,7 @@
 <?php declare(strict_types=1);
+
+namespace {
+
 /**
  * Internal Booking Scheduler - WP-Cron System
  */
@@ -1041,3 +1044,11 @@ function hic_deactivate() {
 
 // Initialize booking poller when WordPress is ready (safe hook registration)
 \FpHic\Helpers\hic_safe_add_hook('action', 'init', 'hic_init_booking_poller');
+
+}
+
+namespace FpHic {
+    function hic_deactivate(): void {
+        \hic_deactivate();
+    }
+}

--- a/tests/preload.php
+++ b/tests/preload.php
@@ -69,6 +69,11 @@ if (!function_exists('wp_doing_cron')) { function wp_doing_cron() { return defin
 if (!function_exists('is_ssl')) { function is_ssl() { return false; } }
 if (!function_exists('wp_unslash')) { function wp_unslash($value) { return $value; } }
 if (!function_exists('is_wp_error')) { function is_wp_error($thing) { return $thing instanceof \WP_Error; } }
+if (!function_exists('wp_error')) { function wp_error($code = '', $message = '', $data = null) { return new \WP_Error($code, $message, $data); } }
+if (!function_exists('delete_option')) { function delete_option($option) { global $hic_test_options; unset($hic_test_options[$option]); return true; } }
+if (!function_exists('delete_transient')) { function delete_transient($transient) { return true; } }
+if (!function_exists('wp_upload_dir')) { function wp_upload_dir($path = null) { return ['basedir' => sys_get_temp_dir(), 'baseurl' => '']; } }
+if (!function_exists('plugin_basename')) { function plugin_basename($file) { return $file; } }
 if (!function_exists('sanitize_text_field')) { function sanitize_text_field($str) { return filter_var($str, FILTER_SANITIZE_STRING); } }
 if (!function_exists('wp_date')) {
     function wp_date($format, $timestamp = null, $timezone = null) {


### PR DESCRIPTION
## Summary
- reference hic_deactivate via namespace in plugin main file
- provide FpHic\hic_deactivate alias in booking poller
- extend test preload with core WordPress stubs

## Testing
- `composer test` (fails: Call to undefined method class@anonymous::get_var())
- `php /tmp/verify.php`

------
https://chatgpt.com/codex/tasks/task_e_68c7e7f2ec80832f89fac3a93965d758