### PR TITLE
Harden automated reporting AJAX capability and nonce handling

### DIFF
--- a/assets/js/reporting.js
+++ b/assets/js/reporting.js
@@ -31,7 +31,7 @@
         generateManualReport() {
             const formData = new FormData(document.getElementById('hic-manual-report-form'));
             formData.append('action', 'hic_generate_manual_report');
-            formData.append('nonce', hicReporting.nonce);
+            formData.append('nonce', hicReporting.hic_reporting_nonce);
             
             const submitButton = $('#hic-manual-report-form button[type="submit"]');
             const originalText = submitButton.text();
@@ -78,7 +78,7 @@
                 data: {
                     action: action,
                     period: period,
-                    nonce: hicReporting.nonce
+                    nonce: hicReporting.hic_reporting_nonce
                 },
                 success: (response) => {
                     if (response.success) {
@@ -107,7 +107,7 @@
                 type: 'POST',
                 data: {
                     action: 'hic_get_report_history',
-                    nonce: hicReporting.nonce
+                    nonce: hicReporting.hic_reporting_nonce
                 },
                 success: (response) => {
                     if (response.success) {

--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -839,7 +839,7 @@ class AutomatedReportingManager {
         
         wp_localize_script('hic-reporting', 'hicReporting', [
             'ajaxUrl' => admin_url('admin-ajax.php'),
-            'nonce' => wp_create_nonce('hic_reporting_nonce')
+            'hic_reporting_nonce' => wp_create_nonce('hic_reporting_nonce')
         ]);
     }
     
@@ -918,12 +918,12 @@ class AutomatedReportingManager {
      * AJAX: Generate manual report
      */
     public function ajax_generate_manual_report() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
-        }
-        
         if (!check_ajax_referer('hic_reporting_nonce', 'nonce', false)) {
             wp_send_json_error('Invalid nonce');
+        }
+
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
         
         $report_type = sanitize_text_field($_POST['report_type'] ?? 'weekly');
@@ -969,10 +969,14 @@ class AutomatedReportingManager {
      * AJAX: Export data as CSV
      */
     public function ajax_export_data_csv() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!check_ajax_referer('hic_reporting_nonce', 'nonce', false)) {
+            wp_send_json_error('Invalid nonce');
         }
-        
+
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
+        }
+
         $period = sanitize_text_field($_POST['period'] ?? 'last_7_days');
         
         try {
@@ -1076,7 +1080,7 @@ class AutomatedReportingManager {
         }
 
         if (!current_user_can('hic_manage')) {
-            wp_die('Insufficient permissions');
+            wp_send_json_error('Insufficient permissions');
         }
 
         $filepath = realpath($this->export_dir . $filename);


### PR DESCRIPTION
## Summary
- Secure AJAX handlers to use `hic_manage` capability and return JSON errors
- Verify `hic_reporting_nonce` in manual report and export actions
- Pass new `hic_reporting_nonce` from backend reporting script

## Testing
- `composer test` *(fails: Class "HIC_Booking_Poller" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c8270989d0832fb8a9442402c5c749