### PR TITLE
Support API connection alias

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -284,7 +284,7 @@ function hic_admin_enqueue_scripts($hook) {
             'polling_metrics_nonce' => wp_create_nonce('hic_polling_metrics'),
             'optimize_db_nonce' => wp_create_nonce('hic_optimize_db'),
             'management_nonce' => wp_create_nonce('hic_management_nonce'),
-            'is_api_connection' => (\FpHic\Helpers\hic_get_connection_type() === 'api'),
+            'is_api_connection' => (\FpHic\Helpers\hic_connection_uses_api()),
             'has_basic_auth' => \FpHic\Helpers\hic_has_basic_auth_credentials(),
             'has_property_id' => (bool) \FpHic\Helpers\hic_get_property_id(),
         ));
@@ -305,7 +305,7 @@ function hic_options_page() {
         </form>
         
         <!-- API Connection Test Section -->
-        <?php if (\FpHic\Helpers\hic_get_connection_type() === 'api'): ?>
+        <?php if (\FpHic\Helpers\hic_connection_uses_api()): ?>
         <div class="hic-api-test-section" style="margin-top: 30px; padding: 20px; background: #f9f9f9; border: 1px solid #ddd; border-radius: 5px;">
             <h2>Test Connessione API</h2>
             <p>Testa la connessione alle API Hotel in Cloud con le credenziali Basic Auth configurate.</p>
@@ -439,10 +439,11 @@ function hic_fb_access_token_render() {
 
 function hic_connection_type_render() {
     $type = \FpHic\Helpers\hic_get_connection_type();
+    $normalized = \FpHic\Helpers\hic_normalize_connection_type($type);
     echo '<select name="hic_connection_type">';
-    echo '<option value="webhook"' . selected($type, 'webhook', false) . '>Webhook</option>';
-    echo '<option value="api"' . selected($type, 'api', false) . '>API Polling</option>';
-    echo '<option value="hybrid"' . selected($type, 'hybrid', false) . '>Hybrid (Webhook + API)</option>';
+    echo '<option value="webhook"' . selected($normalized, 'webhook', false) . '>Webhook</option>';
+    echo '<option value="api"' . selected($normalized, 'api', false) . '>API Polling</option>';
+    echo '<option value="hybrid"' . selected($normalized, 'hybrid', false) . '>Hybrid (Webhook + API)</option>';
     echo '</select>';
     echo '<p class="description">Hybrid: combina webhook in tempo reale con API polling di backup per massima affidabilità</p>';
 }

--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -1045,8 +1045,10 @@ class HIC_Booking_Poller {
             return false;
         }
 
-        if (\FpHic\Helpers\hic_get_connection_type() !== 'api' && \FpHic\Helpers\hic_get_connection_type() !== 'hybrid') {
-            hic_log('Connection type is not API or hybrid');
+        $connection_type = \FpHic\Helpers\hic_get_connection_type();
+
+        if (!\FpHic\Helpers\hic_connection_uses_api($connection_type)) {
+            hic_log('Connection type does not support API polling: ' . ($connection_type !== '' ? $connection_type : 'none'));
             return false;
         }
 
@@ -1223,7 +1225,7 @@ class HIC_Booking_Poller {
         $diagnostics = array_merge($base_stats, array(
             'conditions' => array(
                 'reliable_polling_enabled' => \FpHic\Helpers\hic_reliable_polling_enabled(),
-                'connection_type_api' => in_array(\FpHic\Helpers\hic_get_connection_type(), ['api', 'hybrid']),
+                'connection_type_api' => \FpHic\Helpers\hic_connection_uses_api(),
                 'api_url_configured' => !empty(\FpHic\Helpers\hic_get_api_url()),
                 'has_credentials' => \FpHic\Helpers\hic_has_basic_auth_credentials(),
                 'basic_auth_complete' => \FpHic\Helpers\hic_has_basic_auth_credentials(),

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -163,6 +163,30 @@ function hic_get_fb_access_token() { return hic_get_option('fb_access_token', ''
 
 // Hotel in Cloud Connection Settings (with wp-config.php constants support)
 function hic_get_connection_type() { return hic_get_option('connection_type', 'webhook'); }
+
+function hic_normalize_connection_type($type = null) {
+    if ($type === null) {
+        $type = hic_get_connection_type();
+    }
+
+    if (!is_string($type)) {
+        return '';
+    }
+
+    $normalized = strtolower(trim($type));
+
+    if ($normalized === 'polling') {
+        $normalized = 'api';
+    }
+
+    return $normalized;
+}
+
+function hic_connection_uses_api($type = null) {
+    $normalized = hic_normalize_connection_type($type);
+
+    return in_array($normalized, ['api', 'hybrid'], true);
+}
 function hic_get_webhook_token() { return hic_get_option('webhook_token', ''); }
 function hic_get_api_url() { return hic_get_option('api_url', ''); }
 function hic_get_api_key() { return hic_get_option('api_key', ''); }
@@ -978,6 +1002,8 @@ namespace {
     function hic_get_fb_pixel_id() { return \FpHic\Helpers\hic_get_fb_pixel_id(); }
     function hic_get_fb_access_token() { return \FpHic\Helpers\hic_get_fb_access_token(); }
     function hic_get_connection_type() { return \FpHic\Helpers\hic_get_connection_type(); }
+    function hic_normalize_connection_type($type = null) { return \FpHic\Helpers\hic_normalize_connection_type($type); }
+    function hic_connection_uses_api($type = null) { return \FpHic\Helpers\hic_connection_uses_api($type); }
     function hic_get_webhook_token() { return \FpHic\Helpers\hic_get_webhook_token(); }
     function hic_get_api_url() { return \FpHic\Helpers\hic_get_api_url(); }
     function hic_get_api_key() { return \FpHic\Helpers\hic_get_api_key(); }

--- a/tests/ApiConnectionAliasTest.php
+++ b/tests/ApiConnectionAliasTest.php
@@ -1,0 +1,88 @@
+<?php
+
+class ApiConnectionAliasTest extends WP_UnitTestCase {
+
+    protected function setUp(): void {
+        parent::setUp();
+        require_once __DIR__ . '/../includes/config-validator.php';
+        require_once __DIR__ . '/../includes/admin/diagnostics.php';
+        $this->resetConfiguration();
+    }
+
+    protected function tearDown(): void {
+        $this->resetConfiguration();
+        parent::tearDown();
+    }
+
+    private function resetConfiguration(): void {
+        delete_option('hic_connection_type');
+        delete_option('hic_api_url');
+        delete_option('hic_api_email');
+        delete_option('hic_api_password');
+        delete_option('hic_property_id');
+        delete_option('hic_reliable_polling_enabled');
+        \FpHic\Helpers\hic_clear_option_cache();
+        unset($GLOBALS['hic_config_validator']);
+    }
+
+    private function configureApiConnection(string $connection_type): void {
+        update_option('hic_connection_type', $connection_type);
+        update_option('hic_api_url', 'https://api.hotelincloud.com/api/partner');
+        update_option('hic_api_email', 'alias-test@example.com');
+        update_option('hic_api_password', 'secure_password');
+        update_option('hic_property_id', '98765');
+        update_option('hic_reliable_polling_enabled', '1');
+        \FpHic\Helpers\hic_clear_option_cache();
+        unset($GLOBALS['hic_config_validator']);
+    }
+
+    private function assertSchedulerReady(): void {
+        $state = [
+            'connection_type' => hic_get_connection_type(),
+            'normalized' => \FpHic\Helpers\hic_normalize_connection_type(),
+            'api_url' => hic_get_api_url(),
+            'has_credentials' => hic_has_basic_auth_credentials(),
+            'uses_api' => \FpHic\Helpers\hic_connection_uses_api(),
+            'should_schedule' => hic_should_schedule_poll_event(),
+        ];
+
+        $this->assertTrue(
+            $state['should_schedule'],
+            'Scheduler gate should allow polling. State: ' . json_encode($state)
+        );
+
+        $poller = new \FpHic\HIC_Booking_Poller();
+        $stats = $poller->get_stats();
+        $this->assertArrayHasKey('should_poll', $stats);
+        $this->assertTrue(
+            $stats['should_poll'],
+            'Booking poller should be active. Stats: ' . json_encode($stats)
+        );
+    }
+
+    private function assertValidatorAcceptsConnection(): void {
+        $validator = new \FpHic\HIC_Config_Validator();
+        $result = $validator->validate_all_config();
+
+        foreach ($result['errors'] as $error) {
+            $this->assertStringNotContainsString('Invalid connection type', $error);
+        }
+    }
+
+    public function test_api_connection_type_is_valid(): void {
+        $this->configureApiConnection('api');
+
+        $this->assertTrue(\FpHic\Helpers\hic_connection_uses_api());
+        $this->assertSchedulerReady();
+        $this->assertValidatorAcceptsConnection();
+    }
+
+    public function test_polling_alias_behaves_like_api(): void {
+        $this->configureApiConnection('polling');
+
+        $this->assertSame('api', \FpHic\Helpers\hic_normalize_connection_type());
+        $this->assertTrue(\FpHic\Helpers\hic_connection_uses_api());
+        $this->assertSchedulerReady();
+        $this->assertValidatorAcceptsConnection();
+    }
+}

--- a/tests/HybridModeTest.php
+++ b/tests/HybridModeTest.php
@@ -54,7 +54,7 @@ class HybridModeTest extends WP_UnitTestCase {
     public function test_booking_poller_accepts_hybrid_mode() {
         // Simula le condizioni del booking poller
         $reliable_polling = \FpHic\Helpers\hic_reliable_polling_enabled();
-        $connection_type_ok = in_array(\FpHic\Helpers\hic_get_connection_type(), ['api', 'hybrid']);
+        $connection_type_ok = \FpHic\Helpers\hic_connection_uses_api();
         $has_api_url = !empty(\FpHic\Helpers\hic_get_api_url());
         $has_credentials = \FpHic\Helpers\hic_has_basic_auth_credentials();
         
@@ -69,9 +69,9 @@ class HybridModeTest extends WP_UnitTestCase {
      */
     public function test_diagnostics_recognize_hybrid_mode() {
         // Simula controllo diagnostico
-        $should_activate_scheduler = hic_reliable_polling_enabled() && 
-                                    in_array(hic_get_connection_type(), ['api', 'hybrid']) && 
-                                    hic_get_api_url() && 
+        $should_activate_scheduler = hic_reliable_polling_enabled() &&
+                                    hic_connection_uses_api() &&
+                                    hic_get_api_url() &&
                                     hic_has_basic_auth_credentials();
         
         $this->assertTrue($should_activate_scheduler);


### PR DESCRIPTION
## Summary
- add helpers to normalize the connection type and detect API-capable modes, treating legacy `polling` as the `api` alias
- allow the config validator, booking poller, diagnostics, and admin settings to respect the normalized values
- cover the behaviour with a dedicated PHPUnit suite and refresh existing hybrid assertions

## Testing
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter ApiConnectionAliasTest`
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter HybridModeTest` *(fails: Call to undefined function rest_get_server() — WordPress REST bootstrap not available in the test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68cc4cef6878832f81e2dcd747c15527