### PR TITLE
Refine realtime dashboard initialization

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -237,4 +237,8 @@ if (\is_admin()) {
     new \FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions();
     new \FpHic\CircuitBreaker\CircuitBreakerManager();
     new \FpHic\ReconAndSetup\EnterpriseManagementSuite();
+
+    if (!\wp_doing_cron()) {
+        new \FpHic\RealtimeDashboard\RealtimeDashboard();
+    }
 }

--- a/includes/realtime-dashboard.php
+++ b/includes/realtime-dashboard.php
@@ -52,16 +52,26 @@ class RealtimeDashboard {
      * Initialize real-time dashboard
      */
     public function initialize_dashboard() {
+        static $initialized = false;
+
+        if ($initialized || did_action('hic_realtime_dashboard_initialized')) {
+            return;
+        }
+
+        $initialized = true;
+
         $this->log('Initializing Real-Time Dashboard');
-        
+
         // Create dashboard cache table
         $this->create_dashboard_cache_table();
-        
+
         // Schedule dashboard data refresh
         $this->schedule_dashboard_refresh();
-        
+
         // Initialize booking heatmap data
         $this->initialize_heatmap_data();
+
+        do_action('hic_realtime_dashboard_initialized');
     }
     
     /**
@@ -802,7 +812,3 @@ class RealtimeDashboard {
     }
 }
 
-// Initialize the real-time dashboard
-if ( ! wp_doing_cron() ) {
-    new RealtimeDashboard();
-}


### PR DESCRIPTION
## Summary
- guard realtime dashboard initialization so setup runs only once per request
- remove direct instantiation from the include and instantiate from the admin bootstrap instead
- keep dashboard loading out of cron execution to avoid unnecessary hooks

## Testing
- php -l includes/realtime-dashboard.php
- php -l FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php

------
https://chatgpt.com/codex/tasks/task_e_68c8405738c8832f8f26d9f5971c68e1