### PR TITLE
Improve ISO currency validation

### DIFF
--- a/includes/input-validator.php
+++ b/includes/input-validator.php
@@ -11,6 +11,13 @@ namespace FpHic;
 if (!defined('ABSPATH')) exit;
 
 class HIC_Input_Validator {
+
+    /**
+     * Cached ISO 4217 currency codes list.
+     *
+     * @var string[]|null
+     */
+    private static $iso4217Currencies = null;
     
     /**
      * Validate email with enhanced security checks
@@ -143,18 +150,64 @@ class HIC_Input_Validator {
      * Validate currency code
      */
     public static function validate_currency($currency) {
-        $currency = strtoupper(sanitize_text_field($currency));
-        
-        // ISO 4217 common currency codes
-        $valid_currencies = [
-            'EUR', 'USD', 'GBP', 'JPY', 'CHF', 'CAD', 'AUD', 'CNY', 'SEK', 'NOK', 'DKK'
-        ];
-        
+        if (!is_scalar($currency)) {
+            return new \WP_Error('invalid_currency', 'Codice valuta non valido');
+        }
+
+        $currency = strtoupper(sanitize_text_field((string) $currency));
+
+        if ($currency === '' || !preg_match('/^[A-Z]{3}$/', $currency)) {
+            return new \WP_Error('invalid_currency', 'Codice valuta non valido');
+        }
+
+        $valid_currencies = self::get_iso_4217_currency_codes();
+
         if (!in_array($currency, $valid_currencies, true)) {
             return new \WP_Error('invalid_currency', 'Codice valuta non valido');
         }
-        
+
         return $currency;
+    }
+
+    /**
+     * Retrieve the ISO 4217 currency codes list.
+     *
+     * @return string[]
+     */
+    private static function get_iso_4217_currency_codes() {
+        if (is_array(self::$iso4217Currencies)) {
+            return self::$iso4217Currencies;
+        }
+
+        if (function_exists('get_woocommerce_currencies')) {
+            $currencies = array_keys((array) get_woocommerce_currencies());
+            self::$iso4217Currencies = array_map('strtoupper', $currencies);
+
+            return self::$iso4217Currencies;
+        }
+
+        self::$iso4217Currencies = [
+            'AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG', 'AZN',
+            'BAM', 'BBD', 'BDT', 'BGN', 'BHD', 'BIF', 'BMD', 'BND', 'BOB', 'BOV',
+            'BRL', 'BSD', 'BTN', 'BWP', 'BYN', 'BZD', 'CAD', 'CDF', 'CHE', 'CHF',
+            'CHW', 'CLF', 'CLP', 'CNY', 'COP', 'COU', 'CRC', 'CUC', 'CUP', 'CVE',
+            'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'EUR', 'FJD',
+            'FKP', 'GBP', 'GEL', 'GHS', 'GIP', 'GMD', 'GNF', 'GTQ', 'GYD', 'HKD',
+            'HNL', 'HRK', 'HTG', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK',
+            'JMD', 'JOD', 'JPY', 'KES', 'KGS', 'KHR', 'KMF', 'KPW', 'KRW', 'KWD',
+            'KYD', 'KZT', 'LAK', 'LBP', 'LKR', 'LRD', 'LSL', 'LYD', 'MAD', 'MDL',
+            'MGA', 'MKD', 'MMK', 'MNT', 'MOP', 'MRU', 'MUR', 'MVR', 'MWK', 'MXN',
+            'MXV', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR',
+            'PAB', 'PEN', 'PGK', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD',
+            'RUB', 'RWF', 'SAR', 'SBD', 'SCR', 'SDG', 'SEK', 'SGD', 'SHP', 'SLE',
+            'SLL', 'SOS', 'SRD', 'SSP', 'STN', 'SVC', 'SYP', 'SZL', 'THB', 'TJS', 'TMT',
+            'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'USD', 'USN',
+            'UYI', 'UYU', 'UYW', 'UZS', 'VED', 'VES', 'VND', 'VUV', 'WST', 'XAF',
+            'XAG', 'XAU', 'XBA', 'XBB', 'XBC', 'XBD', 'XCD', 'XDR', 'XOF', 'XPD',
+            'XPF', 'XPT', 'XSU', 'XTS', 'XUA', 'XXX', 'YER', 'ZAR', 'ZMW', 'ZWL',
+        ];
+
+        return self::$iso4217Currencies;
     }
     
     /**

--- a/tests/ImprovementsTest.php
+++ b/tests/ImprovementsTest.php
@@ -50,9 +50,21 @@ class HIC_Improvements_Test {
         // Test currency validation
         $valid_currency = \FpHic\HIC_Input_Validator::validate_currency('eur');
         assert($valid_currency === 'EUR', 'Currency should be normalized to uppercase');
-        
+
+        $valid_brl_currency = \FpHic\HIC_Input_Validator::validate_currency('brl');
+        assert($valid_brl_currency === 'BRL', 'BRL currency should now be accepted');
+
+        $valid_aed_currency = \FpHic\HIC_Input_Validator::validate_currency('aed');
+        assert($valid_aed_currency === 'AED', 'AED currency should now be accepted');
+
         $invalid_currency = \FpHic\HIC_Input_Validator::validate_currency('XYZ');
-        assert(is_wp_error($invalid_currency), 'Invalid currency should fail');
+        assert(is_wp_error($invalid_currency), 'Unknown currency should fail');
+
+        $non_alpha_currency = \FpHic\HIC_Input_Validator::validate_currency('12$');
+        assert(is_wp_error($non_alpha_currency), 'Currency codes must be alphabetic');
+
+        $wrong_length_currency = \FpHic\HIC_Input_Validator::validate_currency('EURO');
+        assert(is_wp_error($wrong_length_currency), 'Currency codes must be 3 letters long');
         
         echo "  ✅ Input validation tests passed\n";
     }

--- a/tests/WebhookConversionTrackingTest.php
+++ b/tests/WebhookConversionTrackingTest.php
@@ -136,6 +136,33 @@ class WebhookConversionTrackingTest extends WP_UnitTestCase {
     }
 
     /**
+     * @dataProvider extendedIsoCurrencyProvider
+     */
+    public function test_webhook_payload_accepts_extended_iso_currencies(string $currency) {
+        $booking_data = [
+            'email' => 'extended@example.com',
+            'reservation_id' => 'EXTENDED_' . strtoupper($currency),
+            'amount' => 180.50,
+            'currency' => strtolower($currency),
+        ];
+
+        $validated = \FpHic\HIC_Input_Validator::validate_webhook_payload($booking_data);
+
+        $this->assertFalse(is_wp_error($validated));
+        $this->assertSame(strtoupper($currency), $validated['currency']);
+
+        $result = \FpHic\hic_process_booking_data($validated);
+        $this->assertIsBool($result);
+    }
+
+    public static function extendedIsoCurrencyProvider(): array {
+        return [
+            ['BRL'],
+            ['AED'],
+        ];
+    }
+
+    /**
      * Test validazione payload webhook
      */
     public function test_webhook_payload_validation() {


### PR DESCRIPTION
## Summary
- replace the hard-coded currency whitelist with a full ISO 4217 lookup that falls back to WooCommerce data when available
- tighten currency sanitization by rejecting non alphabetic or incorrect length values before checking the ISO list
- extend validation coverage to accept BRL and AED currencies and ensure the webhook pipeline processes the newly supported codes

## Testing
- `composer test` *(fails: WordPress/WooCommerce test doubles are unavailable in the container, leading to missing class and function errors outside the touched areas)*

------
https://chatgpt.com/codex/tasks/task_e_68cc3b0cab74832f951c882340570ff6