### PR TITLE
Secure polling metrics AJAX endpoint

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -23,6 +23,13 @@ jQuery(document).ready(function($) {
         }, callback, 'json');
     };
 
+    window.hicGetPollingMetrics = function(callback) {
+        $.post(ajaxurl, {
+            action: 'hic_get_polling_metrics',
+            nonce: hicDiagnostics.polling_metrics_nonce
+        }, callback, 'json');
+    };
+
         // Enhanced UI functionality
 
         // Toast notification system

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -281,6 +281,7 @@ function hic_admin_enqueue_scripts($hook) {
             'diagnostics_nonce' => wp_create_nonce('hic_diagnostics_nonce'),
             'admin_nonce' => wp_create_nonce('hic_admin_action'),
             'monitor_nonce' => wp_create_nonce('hic_monitor_nonce'),
+            'polling_metrics_nonce' => wp_create_nonce('hic_polling_metrics'),
             'is_api_connection' => (\FpHic\Helpers\hic_get_connection_type() === 'api'),
             'has_basic_auth' => \FpHic\Helpers\hic_has_basic_auth_credentials(),
             'has_property_id' => (bool) \FpHic\Helpers\hic_get_property_id(),


### PR DESCRIPTION
## Summary
- restrict polling metrics endpoint to authenticated admins
- validate AJAX requests with dedicated nonce
- expose polling metrics nonce in diagnostics panel script

## Testing
- `php -l includes/intelligent-polling-manager.php`
- `php -l includes/admin/admin-settings.php`
- `composer test` *(fails: Class "HIC_Booking_Poller" not found, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c81d16da08832f8530e9cc057f6c35