### PR TITLE
Add nonce validation for circuit breaker AJAX endpoints

### DIFF
--- a/assets/js/circuit-breaker.js
+++ b/assets/js/circuit-breaker.js
@@ -1,0 +1,52 @@
+jQuery(function($){
+    if (typeof ajaxurl === 'undefined') {
+        var ajaxurl = hicCircuitBreaker.ajaxUrl;
+    }
+
+    function loadCircuitStatus() {
+        $.post(ajaxurl, {
+            action: 'hic_get_circuit_status',
+            nonce: hicCircuitBreaker.nonce
+        }, function(response){
+            if (response.success) {
+                var html = '<pre>' + JSON.stringify(response.data, null, 2) + '</pre>';
+                $('#circuit-status-grid').html(html);
+            } else {
+                $('#circuit-status-grid').text('Error loading circuit status');
+            }
+        }, 'json');
+    }
+
+    function loadRetryQueueStatus() {
+        $.post(ajaxurl, {
+            action: 'hic_get_retry_queue_status',
+            nonce: hicCircuitBreaker.nonce
+        }, function(response){
+            if (response.success) {
+                var data = response.data || {};
+                var html = 'Total: ' + (data.total_items || 0) +
+                    ', Queued: ' + (data.queued_items || 0) +
+                    ', Processing: ' + (data.processing_items || 0) +
+                    ', Completed: ' + (data.completed_items || 0) +
+                    ', Failed: ' + (data.failed_items || 0);
+                $('#retry-queue-status').text(html);
+            } else {
+                $('#retry-queue-status').text('Error loading retry queue status');
+            }
+        }, 'json');
+    }
+
+    $('#process-retry-queue').on('click', function(){
+        $.post(ajaxurl, {
+            action: 'hic_process_retry_queue_manual',
+            nonce: hicCircuitBreaker.nonce
+        }, function(response){
+            if (response.success) {
+                loadRetryQueueStatus();
+            }
+        }, 'json');
+    });
+
+    loadCircuitStatus();
+    loadRetryQueueStatus();
+});

--- a/includes/circuit-breaker.php
+++ b/includes/circuit-breaker.php
@@ -875,10 +875,14 @@ class CircuitBreakerManager {
      * AJAX: Get circuit status
      */
     public function ajax_get_circuit_status() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
-        
+
+        if (!check_ajax_referer('hic_circuit_breaker_nonce', 'nonce', false)) {
+            wp_send_json_error('Invalid nonce');
+        }
+
         global $wpdb;
         
         $table_name = $wpdb->prefix . 'hic_circuit_breakers';
@@ -931,10 +935,14 @@ class CircuitBreakerManager {
      * AJAX: Get retry queue status
      */
     public function ajax_get_retry_queue_status() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
+        if (!current_user_can('hic_manage')) {
+            wp_send_json_error('Insufficient permissions');
         }
-        
+
+        if (!check_ajax_referer('hic_circuit_breaker_nonce', 'nonce', false)) {
+            wp_send_json_error('Invalid nonce');
+        }
+
         global $wpdb;
         
         $table_name = $wpdb->prefix . 'hic_retry_queue';


### PR DESCRIPTION
## Summary
- secure circuit breaker AJAX endpoints with hic_manage capability and nonce validation
- send hic_circuit_breaker_nonce in new circuit-breaker.js AJAX requests

## Testing
- `composer test` *(fails: Class "HIC_Booking_Poller" not found, etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68c82a211798832fa0dcab9888a606e6