### PR TITLE
Enrich booking data for enhanced conversions

### DIFF
--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -66,6 +66,18 @@ function hic_process_booking_data(array $data): bool {
     $data['amount'] = Helpers\hic_normalize_price($data['amount']);
   }
 
+  $filtered_data = apply_filters('hic_booking_data', $data, [
+    'gclid' => $gclid,
+    'fbclid' => $fbclid,
+    'sid' => $sid,
+  ]);
+
+  if (is_array($filtered_data)) {
+    $data = $filtered_data;
+  } else {
+    hic_log('hic_process_booking_data: hic_booking_data filter must return an array');
+  }
+
   $status = strtolower($data['status'] ?? ($data['presence'] ?? ''));
   $is_refund = in_array($status, ['cancelled', 'canceled', 'refunded'], true);
 


### PR DESCRIPTION
## Summary
- add an enrichment helper that normalizes booking identifiers, monetary values, and customer data for enhanced conversions
- run the `hic_booking_data` filter earlier in the booking processor so downstream integrations receive the enriched payload

## Testing
- composer lint:syntax
- composer test *(fails: WP_UnitTestCase not available in CLI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cad848449c832f8980019717f89c60