### PR TITLE
Adjust retry scheduler gating

### DIFF
--- a/tests/ShouldScheduleRetryEventTest.php
+++ b/tests/ShouldScheduleRetryEventTest.php
@@ -2,7 +2,7 @@
 namespace FpHic\Helpers {
     if (!function_exists(__NAMESPACE__ . '\\wp_get_schedules')) {
         function wp_get_schedules() {
-            return [
+            return $GLOBALS['should_schedule_retry_event_schedules'] ?? [
                 'hic_every_fifteen_minutes' => [
                     'interval' => 15 * 60,
                     'display' => 'Every 15 Minutes (HIC Failed Requests)'
@@ -20,12 +20,25 @@ namespace {
     class ShouldScheduleRetryEventTest extends TestCase {
         protected function setUp(): void {
             \FpHic\Helpers\hic_clear_option_cache();
-            update_option('hic_realtime_brevo_sync', '1');
-            update_option('hic_brevo_api_key', 'test-key');
+            $GLOBALS['should_schedule_retry_event_schedules'] = [
+                'hic_every_fifteen_minutes' => [
+                    'interval' => 15 * 60,
+                    'display' => 'Every 15 Minutes (HIC Failed Requests)'
+                ],
+            ];
         }
 
-        public function test_returns_true_when_brevo_sync_active(): void {
+        protected function tearDown(): void {
+            unset($GLOBALS['should_schedule_retry_event_schedules']);
+        }
+
+        public function test_returns_true_when_custom_interval_registered(): void {
             $this->assertTrue(\FpHic\Helpers\hic_should_schedule_retry_event());
+        }
+
+        public function test_returns_false_when_custom_interval_missing(): void {
+            $GLOBALS['should_schedule_retry_event_schedules'] = [];
+            $this->assertFalse(\FpHic\Helpers\hic_should_schedule_retry_event());
         }
     }
 }


### PR DESCRIPTION
## Summary
- decouple the retry scheduler from Brevo configuration and add a guard that only schedules when failed requests are queued
- update retry scheduler and interval detection tests to use shared schedule stubs and assert the new guard logic

## Testing
- composer test *(fails: existing suite depends on unavailable WordPress classes)*
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter ShouldScheduleRetryEventTest
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter ZZFailedRequestRetrySchedulerTest

------
https://chatgpt.com/codex/tasks/task_e_68cbbcb6ce9c832fa4240e2ec2151ea0