### PR TITLE
Ensure retry cron scheduled only when Brevo sync ready

### DIFF
--- a/includes/helpers-scheduling.php
+++ b/includes/helpers-scheduling.php
@@ -68,6 +68,10 @@ function hic_add_failed_request_schedule($schedules) {
 }
 
 function hic_schedule_failed_request_retry() {
+    if (!hic_should_schedule_retry_event()) {
+        return;
+    }
+
     if (!hic_safe_wp_next_scheduled('hic_retry_failed_requests')) {
         hic_safe_wp_schedule_event(time(), 'hic_every_fifteen_minutes', 'hic_retry_failed_requests');
     }

--- a/tests/ZZFailedRequestRetrySchedulerTest.php
+++ b/tests/ZZFailedRequestRetrySchedulerTest.php
@@ -1,0 +1,75 @@
+<?php
+namespace FpHic\Helpers {
+    if (!function_exists(__NAMESPACE__ . '\\wp_get_schedules')) {
+        function wp_get_schedules() {
+            $schedules = [
+                'hourly' => ['interval' => 3600, 'display' => 'Once Hourly'],
+                'twicedaily' => ['interval' => 12 * 3600, 'display' => 'Twice Daily'],
+                'daily' => ['interval' => 24 * 3600, 'display' => 'Once Daily'],
+            ];
+            if (!empty($GLOBALS['schedule_defined'])) {
+                $schedules['hic_every_fifteen_minutes'] = [
+                    'interval' => 15 * 60,
+                    'display'  => 'Every 15 Minutes (HIC Failed Requests)'
+                ];
+            }
+            return $schedules;
+        }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_next_scheduled')) {
+        function wp_next_scheduled($hook) {
+            return $GLOBALS['next_scheduled'] ?? false;
+        }
+    }
+    if (!function_exists(__NAMESPACE__ . '\\wp_schedule_event')) {
+        function wp_schedule_event($timestamp, $recurrence, $hook, $args = array(), $wp_error = false) {
+            $GLOBALS['scheduled_events'][] = [
+                'timestamp' => $timestamp,
+                'recurrence' => $recurrence,
+                'hook' => $hook,
+                'args' => $args,
+            ];
+            return true;
+        }
+    }
+}
+
+namespace {
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/../includes/functions.php';
+    require_once __DIR__ . '/../includes/helpers-scheduling.php';
+
+    final class ZZFailedRequestRetrySchedulerTest extends TestCase {
+        protected function setUp(): void {
+            \FpHic\Helpers\hic_clear_option_cache();
+            update_option('hic_realtime_brevo_sync', '1');
+            update_option('hic_brevo_api_key', 'test-key');
+            $GLOBALS['next_scheduled'] = false;
+            $GLOBALS['schedule_defined'] = true;
+            $GLOBALS['scheduled_events'] = [];
+        }
+
+        public function test_schedules_retry_when_conditions_met(): void {
+            $this->assertTrue(\FpHic\Helpers\hic_should_schedule_retry_event());
+            \FpHic\Helpers\hic_schedule_failed_request_retry();
+            $this->assertNotEmpty($GLOBALS['scheduled_events']);
+            $this->assertSame('hic_retry_failed_requests', $GLOBALS['scheduled_events'][0]['hook']);
+        }
+
+        public function test_does_not_schedule_when_brevo_sync_disabled(): void {
+            update_option('hic_realtime_brevo_sync', '0');
+            \FpHic\Helpers\hic_clear_option_cache();
+            $GLOBALS['scheduled_events'] = [];
+            \FpHic\Helpers\hic_schedule_failed_request_retry();
+            $this->assertEmpty($GLOBALS['scheduled_events']);
+        }
+
+        public function test_does_not_schedule_when_schedule_missing(): void {
+            $GLOBALS['schedule_defined'] = false;
+            $GLOBALS['scheduled_events'] = [];
+            \FpHic\Helpers\hic_schedule_failed_request_retry();
+            $this->assertEmpty($GLOBALS['scheduled_events']);
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- prevent retry cron from scheduling when prerequisites fail
- add regression tests for retry scheduling logic

## Testing
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/ZZFailedRequestRetrySchedulerTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68c7ea1e7dd0832fac2cdf30d7b3f69b