### PR TITLE
Clear orphaned scheduled hooks on activation

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -93,6 +93,11 @@ function hic_activate($network_wide)
         }
     }
 
+    // Clear potential orphaned scheduled events
+    \wp_clear_scheduled_hook('hic_db_database_optimization');
+    \wp_clear_scheduled_hook('hic_reconciliation');
+    \wp_clear_scheduled_hook('hic_capture_tracking_params');
+
     $log_dir = WP_CONTENT_DIR . '/uploads/hic-logs';
     $dir_ok  = true;
     if (!file_exists($log_dir)) {


### PR DESCRIPTION
## Summary
- Clear potential orphaned scheduled events during plugin activation

## Testing
- `composer lint:syntax` *(no output)*
- `composer lint` *(no output)*
- `composer test` *(fails: Class "HIC_Booking_Poller" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c815b8eab4832f9cd680aadb2efb2e