### PR TITLE
Allow special characters in API password

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -71,7 +71,11 @@ function hic_ajax_test_api_connection() {
     // Get credentials from AJAX request or settings
     $prop_id = sanitize_text_field( wp_unslash( $_POST['prop_id'] ?? '' ) );
     $email = sanitize_email( wp_unslash( $_POST['email'] ?? '' ) );
-    $password = sanitize_text_field( wp_unslash( $_POST['password'] ?? '' ) );
+    // Allow special characters in password; only unslash without sanitization.
+    $password = wp_unslash( $_POST['password'] ?? '' );
+    if ( strlen( $password ) === 0 ) {
+        $password = '';
+    }
     
     // Test the API connection
     $result = \FpHic\hic_test_api_connection($prop_id, $email, $password);


### PR DESCRIPTION
## Summary
- Allow special characters in API test password by removing sanitize_text_field

## Testing
- `composer lint:syntax` *(no output)*
- `php -l includes/admin/admin-settings.php`
- `composer test` *(fails: Assertions and method errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c7f74666d0832fad92c57517f33e97