### PR TITLE
Update continuous poll timestamp on every attempt

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -617,10 +617,8 @@ class HIC_Booking_Poller {
             hic_log('Continuous polling error: ' . $e->getMessage(), HIC_LOG_LEVEL_ERROR);
             $this->increment_failure_counter('hic_continuous_poll_failures');
         } finally {
-            if ($result === true) {
-                update_option('hic_last_continuous_poll', time(), false);
-                \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
-            }
+            update_option('hic_last_continuous_poll', time(), false);
+            \FpHic\Helpers\hic_clear_option_cache('hic_last_continuous_poll');
         }
         return $result;
     }


### PR DESCRIPTION
## Summary
- update the continuous polling timestamp after every scheduler run
- always clear the cached continuous poll option regardless of result

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c84c1708a4832f80bb7d1b72f8ee5c