### PR TITLE
Avoid cron initialization of dashboards

### DIFF
--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -1078,4 +1078,6 @@ class AutomatedReportingManager {
 }
 
 // Initialize the automated reporting manager
-new AutomatedReportingManager();
+if ( ! wp_doing_cron() ) {
+    new AutomatedReportingManager();
+}

--- a/includes/realtime-dashboard.php
+++ b/includes/realtime-dashboard.php
@@ -779,4 +779,6 @@ class RealtimeDashboard {
 }
 
 // Initialize the real-time dashboard
-new RealtimeDashboard();
+if ( ! wp_doing_cron() ) {
+    new RealtimeDashboard();
+}


### PR DESCRIPTION
## Summary
- prevent real-time dashboard from loading during cron requests
- prevent automated reporting manager from initializing during cron

## Testing
- `php qa-runner.php` *(fails: BookingPollerSchedulerTest missing HIC_Booking_Poller class etc.)*
- `php /tmp/cron_test.php`


------
https://chatgpt.com/codex/tasks/task_e_68c821cdef28832f8fd55c5fdb0cee7a