### PR TITLE
Secure AJAX handlers with nonce and capability

### DIFF
--- a/assets/js/enhanced-conversions.js
+++ b/assets/js/enhanced-conversions.js
@@ -1,0 +1,41 @@
+jQuery(function($){
+    function fetchStats(){
+        $.post(hicEnhancedConversions.ajaxUrl, {
+            action: 'hic_get_enhanced_conversion_stats',
+            nonce: hicEnhancedConversions.nonce
+        }, function(response){
+            if (response.success) {
+                var data = response.data || {};
+                $('#enhanced-conversion-stats').text(
+                    'Total: ' + (data.total_conversions || 0) +
+                    ', Uploaded: ' + (data.uploaded_conversions || 0) +
+                    ', Pending: ' + (data.pending_conversions || 0) +
+                    ', Failed: ' + (data.failed_conversions || 0)
+                );
+            } else {
+                $('#enhanced-conversion-stats').text('Error loading statistics');
+            }
+        }, 'json');
+    }
+
+    $('#test-google-ads-connection').on('click', function(){
+        $.post(hicEnhancedConversions.ajaxUrl, {
+            action: 'hic_test_google_ads_connection',
+            nonce: hicEnhancedConversions.nonce
+        }, function(response){
+            alert(response.data && response.data.message ? response.data.message : 'Request completed');
+        }, 'json');
+    });
+
+    $('#upload-enhanced-conversions').on('click', function(){
+        $.post(hicEnhancedConversions.ajaxUrl, {
+            action: 'hic_upload_enhanced_conversions',
+            nonce: hicEnhancedConversions.nonce
+        }, function(response){
+            alert(response.data && response.data.message ? response.data.message : 'Request completed');
+            fetchStats();
+        }, 'json');
+    });
+
+    fetchStats();
+});

--- a/includes/google-ads-enhanced.php
+++ b/includes/google-ads-enhanced.php
@@ -950,10 +950,10 @@ class GoogleAdsEnhancedConversions {
      * AJAX: Test Google Ads connection
      */
     public function ajax_test_google_ads_connection() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
-        
+
         if (!check_ajax_referer('hic_enhanced_conversions_nonce', 'nonce', false)) {
             wp_send_json_error('Invalid nonce');
         }
@@ -976,16 +976,20 @@ class GoogleAdsEnhancedConversions {
      * AJAX: Get enhanced conversion statistics
      */
     public function ajax_get_enhanced_conversion_stats() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
-        
+
+        if (!check_ajax_referer('hic_enhanced_conversions_nonce', 'nonce', false)) {
+            wp_send_json_error('Invalid nonce');
+        }
+
         global $wpdb;
-        
+
         $table_name = $wpdb->prefix . 'hic_enhanced_conversions';
-        
+
         $stats = $wpdb->get_row("
-            SELECT 
+            SELECT
                 COUNT(*) as total_conversions,
                 SUM(CASE WHEN upload_status = 'uploaded' THEN 1 ELSE 0 END) as uploaded_conversions,
                 SUM(CASE WHEN upload_status = 'pending' THEN 1 ELSE 0 END) as pending_conversions,
@@ -993,7 +997,7 @@ class GoogleAdsEnhancedConversions {
                 SUM(conversion_value) as total_value
             FROM {$table_name}
         ", ARRAY_A);
-        
+
         wp_send_json_success($stats);
     }
     
@@ -1001,10 +1005,10 @@ class GoogleAdsEnhancedConversions {
      * AJAX: Upload enhanced conversions
      */
     public function ajax_upload_enhanced_conversions() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
-        
+
         if (!check_ajax_referer('hic_enhanced_conversions_nonce', 'nonce', false)) {
             wp_send_json_error('Invalid nonce');
         }


### PR DESCRIPTION
## Summary
- Restrict Google Ads enhanced conversion AJAX actions to `hic_manage`
- Validate `hic_enhanced_conversions_nonce` for stats requests
- Add admin script that passes nonce with all enhanced conversion AJAX calls

## Testing
- `php -l includes/google-ads-enhanced.php`
- `composer test` *(fails: Failed asserting that false is true)*

------
https://chatgpt.com/codex/tasks/task_e_68c82916668c832f8c69ef7ff3ba6ac1