### PR TITLE
Prevent duplicate failed request rows on retry

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -375,7 +375,7 @@ function hic_booking_uid($reservation) {
 }
 
 /* ============ Helpers ============ */
-function hic_http_request($url, $args = []) {
+function hic_http_request($url, $args = [], bool $suppress_failed_storage = false) {
     $validated_url = wp_http_validate_url($url);
     if (!$validated_url) {
         hic_log('HTTP request rifiutata: URL non valido ' . $url, HIC_LOG_LEVEL_ERROR);
@@ -409,13 +409,17 @@ function hic_http_request($url, $args = []) {
     if (is_wp_error($response)) {
         $error_message = $response->get_error_message();
         hic_log('HTTP request error: ' . $error_message, HIC_LOG_LEVEL_ERROR);
-        hic_store_failed_request($url, $args, $error_message);
+        if (!$suppress_failed_storage) {
+            hic_store_failed_request($url, $args, $error_message);
+        }
     } else {
         $code = wp_remote_retrieve_response_code($response);
         if ($code >= 400) {
             $error_message = 'HTTP ' . $code;
             hic_log('HTTP request to ' . $url . ' failed with status ' . $code, HIC_LOG_LEVEL_ERROR);
-            hic_store_failed_request($url, $args, $error_message);
+            if (!$suppress_failed_storage) {
+                hic_store_failed_request($url, $args, $error_message);
+            }
         }
     }
 
@@ -948,7 +952,7 @@ function hic_get_processing_statistics() {
 
 // Global wrappers for backward compatibility
 namespace {
-    function hic_http_request($url, $args = array()) { return \FpHic\Helpers\hic_http_request($url, $args); }
+    function hic_http_request($url, $args = array(), $suppress_failed_storage = false) { return \FpHic\Helpers\hic_http_request($url, $args, $suppress_failed_storage); }
     function hic_get_option($key, $default = '') { return \FpHic\Helpers\hic_get_option($key, $default); }
     function hic_clear_option_cache($key = null) { return \FpHic\Helpers\hic_clear_option_cache($key); }
     function hic_get_measurement_id() { return \FpHic\Helpers\hic_get_measurement_id(); }

--- a/includes/helpers-scheduling.php
+++ b/includes/helpers-scheduling.php
@@ -142,7 +142,7 @@ function hic_retry_failed_requests() {
             $wpdb->delete($table, array('id' => $row->id));
             continue;
         }
-        $response = hic_http_request($row->endpoint, is_array($args) ? $args : array());
+        $response = hic_http_request($row->endpoint, is_array($args) ? $args : array(), true);
 
         if (is_wp_error($response) || wp_remote_retrieve_response_code($response) >= 400) {
             $error_message = is_wp_error($response) ? $response->get_error_message() : 'HTTP ' . wp_remote_retrieve_response_code($response);

--- a/tests/RetryFailedRequestsTest.php
+++ b/tests/RetryFailedRequestsTest.php
@@ -6,23 +6,80 @@ require_once __DIR__ . '/../includes/log-manager.php';
 
 class RetryFailedRequestsTest extends TestCase {
     protected function setUp(): void {
-        global $wpdb, $hic_last_request, $retry_log_messages;
+        parent::setUp();
+
+        global $wpdb, $hic_last_request, $retry_log_messages, $hic_test_http_error, $hic_test_http_error_urls, $hic_test_http_mock;
         $hic_last_request = null;
         $retry_log_messages = [];
+        $hic_test_http_error = null;
+        $hic_test_http_error_urls = null;
+        $hic_test_http_mock = null;
+
+        unset($GLOBALS['hic_test_filters']['hic_log_message']);
         add_filter('hic_log_message', function($msg, $level) {
             global $retry_log_messages;
             $retry_log_messages[] = $msg;
             return $msg;
         }, 10, 2);
+
         $wpdb = new class {
             public $prefix = 'wp_';
             public $rows = [];
             public $deleted = [];
             public $updated = [];
-            public function get_results($query) { return $this->rows; }
-            public function delete($table, $where) { $this->deleted[] = $where; $this->rows = []; }
-            public function update($table, $data, $where, $formats = null, $where_formats = null) { $this->updated[] = compact('data', 'where'); }
+            public $inserted = [];
+
+            public function get_results($query) {
+                return $this->rows;
+            }
+
+            public function delete($table, $where) {
+                $this->deleted[] = $where;
+                $this->rows = array_values(array_filter($this->rows, function($row) use ($where) {
+                    foreach ($where as $key => $value) {
+                        if (!property_exists($row, $key) || (string) $row->$key !== (string) $value) {
+                            return true;
+                        }
+                    }
+                    return false;
+                }));
+                return true;
+            }
+
+            public function update($table, $data, $where, $formats = null, $where_formats = null) {
+                $this->updated[] = ['data' => $data, 'where' => $where];
+                foreach ($this->rows as $index => $row) {
+                    $matches = true;
+                    foreach ($where as $key => $value) {
+                        if (!property_exists($row, $key) || (string) $row->$key !== (string) $value) {
+                            $matches = false;
+                            break;
+                        }
+                    }
+                    if ($matches) {
+                        $new_row = clone $row;
+                        foreach ($data as $key => $value) {
+                            $new_row->$key = $value;
+                        }
+                        $this->rows[$index] = $new_row;
+                    }
+                }
+                return true;
+            }
+
+            public function insert($table, $data, $formats = null) {
+                $this->inserted[] = ['data' => $data, 'table' => $table, 'formats' => $formats];
+                return true;
+            }
         };
+    }
+
+    protected function tearDown(): void {
+        global $hic_test_http_error, $hic_test_http_error_urls, $hic_test_http_mock;
+        $hic_test_http_error = null;
+        $hic_test_http_error_urls = null;
+        $hic_test_http_mock = null;
+        parent::tearDown();
     }
 
     public function test_invalid_json_logs_and_removes_row() {
@@ -51,5 +108,45 @@ class RetryFailedRequestsTest extends TestCase {
         \FpHic\Helpers\hic_retry_failed_requests();
         $this->assertNotNull($hic_last_request);
         $this->assertCount(1, $wpdb->deleted);
+    }
+
+    public function test_persistent_http_500_retries_until_cleanup_without_duplicates() {
+        global $wpdb, $hic_test_http_mock;
+
+        $wpdb->rows = [(object)[
+            'id' => 3,
+            'endpoint' => 'https://example.com/fail',
+            'payload' => json_encode(['method' => 'GET']),
+            'attempts' => 1,
+            'last_try' => '2000-01-01 00:00:00',
+        ]];
+
+        $hic_test_http_mock = static function() {
+            return [
+                'body' => '{}',
+                'response' => ['code' => 500],
+            ];
+        };
+
+        for ($i = 0; $i < 5; $i++) {
+            \FpHic\Helpers\hic_retry_failed_requests();
+            if (!empty($wpdb->rows)) {
+                $wpdb->rows[0]->last_try = '2000-01-01 00:00:00';
+            }
+        }
+
+        $this->assertCount(4, $wpdb->updated, 'Each failure should update the existing queue entry.');
+        $attempts = array_map(static function ($update) {
+            return $update['data']['attempts'] ?? null;
+        }, $wpdb->updated);
+        $this->assertSame([2, 3, 4, 5], $attempts, 'Attempts should increment up to five.');
+
+        $lastUpdate = end($wpdb->updated);
+        $this->assertIsArray($lastUpdate);
+        $this->assertSame('HTTP 500', $lastUpdate['data']['last_error'] ?? null);
+
+        $this->assertEmpty($wpdb->rows, 'The entry should be removed after the fifth failure.');
+        $this->assertCount(1, $wpdb->deleted, 'The queue entry should be deleted once the maximum is reached.');
+        $this->assertEmpty($wpdb->inserted, 'Processing the queue should not create duplicate rows.');
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -194,8 +194,15 @@ if (!function_exists('wp_json_encode')) {
 
 if (!function_exists('wp_safe_remote_request')) {
     function wp_safe_remote_request($url, $args = array()) {
-        global $hic_last_request, $hic_test_http_error, $hic_test_http_error_urls;
+        global $hic_last_request, $hic_test_http_error, $hic_test_http_error_urls, $hic_test_http_mock;
         $hic_last_request = ['url' => $url, 'args' => $args];
+
+        if (isset($hic_test_http_mock) && is_callable($hic_test_http_mock)) {
+            $mock_response = call_user_func($hic_test_http_mock, $url, $args);
+            if ($mock_response !== null) {
+                return $mock_response;
+            }
+        }
 
         $should_fail = false;
         if (!empty($hic_test_http_error)) {


### PR DESCRIPTION
## Summary
- add an optional suppression flag to `hic_http_request` so callers can opt-out of enqueuing another failed request record
- ensure the retry scheduler uses the suppression flag and add a deterministic HTTP mock for tests
- expand the retry test suite to cover repeated 500 responses and verify the row is updated/deleted without duplicating records

## Testing
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter RetryFailedRequestsTest`


------
https://chatgpt.com/codex/tasks/task_e_68cc40c645e0832fa07b3af4bf8411ee