### PR TITLE
Ensure realtime dashboard cron callbacks

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -246,7 +246,7 @@ if (\is_admin()) {
     }
     new \FpHic\AutomatedReporting\AutomatedReportingManager();
 
-    if (!\wp_doing_cron()) {
-        new \FpHic\RealtimeDashboard\RealtimeDashboard();
-    }
 }
+
+// Initialize the real-time dashboard in all contexts (admin, frontend, cron)
+new \FpHic\RealtimeDashboard\RealtimeDashboard();

--- a/includes/realtime-dashboard.php
+++ b/includes/realtime-dashboard.php
@@ -33,6 +33,7 @@ class RealtimeDashboard {
         add_action('init', [$this, 'initialize_dashboard'], 25);
         add_action('wp_dashboard_setup', [$this, 'add_dashboard_widgets']);
         add_action('admin_enqueue_scripts', [$this, 'enqueue_dashboard_assets']);
+        add_action('hic_refresh_dashboard_data', [$this, 'refresh_dashboard_cache']);
         
         // AJAX handlers for real-time data
         add_action('wp_ajax_hic_get_realtime_stats', [$this, 'ajax_get_realtime_stats']);
@@ -104,7 +105,6 @@ class RealtimeDashboard {
     private function schedule_dashboard_refresh() {
         if (!wp_next_scheduled('hic_refresh_dashboard_data')) {
             wp_schedule_event(time(), 'hic_every_thirty_seconds', 'hic_refresh_dashboard_data');
-            add_action('hic_refresh_dashboard_data', [$this, 'refresh_dashboard_cache']);
         }
     }
     


### PR DESCRIPTION
## Summary
- instantiate the real-time dashboard outside of the admin-only block so it is available during cron and front-end requests
- hook the `hic_refresh_dashboard_data` action on every request instead of only when scheduling the event so cron executions always trigger the refresh

## Testing
- composer lint:syntax
- wp cron event run hic_refresh_dashboard_data *(fails: `wp` command not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cac8e7b120832f872a04f102d5726e