### PR TITLE
Rename 30-second cron schedule

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -77,7 +77,7 @@ class HIC_Booking_Poller {
         // Check and schedule continuous polling event
         $continuous_next = \FpHic\Helpers\hic_safe_wp_next_scheduled('hic_continuous_poll_event');
         if (!$continuous_next) {
-            $scheduled = \FpHic\Helpers\hic_safe_wp_schedule_event(time(), 'hic_every_minute', 'hic_continuous_poll_event');
+            $scheduled = \FpHic\Helpers\hic_safe_wp_schedule_event(time(), 'hic_every_thirty_seconds', 'hic_continuous_poll_event');
             if ($scheduled) {
                 hic_log('WP-Cron Scheduler: Scheduled continuous polling every 30 seconds (near real-time) with 30-minute deep check');
             } else {
@@ -89,7 +89,7 @@ class HIC_Booking_Poller {
             if ($continuous_next < (time() - $overdue_threshold)) {
                 hic_log('WP-Cron Scheduler: Continuous polling event is overdue, rescheduling');
                 \FpHic\Helpers\hic_safe_wp_clear_scheduled_hook('hic_continuous_poll_event');
-                \FpHic\Helpers\hic_safe_wp_schedule_event(time(), 'hic_every_minute', 'hic_continuous_poll_event');
+                \FpHic\Helpers\hic_safe_wp_schedule_event(time(), 'hic_every_thirty_seconds', 'hic_continuous_poll_event');
             }
         }
         
@@ -142,7 +142,7 @@ class HIC_Booking_Poller {
      * Add custom WP-Cron intervals
      */
     public function add_custom_cron_intervals($schedules) {
-        $schedules['hic_every_minute'] = array(
+        $schedules['hic_every_thirty_seconds'] = array(
             'interval' => HIC_CONTINUOUS_POLLING_INTERVAL,
             'display' => 'Every 30 Seconds (HIC Near Real-Time Polling)'
         );
@@ -300,7 +300,7 @@ class HIC_Booking_Poller {
             case 'continuous':
                 // Force reschedule continuous polling
                 \FpHic\Helpers\hic_safe_wp_clear_scheduled_hook('hic_continuous_poll_event');
-                \FpHic\Helpers\hic_safe_wp_schedule_event(time(), 'hic_every_minute', 'hic_continuous_poll_event');
+                \FpHic\Helpers\hic_safe_wp_schedule_event(time(), 'hic_every_thirty_seconds', 'hic_continuous_poll_event');
                 // Trigger immediate execution
                 $this->execute_continuous_polling();
                 break;

--- a/includes/circuit-breaker.php
+++ b/includes/circuit-breaker.php
@@ -238,13 +238,13 @@ class CircuitBreakerManager {
     public function schedule_circuit_breaker_tasks() {
         // Schedule retry queue processing
         if (!wp_next_scheduled('hic_process_retry_queue')) {
-            wp_schedule_event(time(), 'hic_every_minute', 'hic_process_retry_queue');
+            wp_schedule_event(time(), 'hic_every_thirty_seconds', 'hic_process_retry_queue');
             $this->log('Scheduled retry queue processing');
         }
         
         // Schedule circuit breaker recovery checks
         if (!wp_next_scheduled('hic_check_circuit_breaker_recovery')) {
-            wp_schedule_event(time(), 'hic_every_minute', 'hic_check_circuit_breaker_recovery');
+            wp_schedule_event(time(), 'hic_every_thirty_seconds', 'hic_check_circuit_breaker_recovery');
             $this->log('Scheduled circuit breaker recovery checks');
         }
     }

--- a/includes/realtime-dashboard.php
+++ b/includes/realtime-dashboard.php
@@ -93,7 +93,7 @@ class RealtimeDashboard {
      */
     private function schedule_dashboard_refresh() {
         if (!wp_next_scheduled('hic_refresh_dashboard_data')) {
-            wp_schedule_event(time(), 'hic_every_minute', 'hic_refresh_dashboard_data');
+            wp_schedule_event(time(), 'hic_every_thirty_seconds', 'hic_refresh_dashboard_data');
             add_action('hic_refresh_dashboard_data', [$this, 'refresh_dashboard_cache']);
         }
     }


### PR DESCRIPTION
## Summary
- rename cron schedule key to hic_every_thirty_seconds for 30-second polling
- update circuit breaker and dashboard to use new 30-second schedule

## Testing
- `php -l includes/booking-poller.php`
- `php -l includes/circuit-breaker.php`
- `php -l includes/realtime-dashboard.php`
- `composer test` *(fails: Class "HIC_Booking_Poller" not found and other failures)*

------
https://chatgpt.com/codex/tasks/task_e_68c81748e91c832fb7df344172f1d1a9