### PR TITLE
Initialize circuit breaker manager for all contexts

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -245,8 +245,10 @@ if (\is_admin()) {
     // Initialize admin-only classes that create submenus
     // This ensures the parent menu exists before submenus are added
     new \FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions();
-    \FpHic\CircuitBreaker\hic_get_circuit_breaker_manager();
 }
+
+// Ensure the circuit breaker manager is initialized in every context
+\FpHic\CircuitBreaker\hic_get_circuit_breaker_manager();
 
 \FpHic\AutomatedReporting\AutomatedReportingManager::instance();
 

--- a/includes/circuit-breaker.php
+++ b/includes/circuit-breaker.php
@@ -50,8 +50,10 @@ class CircuitBreakerManager {
         add_action('http_api_debug', [$this, 'track_api_response'], 10, 5);
 
         // Admin integration
-        add_action('admin_menu', [$this, 'add_circuit_breaker_menu']);
-        add_action('admin_enqueue_scripts', [$this, 'enqueue_circuit_breaker_assets']);
+        if (\is_admin()) {
+            add_action('admin_menu', [$this, 'add_circuit_breaker_menu']);
+            add_action('admin_enqueue_scripts', [$this, 'enqueue_circuit_breaker_assets']);
+        }
 
         // AJAX handlers
         add_action('wp_ajax_hic_get_circuit_status', [$this, 'ajax_get_circuit_status']);


### PR DESCRIPTION
## Summary
- initialize the circuit breaker manager outside of the admin-only bootstrap so it loads during frontend and cron execution
- wrap circuit breaker admin integrations in an is_admin() guard to avoid touching menu and asset hooks outside the dashboard

## Testing
- php -l FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
- php -l includes/circuit-breaker.php

------
https://chatgpt.com/codex/tasks/task_e_68cacfb3062c832f97d4f16a9005cebf