### PR TITLE
Implement per-session GTM event delivery

### DIFF
--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -229,6 +229,11 @@ function hic_activate($network_wide)
             HIC_PLUGIN_VERSION,
             true
         );
+
+        \wp_localize_script('hic-frontend', 'hicFrontend', [
+            'gtmEnabled'        => Helpers\hic_is_gtm_enabled(),
+            'gtmEventsEndpoint' => esc_url_raw(rest_url('hic/v1/gtm-events')),
+        ]);
     }
 });
 


### PR DESCRIPTION
## Summary
- store GTM purchase events per SID and clear queues through a dedicated helper
- register a REST endpoint that validates the SID and returns session-specific GTM events instead of printing them in the footer
- expose the endpoint to the frontend script and fetch events for the current session before pushing them to the dataLayer

## Testing
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68cbdcd6ee94832fb0500c61c381e79d