### PR TITLE
Guard EMS init and install tables on activation

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -69,6 +69,7 @@ function hic_activate($network_wide)
         foreach ($sites as $site) {
             \switch_to_blog($site->blog_id);
             \hic_maybe_upgrade_db();
+            \FpHic\ReconAndSetup\EnterpriseManagementSuite::maybe_install_tables();
             \FpHic\CircuitBreaker\CircuitBreakerManager::activate();
             $role = \get_role('administrator');
             if ($role) {
@@ -83,6 +84,7 @@ function hic_activate($network_wide)
         }
     } else {
         \hic_maybe_upgrade_db();
+        \FpHic\ReconAndSetup\EnterpriseManagementSuite::maybe_install_tables();
         \FpHic\CircuitBreaker\CircuitBreakerManager::activate();
         $role = \get_role('administrator');
         if ($role) {
@@ -238,7 +240,10 @@ if (\is_admin()) {
     // This ensures the parent menu exists before submenus are added
     new \FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions();
     \FpHic\CircuitBreaker\hic_get_circuit_breaker_manager();
-    new \FpHic\ReconAndSetup\EnterpriseManagementSuite();
+    if (!did_action('hic_enterprise_management_suite_loaded')) {
+        $GLOBALS['hic_enterprise_management_suite'] = new \FpHic\ReconAndSetup\EnterpriseManagementSuite();
+        do_action('hic_enterprise_management_suite_loaded', $GLOBALS['hic_enterprise_management_suite']);
+    }
     new \FpHic\AutomatedReporting\AutomatedReportingManager();
 
     if (!\wp_doing_cron()) {


### PR DESCRIPTION
## Summary
- guard Enterprise Management Suite bootstrap to avoid duplicate initialization and emit hic_ems_initialized
- add a reusable maybe_install_tables() helper that installs tables once and trigger it from plugin activation
- ensure the EnterpriseManagementSuite admin class is instantiated only once via a did_action guard

## Testing
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68c84a577d1c832fb1c8158f63fe3eb2