### PR TITLE
Fix self-healing cleanup scheduling

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -1485,8 +1485,8 @@ class HIC_Booking_Poller {
             // Reschedule all events immediately (no delay needed for WP-Cron)
             \FpHic\Helpers\hic_safe_wp_schedule_event($current_time + 30, 'hic_every_thirty_seconds', 'hic_continuous_poll_event');
             \FpHic\Helpers\hic_safe_wp_schedule_event($current_time + 300, 'hic_every_thirty_minutes', 'hic_deep_check_event');
-            \FpHic\Helpers\hic_safe_wp_schedule_event($current_time + 3600, 'hic_daily', 'hic_cleanup_event');
-            \FpHic\Helpers\hic_safe_wp_schedule_event($current_time + 7200, 'hic_daily', 'hic_booking_events_cleanup');
+            \FpHic\Helpers\hic_safe_wp_schedule_event($current_time + 3600, 'daily', 'hic_cleanup_event');
+            \FpHic\Helpers\hic_safe_wp_schedule_event($current_time + 7200, 'daily', 'hic_booking_events_cleanup');
             
             // Reschedule self-healing recovery for next cycle
             \FpHic\Helpers\hic_safe_wp_schedule_event($current_time + 900, 'hic_every_fifteen_minutes', 'hic_self_healing_recovery');

--- a/tests/SelfHealingRecoveryTest.php
+++ b/tests/SelfHealingRecoveryTest.php
@@ -1,0 +1,97 @@
+<?php
+namespace {
+    use PHPUnit\Framework\TestCase;
+
+    require_once __DIR__ . '/../includes/booking-poller.php';
+    require_once __DIR__ . '/../includes/log-manager.php';
+    require_once __DIR__ . '/../includes/helpers-logging.php';
+
+    final class SelfHealingRecoveryTest extends TestCase {
+        /** @var callable|null */
+        private $logFilter;
+
+        protected function setUp(): void {
+            global $recovery_log_messages, $wp_scheduled_events, $wp_schedule_event_invalid;
+
+            $recovery_log_messages = [];
+            $wp_scheduled_events = [];
+            $wp_schedule_event_invalid = [
+                'hic_daily' => true,
+            ];
+
+            \FpHic\Helpers\hic_clear_option_cache();
+
+            update_option('hic_reliable_polling_enabled', '1');
+            update_option('hic_connection_type', 'api');
+            update_option('hic_api_url', 'https://example.com');
+            update_option('hic_property_id', '123');
+            update_option('hic_api_email', 'test@example.com');
+            update_option('hic_api_password', 'secret');
+            update_option('hic_last_continuous_poll', 0);
+            update_option('hic_last_deep_check', 0);
+            update_option('hic_last_successful_poll', 0);
+            update_option('hic_last_successful_deep_check', 0);
+            update_option('hic_log_file', sys_get_temp_dir() . '/hic-test.log');
+
+            \FpHic\Helpers\hic_clear_option_cache('log_file');
+            $GLOBALS['hic_log_manager'] = null;
+
+            $this->logFilter = function ($msg, $level) {
+                global $recovery_log_messages;
+                $recovery_log_messages[] = [
+                    'msg' => $msg,
+                    'level' => $level,
+                ];
+                return $msg;
+            };
+
+            add_filter('hic_log_message', $this->logFilter, 10, 2);
+        }
+
+        protected function tearDown(): void {
+            global $wp_schedule_event_invalid, $hic_test_filters;
+
+            $wp_schedule_event_invalid = [];
+
+            if ($this->logFilter && isset($hic_test_filters['hic_log_message'][10])) {
+                foreach ($hic_test_filters['hic_log_message'][10] as $index => $callback) {
+                    if ($callback['function'] === $this->logFilter) {
+                        unset($hic_test_filters['hic_log_message'][10][$index]);
+                    }
+                }
+            }
+
+            $this->logFilter = null;
+        }
+
+        public function test_recovery_schedules_cleanup_events_with_daily_recurrence(): void {
+            global $recovery_log_messages, $wp_scheduled_events;
+
+            $poller = new \FpHic\HIC_Booking_Poller();
+            $poller->execute_self_healing_recovery();
+
+            $cleanupEvents = array_values(array_filter(
+                $wp_scheduled_events,
+                function ($event) {
+                    return in_array($event['hook'], ['hic_cleanup_event', 'hic_booking_events_cleanup'], true);
+                }
+            ));
+
+            $this->assertCount(2, $cleanupEvents, 'Both cleanup events should be scheduled during recovery.');
+
+            foreach ($cleanupEvents as $event) {
+                $this->assertSame('daily', $event['recurrence']);
+            }
+
+            $invalidErrors = array_filter(
+                $recovery_log_messages,
+                function ($entry) {
+                    return $entry['level'] === HIC_LOG_LEVEL_ERROR
+                        && strpos($entry['msg'], 'Invalid schedule') !== false;
+                }
+            );
+
+            $this->assertEmpty($invalidErrors, 'Recovery should not log invalid schedule errors for cleanup hooks.');
+        }
+    }
+}

--- a/tests/preload.php
+++ b/tests/preload.php
@@ -41,7 +41,26 @@ if (!function_exists('apply_filters')) {
 if (!function_exists('register_activation_hook')) { function register_activation_hook(...$args) {} }
 if (!function_exists('register_deactivation_hook')) { function register_deactivation_hook(...$args) {} }
 if (!function_exists('wp_next_scheduled')) { function wp_next_scheduled(...$args) { return false; } }
-if (!function_exists('wp_schedule_event')) { function wp_schedule_event(...$args) { return true; } }
+if (!function_exists('wp_schedule_event')) {
+    function wp_schedule_event($timestamp, $recurrence, $hook, $args = array()) {
+        if (!empty($GLOBALS['wp_schedule_event_invalid'][$recurrence])) {
+            return new WP_Error('invalid_schedule', 'Invalid schedule');
+        }
+
+        if (!isset($GLOBALS['wp_scheduled_events'])) {
+            $GLOBALS['wp_scheduled_events'] = [];
+        }
+
+        $GLOBALS['wp_scheduled_events'][] = [
+            'timestamp' => $timestamp,
+            'recurrence' => $recurrence,
+            'hook' => $hook,
+            'args' => $args,
+        ];
+
+        return true;
+    }
+}
 if (!function_exists('wp_unschedule_event')) { function wp_unschedule_event(...$args) { return true; } }
 if (!function_exists('wp_clear_scheduled_hook')) { function wp_clear_scheduled_hook(...$args) { return true; } }
 if (!function_exists('wp_schedule_single_event')) {


### PR DESCRIPTION
## Summary
- replace the custom `hic_daily` recurrence with WordPress' built-in `daily` interval during self-healing recovery
- enhance the PHPUnit cron stub to flag invalid schedules and track scheduled hooks
- add coverage that forces the recovery path, asserting the cleanup hooks schedule on the `daily` interval without logging invalid schedule errors

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/SelfHealingRecoveryTest.php

------
https://chatgpt.com/codex/tasks/task_e_68cac33c9d6c832f8b102173ec0ce2e6