### PR TITLE
Preserve reservation IDs in analytics dispatchers

### DIFF
--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -326,9 +326,6 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
   if ($sid === '' && !empty($data['sid']) && is_scalar($data['sid'])) {
     $sid = \sanitize_text_field((string) $data['sid']);
   }
-  if ($sid !== '') {
-    $transaction_id = $sid;
-  }
 
   // Get tracking IDs for bucket normalization if available
   $gclid = '';
@@ -377,6 +374,10 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
     'bucket' => $bucket,             // Bucket attribution for custom conversions
     'vertical' => 'hotel'
   ];
+
+  if ($sid !== '') {
+    $custom_data['reservation_sid'] = $sid;
+  }
 
   if (!empty($gclid))   { $custom_data['gclid']   = sanitize_text_field($gclid); }
   if (!empty($fbclid))  { $custom_data['fbclid']  = sanitize_text_field($fbclid); }

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -276,7 +276,6 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
   }
   if ($sid !== '') {
     $client_id = $sid;
-    $transaction_id = $sid;
   }
 
   // Get tracking IDs for bucket normalization if available
@@ -313,6 +312,10 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
     'bucket' => $bucket,             // Use normalized bucket based on attribution
     'vertical' => 'hotel'
   ];
+
+  if ($sid !== '') {
+    $params['hic_sid'] = $sid;
+  }
 
   if (!empty($gclid))   { $params['gclid']   = sanitize_text_field($gclid); }
   if (!empty($fbclid))  { $params['fbclid']  = sanitize_text_field($fbclid); }

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -254,9 +254,6 @@ function hic_dispatch_gtm_reservation($data, $sid = '') {
     if ($sid === '' && !empty($data['sid']) && is_scalar($data['sid'])) {
         $sid = \sanitize_text_field((string) $data['sid']);
     }
-    if ($sid !== '') {
-        $transaction_id = $sid;
-    }
 
     // Get gclid/fbclid for bucket normalization if available
     $gclid = '';
@@ -295,6 +292,11 @@ function hic_dispatch_gtm_reservation($data, $sid = '') {
         'bucket' => $bucket,
         'vertical' => 'hotel'
     ];
+
+    if ($sid !== '') {
+        $gtm_data['client_id'] = $sid;
+        $gtm_data['hic_sid'] = $sid;
+    }
 
     // Add tracking IDs if available
     if (!empty($gclid)) {


### PR DESCRIPTION
## Summary
- keep reservation-centric transaction identifiers when dispatching GA4 reservation events and expose the SID separately
- surface the session SID alongside GTM reservation pushes while leaving the ecommerce transaction id untouched
- include the reservation SID in Facebook custom data instead of overwriting the transaction id

## Testing
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68cbb26ea4f4832fb32a52d0647b8443