### PR TITLE
Ensure weekly and monthly cron intervals exist

### DIFF
--- a/includes/helpers-scheduling.php
+++ b/includes/helpers-scheduling.php
@@ -61,23 +61,19 @@ function hic_safe_wp_clear_scheduled_hook($hook, $args = array()) {
 
 function hic_add_failed_request_schedule($schedules) {
     $schedules['hic_every_fifteen_minutes'] = array(
-        'interval' => 15 * 60,
+        'interval' => 15 * MINUTE_IN_SECONDS,
         'display'  => 'Every 15 Minutes (HIC Failed Requests)'
     );
 
-    if (!isset($schedules['weekly'])) {
-        $schedules['weekly'] = array(
-            'interval' => 7 * 24 * 60 * 60,
-            'display'  => 'Once Weekly (Hotel in Cloud)'
-        );
-    }
+    $schedules['weekly'] = array(
+        'interval' => 7 * DAY_IN_SECONDS,
+        'display'  => 'Once Weekly (Hotel in Cloud)'
+    );
 
-    if (!isset($schedules['monthly'])) {
-        $schedules['monthly'] = array(
-            'interval' => 30 * 24 * 60 * 60,
-            'display'  => 'Once Monthly (Hotel in Cloud)'
-        );
-    }
+    $schedules['monthly'] = array(
+        'interval' => 30 * DAY_IN_SECONDS,
+        'display'  => 'Once Monthly (Hotel in Cloud)'
+    );
 
     return $schedules;
 }


### PR DESCRIPTION
## Summary
- update the cron schedule helper to always register weekly and monthly intervals using WordPress time constants so dependent events can be scheduled reliably

## Testing
- composer test *(fails: PHPUnit cannot load WP_UnitTestCase in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad75f8934832fa0243578224b8af8