### PR TITLE
Load frontend script for GA4 and hybrid tracking

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -219,7 +219,9 @@ function hic_activate($network_wide)
 
 // Enqueue frontend JavaScript
 \add_action('wp_enqueue_scripts', function() {
-    if (Helpers\hic_get_tracking_mode() === 'gtm_only') {
+    $tracking_mode = Helpers\hic_get_tracking_mode();
+
+    if (\in_array($tracking_mode, ['gtm_only', 'ga4_only', 'hybrid'], true)) {
         \wp_enqueue_script(
             'hic-frontend',
             \plugin_dir_url(__FILE__) . 'assets/js/frontend.js',


### PR DESCRIPTION
## Summary
- ensure the frontend tracking script is enqueued when the tracking mode is GTM-only, GA4-only, or hybrid so SID propagation works for server-side flows

## Testing
- php -l FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php

------
https://chatgpt.com/codex/tasks/task_e_68cb2212f678832fba44ecaee8572633