### PR TITLE
Allow refund processing without tracking

### DIFF
--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -335,36 +335,35 @@ function hic_process_booking_data(array $data): bool {
 
     if ($is_refund) {
       if (!Helpers\hic_refund_tracking_enabled()) {
-        hic_log('hic_process_booking_data: refund detected but tracking disabled');
-        return false;
-      }
-
-      // GA4 refund event
-      if (($tracking_mode === 'ga4_only' || $tracking_mode === 'hybrid') &&
-          Helpers\hic_get_measurement_id() && Helpers\hic_get_api_secret()) {
-        if (hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid, $ttclid, $sid)) {
-          $success_count++;
-        } else {
-          $error_count++;
+        hic_log('hic_process_booking_data: refund detected but tracking disabled, skipping refund events');
+      } else {
+        // GA4 refund event
+        if (($tracking_mode === 'ga4_only' || $tracking_mode === 'hybrid') &&
+            Helpers\hic_get_measurement_id() && Helpers\hic_get_api_secret()) {
+          if (hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid, $ttclid, $sid)) {
+            $success_count++;
+          } else {
+            $error_count++;
+          }
         }
-      }
 
-      // Facebook refund event
-      if (Helpers\hic_get_fb_pixel_id() && Helpers\hic_get_fb_access_token()) {
-        if (hic_send_fb_refund($data, $gclid, $fbclid, $msclkid, $ttclid)) {
-          $success_count++;
-        } else {
-          $error_count++;
+        // Facebook refund event
+        if (Helpers\hic_get_fb_pixel_id() && Helpers\hic_get_fb_access_token()) {
+          if (hic_send_fb_refund($data, $gclid, $fbclid, $msclkid, $ttclid)) {
+            $success_count++;
+          } else {
+            $error_count++;
+          }
         }
-      }
 
-      // Brevo refund event
-      if (Helpers\hic_is_brevo_enabled() && Helpers\hic_get_brevo_api_key()) {
-        $brevo_success = hic_send_brevo_refund_event($data, $gclid, $fbclid, $msclkid, $ttclid);
-        if ($brevo_success) {
-          $success_count++;
-        } else {
-          $error_count++;
+        // Brevo refund event
+        if (Helpers\hic_is_brevo_enabled() && Helpers\hic_get_brevo_api_key()) {
+          $brevo_success = hic_send_brevo_refund_event($data, $gclid, $fbclid, $msclkid, $ttclid);
+          if ($brevo_success) {
+            $success_count++;
+          } else {
+            $error_count++;
+          }
         }
       }
     } else {

--- a/tests/BookingProcessorRefundTrackingTest.php
+++ b/tests/BookingProcessorRefundTrackingTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+final class BookingProcessorRefundTrackingTest extends TestCase
+{
+    private string $logFile;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        \FpHic\Helpers\hic_clear_option_cache();
+
+        $this->logFile = sys_get_temp_dir() . '/hic-refund-tracking-disabled.log';
+        update_option('hic_log_file', $this->logFile);
+        \FpHic\Helpers\hic_clear_option_cache('log_file');
+        if (file_exists($this->logFile)) {
+            unlink($this->logFile);
+        }
+
+        unset($GLOBALS['hic_log_manager']);
+
+        update_option('hic_refund_tracking', '0');
+        \FpHic\Helpers\hic_clear_option_cache('refund_tracking');
+
+        update_option('hic_tracking_mode', 'ga4_only');
+        \FpHic\Helpers\hic_clear_option_cache('tracking_mode');
+    }
+
+    protected function tearDown(): void
+    {
+        if (file_exists($this->logFile)) {
+            unlink($this->logFile);
+        }
+
+        parent::tearDown();
+    }
+
+    public function testRefundProcessingSucceedsWhenTrackingDisabled(): void
+    {
+        $bookingData = [
+            'email' => 'cancelled@example.com',
+            'reservation_id' => 'CANCELLED-123',
+            'amount' => 199.99,
+            'currency' => 'EUR',
+            'status' => 'cancelled',
+        ];
+
+        $result = \FpHic\hic_process_booking_data($bookingData);
+
+        $this->assertTrue($result, 'Refund processing should succeed when tracking is disabled');
+
+        $this->assertFileExists($this->logFile);
+        $logContents = file_get_contents($this->logFile);
+        $this->assertIsString($logContents);
+        $this->assertStringContainsString('refund detected but tracking disabled, skipping refund events', $logContents);
+        $this->assertStringContainsString('Successi: 0, Errori: 0', $logContents);
+    }
+}


### PR DESCRIPTION
## Summary
- let hic_process_booking_data skip refund dispatch when tracking is disabled while still reaching the normal success flow
- keep the refund dispatch logic inside an `else` branch so integrations run only when refund tracking is active
- add a PHPUnit test that simulates a cancelled booking with refund tracking disabled and asserts the processor succeeds and logs the success summary

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter BookingProcessorRefundTrackingTest


------
https://chatgpt.com/codex/tasks/task_e_68cbd64e1c34832f834df4d4d771e450