### PR TITLE
Add management nonce checks to reconciliation and health status

### DIFF
--- a/assets/js/diagnostics.js
+++ b/assets/js/diagnostics.js
@@ -37,6 +37,20 @@ jQuery(document).ready(function($) {
         }, callback, 'json');
     };
 
+    window.hicRunReconciliation = function(callback) {
+        $.post(ajaxurl, {
+            action: 'hic_run_reconciliation',
+            nonce: hicDiagnostics.management_nonce
+        }, callback, 'json');
+    };
+
+    window.hicGetHealthStatus = function(callback) {
+        $.post(ajaxurl, {
+            action: 'hic_get_health_status',
+            nonce: hicDiagnostics.management_nonce
+        }, callback, 'json');
+    };
+
         // Enhanced UI functionality
 
         // Toast notification system

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -283,6 +283,7 @@ function hic_admin_enqueue_scripts($hook) {
             'monitor_nonce' => wp_create_nonce('hic_monitor_nonce'),
             'polling_metrics_nonce' => wp_create_nonce('hic_polling_metrics'),
             'optimize_db_nonce' => wp_create_nonce('hic_optimize_db'),
+            'management_nonce' => wp_create_nonce('hic_management_nonce'),
             'is_api_connection' => (\FpHic\Helpers\hic_get_connection_type() === 'api'),
             'has_basic_auth' => \FpHic\Helpers\hic_has_basic_auth_credentials(),
             'has_property_id' => (bool) \FpHic\Helpers\hic_get_property_id(),

--- a/includes/enterprise-management-suite.php
+++ b/includes/enterprise-management-suite.php
@@ -986,10 +986,14 @@ class EnterpriseManagementSuite {
      * AJAX: Run reconciliation
      */
     public function ajax_run_reconciliation() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
-        
+
+        if (!check_ajax_referer('hic_management_nonce', 'nonce', false)) {
+            wp_send_json_error('Invalid nonce');
+        }
+
         $this->run_daily_reconciliation();
         wp_send_json_success(['message' => 'Reconciliation completed']);
     }
@@ -998,10 +1002,14 @@ class EnterpriseManagementSuite {
      * AJAX: Get health status
      */
     public function ajax_get_health_status() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
-        
+
+        if (!check_ajax_referer('hic_management_nonce', 'nonce', false)) {
+            wp_send_json_error('Invalid nonce');
+        }
+
         global $wpdb;
         
         $table_name = $wpdb->prefix . 'hic_health_checks';


### PR DESCRIPTION
## Summary
- require `hic_manage` capability and validate `hic_management_nonce` in reconciliation and health status AJAX handlers
- expose new `management_nonce` to diagnostics script and send it when calling reconciliation and health status actions

## Testing
- `composer test` *(fails: Class "HIC_Booking_Poller" not found, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68c820515360832f8597b5974a081562