### PR TITLE
Load enhanced conversions in all contexts

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -236,15 +236,14 @@ if (!did_action('hic_enterprise_management_suite_loaded')) {
     do_action('hic_enterprise_management_suite_loaded', $GLOBALS['hic_enterprise_management_suite']);
 }
 
+// Ensure Google Ads Enhanced Conversions hooks are available in all request contexts
+new \FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions();
+
 // Load admin functionality only in dashboard
 if (\is_admin()) {
     require_once __DIR__ . '/includes/admin/admin-settings.php';
     require_once __DIR__ . '/includes/admin/diagnostics.php';
     require_once __DIR__ . '/includes/site-health.php';
-
-    // Initialize admin-only classes that create submenus
-    // This ensures the parent menu exists before submenus are added
-    new \FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions();
 }
 
 // Ensure the circuit breaker manager is initialized in every context


### PR DESCRIPTION
## Summary
- Instantiate Google Ads Enhanced Conversions outside of the `is_admin()` guard so REST, cron, and frontend requests can register its hooks while keeping admin-only includes inside the dashboard check.
- Refactor the Google Ads Enhanced Conversions bootstrap to add booking hooks in every context and register admin menus, assets, and AJAX handlers only when `is_admin()` is true.

## Testing
- composer lint:syntax
- composer test *(fails: WordPress test suite not available, `WP_UnitTestCase` missing)*

------
https://chatgpt.com/codex/tasks/task_e_68cb20ebf960832fb0472fc5f6a408f7