### PR TITLE
Ensure automated reporting cron callbacks are available globally

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -244,9 +244,9 @@ if (\is_admin()) {
         $GLOBALS['hic_enterprise_management_suite'] = new \FpHic\ReconAndSetup\EnterpriseManagementSuite();
         do_action('hic_enterprise_management_suite_loaded', $GLOBALS['hic_enterprise_management_suite']);
     }
-    new \FpHic\AutomatedReporting\AutomatedReportingManager();
-
 }
+
+\FpHic\AutomatedReporting\AutomatedReportingManager::instance();
 
 // Initialize the real-time dashboard in all contexts (admin, frontend, cron)
 new \FpHic\RealtimeDashboard\RealtimeDashboard();


### PR DESCRIPTION
## Summary
- instantiate the automated reporting manager outside of the admin-only bootstrap so cron executions can access its hooks
- introduce a singleton accessor and static cron handlers that lazily construct the manager before running scheduled tasks
- register the cron callbacks at load time to cover cleanup alongside daily, weekly, and monthly reports

## Testing
- php -l FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
- php -l includes/automated-reporting.php
- wp cron event run hic_daily_report *(fails: wp not available in container)*
- wp cron event run hic_cleanup_exports *(fails: wp not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68caca5c6314832faa568f8e7d3bb642