### PR TITLE
Preserve API password characters

### DIFF
--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -133,7 +133,7 @@ function hic_settings_init() {
     register_setting('hic_settings', 'hic_api_url', array('sanitize_callback' => 'sanitize_text_field'));
     // New Basic Auth settings
     register_setting('hic_settings', 'hic_api_email', array('sanitize_callback' => 'sanitize_email'));
-    register_setting('hic_settings', 'hic_api_password', array('sanitize_callback' => 'sanitize_text_field'));
+    register_setting('hic_settings', 'hic_api_password', array('sanitize_callback' => 'hic_preserve_password_field'));
     register_setting('hic_settings', 'hic_property_id', array('sanitize_callback' => 'absint'));
     register_setting('hic_settings', 'hic_polling_interval', array('sanitize_callback' => 'sanitize_text_field'));
     register_setting('hic_settings', 'hic_reliable_polling_enabled', array('sanitize_callback' => 'rest_sanitize_boolean'));
@@ -602,6 +602,28 @@ function hic_brevo_event_endpoint_render() {
 }
 
 /* ============ Validation Functions ============ */
+/**
+ * Preserve password values without stripping characters that are valid for API authentication.
+ *
+ * WordPress core adds slashes to incoming form values, so we only unslash the
+ * value and cast it to a string. Any other data types are coerced to an empty
+ * string to avoid storing unexpected structures.
+ *
+ * @param mixed $value Raw password value coming from user input.
+ * @return string The password with original characters preserved.
+ */
+function hic_preserve_password_field($value) {
+    if (is_array($value) || is_object($value)) {
+        return '';
+    }
+
+    if ($value === null) {
+        return '';
+    }
+
+    return wp_unslash((string) $value);
+}
+
 function hic_validate_admin_email($input) {
     // Allow empty value (will fall back to WordPress admin email)
     if (empty($input)) {

--- a/tests/AdminSettingsSanitizationTest.php
+++ b/tests/AdminSettingsSanitizationTest.php
@@ -49,4 +49,12 @@ final class AdminSettingsSanitizationTest extends TestCase {
         update_option('hic_brevo_enabled', $sanitized);
         $this->assertFalse(get_option('hic_brevo_enabled'));
     }
+
+    public function testApiPasswordPreservesSpecialCharacters() {
+        global $hic_registered_settings;
+        $raw = 'p&ssw%rd<secure>';
+        $sanitized = call_user_func($hic_registered_settings['hic_api_password'], $raw);
+        update_option('hic_api_password', $sanitized);
+        $this->assertSame('p&ssw%rd<secure>', get_option('hic_api_password'));
+    }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -85,6 +85,16 @@ if (!function_exists('sanitize_email')) {
     }
 }
 
+if (!function_exists('wp_unslash')) {
+    function wp_unslash($value) {
+        if (is_array($value)) {
+            return array_map('wp_unslash', $value);
+        }
+
+        return is_string($value) ? stripslashes($value) : $value;
+    }
+}
+
 if (!function_exists('is_email')) {
     function is_email($email) {
         return filter_var($email, FILTER_VALIDATE_EMAIL) ? $email : false;


### PR DESCRIPTION
## Summary
- replace the hic_api_password sanitizer with a helper that only unslashes the submitted value
- add the hic_preserve_password_field helper alongside other sanitizers and cover it with a unit test
- provide a wp_unslash test stub so the helper can be executed in the PHPUnit suite

## Testing
- composer test *(fails: WordPress test doubles in this environment lack several core classes/functions such as HIC_Booking_Poller, MINUTE_IN_SECONDS, rest_get_server, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68cc6c5eae44832f9c0b82b6115886c3