### PR TITLE
Use namespaced debug verbose check

### DIFF
--- a/includes/log-manager.php
+++ b/includes/log-manager.php
@@ -109,7 +109,7 @@ class HIC_Log_Manager {
      * Log debug message (only if debug mode enabled)
      */
     public function debug($message, $context = []) {
-        if (Helpers\hic_is_debug_verbose()) {
+        if (\FpHic\Helpers\hic_is_debug_verbose()) {
             return $this->log($message, HIC_LOG_LEVEL_DEBUG, $context);
         }
         return true;


### PR DESCRIPTION
## Summary
- Use fully-qualified `\FpHic\Helpers\hic_is_debug_verbose()` in log manager to avoid undefined function calls

## Testing
- `composer test` (fails: Call to undefined method class@anonymous::get_var, among other failures)
- Manual debug logging script returns `bool(true)` and completes without errors


------
https://chatgpt.com/codex/tasks/task_e_68c7f50d0db4832faaf85716eb19fc76