### PR TITLE
Keep reservation IDs for GA4 and GTM events

### DIFF
--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -40,7 +40,6 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $s
   }
   if ($sid !== '') {
     $client_id = $sid;
-    $transaction_id = $sid;
   }
 
   $params = [
@@ -56,6 +55,10 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $s
     'method'         => 'HotelInCloud',
     'vertical'       => 'hotel',
   ];
+
+  if ($sid !== '') {
+    $params['hic_sid'] = $sid;
+  }
   
   if (!empty($gclid))   { $params['gclid']   = sanitize_text_field($gclid); }
   if (!empty($fbclid))  { $params['fbclid']  = sanitize_text_field($fbclid); }
@@ -153,7 +156,6 @@ function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''
   }
   if ($sid !== '') {
     $client_id = $sid;
-    $transaction_id = $sid;
   }
 
   $params = [
@@ -169,6 +171,10 @@ function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''
     'method'         => 'HotelInCloud',
     'vertical'       => 'hotel',
   ];
+
+  if ($sid !== '') {
+    $params['hic_sid'] = $sid;
+  }
 
   if (!empty($gclid))   { $params['gclid']   = sanitize_text_field($gclid); }
   if (!empty($fbclid))  { $params['fbclid']  = sanitize_text_field($fbclid); }

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -33,9 +33,7 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $sid = null) {
 
     // Generate transaction ID using consistent extraction
     $transaction_id = Helpers\hic_extract_reservation_id($data);
-    if ($sid !== '') {
-        $transaction_id = $sid;
-    } elseif (empty($transaction_id)) {
+    if (empty($transaction_id)) {
         $transaction_id = uniqid('hic_gtm_');
     }
 
@@ -63,6 +61,7 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $sid = null) {
 
     if ($sid !== '') {
         $gtm_data['client_id'] = $sid;
+        $gtm_data['sid'] = $sid;
     }
 
     // Add tracking IDs if available for enhanced attribution


### PR DESCRIPTION
## Summary
- stop replacing GA4 transaction IDs with the HotelInCloud SID while still sharing the SID as a custom parameter
- ensure GA4 refund events reuse the same reservation-based transaction identifiers
- keep GTM ecommerce order IDs tied to reservation IDs and expose the SID through dedicated fields

## Testing
- php -l includes/integrations/ga4.php
- php -l includes/integrations/gtm.php

------
https://chatgpt.com/codex/tasks/task_e_68cbb11f8310832f99d57dc38d8605af