### PR TITLE
Move circuit breaker setup to activation

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -69,6 +69,7 @@ function hic_activate($network_wide)
         foreach ($sites as $site) {
             \switch_to_blog($site->blog_id);
             \hic_maybe_upgrade_db();
+            \FpHic\CircuitBreaker\CircuitBreakerManager::activate();
             $role = \get_role('administrator');
             if ($role) {
                 if (!$role->has_cap('hic_manage')) {
@@ -82,6 +83,7 @@ function hic_activate($network_wide)
         }
     } else {
         \hic_maybe_upgrade_db();
+        \FpHic\CircuitBreaker\CircuitBreakerManager::activate();
         $role = \get_role('administrator');
         if ($role) {
             if (!$role->has_cap('hic_manage')) {
@@ -235,7 +237,7 @@ if (\is_admin()) {
     // Initialize admin-only classes that create submenus
     // This ensures the parent menu exists before submenus are added
     new \FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions();
-    new \FpHic\CircuitBreaker\CircuitBreakerManager();
+    \FpHic\CircuitBreaker\hic_get_circuit_breaker_manager();
     new \FpHic\ReconAndSetup\EnterpriseManagementSuite();
     new \FpHic\AutomatedReporting\AutomatedReportingManager();
 


### PR DESCRIPTION
## Summary
- add an activation routine to `CircuitBreakerManager` so database setup runs only during plugin activation
- guard the runtime initializer to prevent duplicate fallback registration
- instantiate the circuit breaker manager through a helper to avoid multiple constructions

## Testing
- php -l includes/circuit-breaker.php
- php -l FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php

------
https://chatgpt.com/codex/tasks/task_e_68c842c2f94c832f9983e541146328ba