### PR TITLE
Load plugin text domain on plugins_loaded

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -18,6 +18,10 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+\add_action('plugins_loaded', function () {
+    \load_plugin_textdomain('hotel-in-cloud', false, \dirname(\plugin_basename(__FILE__)) . '/languages');
+});
+
 // Load Composer autoloader or fallback to manual loading
 $vendor_available = false;
 if (file_exists(__DIR__ . '/vendor/autoload.php')) {


### PR DESCRIPTION
## Summary
- load plugin translations on `plugins_loaded` using `load_plugin_textdomain`

## Testing
- `composer test` *(fails: Failed asserting that false is true)*
- `php verify_translation.php` *(removed script after run; confirmed output "Settings")*

------
https://chatgpt.com/codex/tasks/task_e_68c7f36f62c0832fbeb40a8cab5c04e3