### PR TITLE
Add nonce validation for database stats endpoint

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -30,6 +30,13 @@ jQuery(document).ready(function($) {
         }, callback, 'json');
     };
 
+    window.hicGetDatabaseStats = function(callback) {
+        $.post(ajaxurl, {
+            action: 'hic_get_database_stats',
+            nonce: hicDiagnostics.optimize_db_nonce
+        }, callback, 'json');
+    };
+
         // Enhanced UI functionality
 
         // Toast notification system

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -282,6 +282,7 @@ function hic_admin_enqueue_scripts($hook) {
             'admin_nonce' => wp_create_nonce('hic_admin_action'),
             'monitor_nonce' => wp_create_nonce('hic_monitor_nonce'),
             'polling_metrics_nonce' => wp_create_nonce('hic_polling_metrics'),
+            'optimize_db_nonce' => wp_create_nonce('hic_optimize_db'),
             'is_api_connection' => (\FpHic\Helpers\hic_get_connection_type() === 'api'),
             'has_basic_auth' => \FpHic\Helpers\hic_has_basic_auth_credentials(),
             'has_property_id' => (bool) \FpHic\Helpers\hic_get_property_id(),

--- a/includes/database-optimizer.php
+++ b/includes/database-optimizer.php
@@ -662,8 +662,12 @@ class DatabaseOptimizer {
      * AJAX: Get database statistics
      */
     public function ajax_get_database_stats() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
+        }
+
+        if (!check_ajax_referer('hic_optimize_db', 'nonce', false)) {
+            wp_send_json_error('Invalid nonce');
         }
         
         global $wpdb;


### PR DESCRIPTION
## Summary
- secure database stats AJAX action with hic_manage capability and nonce validation
- expose hic_optimize_db nonce to admin scripts and use it in diagnostics utility

## Testing
- `composer lint:syntax`
- `composer test` *(fails: Class "HIC_Booking_Poller" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c81eacdb34832fa02affa8cf172335