### PR TITLE
Refine automated reporting initialization

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -237,6 +237,7 @@ if (\is_admin()) {
     new \FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions();
     new \FpHic\CircuitBreaker\CircuitBreakerManager();
     new \FpHic\ReconAndSetup\EnterpriseManagementSuite();
+    new \FpHic\AutomatedReporting\AutomatedReportingManager();
 
     if (!\wp_doing_cron()) {
         new \FpHic\RealtimeDashboard\RealtimeDashboard();

--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -66,19 +66,26 @@ class AutomatedReportingManager {
      * Initialize reporting system
      */
     public function initialize_reporting() {
+        if (did_action('hic_automated_reporting_initialized')) {
+            $this->log('Automated Reporting Manager already initialized, skipping duplicate setup');
+            return;
+        }
+
         $this->log('Initializing Automated Reporting Manager');
-        
+
         // Create exports directory
         $this->ensure_export_directory();
-        
+
         // Create reports history table
         $this->create_reports_history_table();
-        
+
         // Schedule automatic reports
         $this->schedule_automatic_reports();
-        
+
         // Clean up old exports periodically
         $this->schedule_export_cleanup();
+
+        do_action('hic_automated_reporting_initialized', $this);
     }
     
     /**
@@ -1208,9 +1215,4 @@ class AutomatedReportingManager {
             \FpHic\Helpers\hic_log("[Automated Reporting] {$message}");
         }
     }
-}
-
-// Initialize the automated reporting manager
-if ( ! wp_doing_cron() ) {
-    new AutomatedReportingManager();
 }


### PR DESCRIPTION
## Summary
- add an idempotency guard to the automated reporting initialization routine
- move AutomatedReportingManager bootstrapping to the main plugin within the admin-only section

## Testing
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68c8411be15c832faa60b6fc2c3beac2