### PR TITLE
Import hic_log helper in HTTP security

### DIFF
--- a/includes/http-security.php
+++ b/includes/http-security.php
@@ -8,6 +8,8 @@
 
 namespace FpHic;
 
+use function FpHic\Helpers\hic_log;
+
 if (!defined('ABSPATH')) exit;
 
 class HIC_HTTP_Security {


### PR DESCRIPTION
## Summary
- import hic_log helper function into HTTP security module to avoid namespace issues

## Testing
- `composer test` *(fails: Failed asserting that false is true; Tests: 64, Assertions: 121, Errors: 3, Failures: 10, Warnings: 17, Deprecations: 11)*

------
https://chatgpt.com/codex/tasks/task_e_68c7ed5bda28832f9c74772e6de5d2a0