### PR TITLE
Add gbraid and wbraid tracking support

### DIFF
--- a/demo-without-enhanced.php
+++ b/demo-without-enhanced.php
@@ -69,14 +69,14 @@ namespace FpHic {
         echo "✅ Amount: €{$data['amount']}\n";
         
         // Mock sending to integrations
-        \hic_send_to_ga4($data, null, null, null, null, null);
+        \hic_send_to_ga4($data, null, null, null, null, null, null, null);
         
         return true;
     }
 }
 
 // Mock integration functions
-function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid, $ttclid, $sid) {
+function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid, $sid) {
     echo "✅ GA4: Sending purchase event for {$data['email']} (€{$data['amount']})\n";
     return true;
 }

--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -262,7 +262,7 @@ function hic_test_dispatch_functions() {
         // Test GA4
         if (!empty(hic_get_measurement_id()) && !empty(hic_get_api_secret())) {
             $sid = $test_data['sid'] ?? null;
-            hic_send_to_ga4($test_data, $gclid, $fbclid, '', '', $sid);
+            hic_send_to_ga4($test_data, $gclid, $fbclid, '', '', '', '', $sid);
             $results['ga4'] = 'Test event sent to GA4';
         } else {
             $results['ga4'] = 'GA4 not configured';
@@ -271,7 +271,7 @@ function hic_test_dispatch_functions() {
         // Test GTM
         if (hic_is_gtm_enabled() && !empty(hic_get_gtm_container_id())) {
             $sid = $test_data['sid'] ?? null;
-            hic_send_to_gtm_datalayer($test_data, $gclid, $fbclid, $sid);
+            hic_send_to_gtm_datalayer($test_data, $gclid, $fbclid, '', '', '', '', $sid);
             $results['gtm'] = 'Test event queued for GTM DataLayer';
         } else {
             $results['gtm'] = 'GTM not configured or disabled';
@@ -279,7 +279,7 @@ function hic_test_dispatch_functions() {
         
         // Test Facebook
         if (!empty(hic_get_fb_pixel_id()) && !empty(hic_get_fb_access_token())) {
-            hic_send_to_fb($test_data, $gclid, $fbclid, '', '');
+            hic_send_to_fb($test_data, $gclid, $fbclid, '', '', '', '');
             $results['facebook'] = 'Test event sent to Facebook';
         } else {
             $results['facebook'] = 'Facebook not configured';
@@ -287,8 +287,8 @@ function hic_test_dispatch_functions() {
         
         // Test Brevo
         if (hic_is_brevo_enabled() && !empty(hic_get_brevo_api_key())) {
-            hic_send_brevo_contact($test_data, $gclid, $fbclid, '', '');
-            hic_send_brevo_event($test_data, $gclid, $fbclid, '', '');
+            hic_send_brevo_contact($test_data, $gclid, $fbclid, '', '', '', '');
+            hic_send_brevo_event($test_data, $gclid, $fbclid, '', '', '', '');
             $results['brevo'] = 'Test contact and event sent to Brevo';
         } else {
             $results['brevo'] = 'Brevo not configured or disabled';

--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -1161,12 +1161,14 @@ class AutomatedReportingManager {
         $date_condition = $this->get_date_condition_for_period($period);
         
         return $wpdb->get_results($wpdb->prepare("
-            SELECT 
+            SELECT
                 id,
                 gclid,
                 fbclid,
                 msclkid,
                 ttclid,
+                gbraid,
+                wbraid,
                 sid,
                 utm_source,
                 utm_medium,

--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -52,6 +52,8 @@ function hic_process_booking_data(array $data): bool {
   $fbclid  = null;
   $msclkid = null;
   $ttclid  = null;
+  $gbraid  = null;
+  $wbraid  = null;
 
   if ($sid) {
     $tracking = Helpers\hic_get_tracking_ids_by_sid($sid);
@@ -59,6 +61,8 @@ function hic_process_booking_data(array $data): bool {
     $fbclid  = $tracking['fbclid'];
     $msclkid = $tracking['msclkid'];
     $ttclid  = $tracking['ttclid'];
+    $gbraid  = $tracking['gbraid'];
+    $wbraid  = $tracking['wbraid'];
   }
 
   // Validation for amount if present
@@ -67,9 +71,13 @@ function hic_process_booking_data(array $data): bool {
   }
 
   $filtered_data = apply_filters('hic_booking_data', $data, [
-    'gclid' => $gclid,
-    'fbclid' => $fbclid,
-    'sid' => $sid,
+    'gclid'   => $gclid,
+    'fbclid'  => $fbclid,
+    'msclkid' => $msclkid,
+    'ttclid'  => $ttclid,
+    'gbraid'  => $gbraid,
+    'wbraid'  => $wbraid,
+    'sid'     => $sid,
   ]);
 
   if (is_array($filtered_data)) {
@@ -248,6 +256,8 @@ function hic_process_booking_data(array $data): bool {
     'fbclid'         => $fbclid,
     'msclkid'        => $msclkid,
     'ttclid'         => $ttclid,
+    'gbraid'         => $gbraid,
+    'wbraid'         => $wbraid,
     'currency'       => $currency,
     'status'         => $status ?: null,
     'is_refund'      => $is_refund,
@@ -356,7 +366,7 @@ function hic_process_booking_data(array $data): bool {
           // GA4 refund event
           if (($tracking_mode === 'ga4_only' || $tracking_mode === 'hybrid') &&
               Helpers\hic_get_measurement_id() && Helpers\hic_get_api_secret()) {
-            if (hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid, $ttclid, $sid)) {
+            if (hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid, $sid)) {
               $success_count++;
             } else {
               $error_count++;
@@ -365,7 +375,7 @@ function hic_process_booking_data(array $data): bool {
 
           // Facebook refund event
           if (Helpers\hic_get_fb_pixel_id() && Helpers\hic_get_fb_access_token()) {
-            if (hic_send_fb_refund($data, $gclid, $fbclid, $msclkid, $ttclid)) {
+            if (hic_send_fb_refund($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid)) {
               $success_count++;
             } else {
               $error_count++;
@@ -374,7 +384,7 @@ function hic_process_booking_data(array $data): bool {
 
           // Brevo refund event
           if (Helpers\hic_is_brevo_enabled() && Helpers\hic_get_brevo_api_key()) {
-            $brevo_success = hic_send_brevo_refund_event($data, $gclid, $fbclid, $msclkid, $ttclid);
+            $brevo_success = hic_send_brevo_refund_event($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid);
             if ($brevo_success) {
               $success_count++;
             } else {
@@ -386,7 +396,7 @@ function hic_process_booking_data(array $data): bool {
         // GA4 Integration (server-side)
         if (($tracking_mode === 'ga4_only' || $tracking_mode === 'hybrid') &&
             Helpers\hic_get_measurement_id() && Helpers\hic_get_api_secret()) {
-          if (hic_send_to_ga4($data, $gclid, $fbclid, $msclkid, $ttclid, $sid)) {
+          if (hic_send_to_ga4($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid, $sid)) {
             $success_count++;
           } else {
             $error_count++;
@@ -397,7 +407,7 @@ function hic_process_booking_data(array $data): bool {
 
         // GTM Integration (client-side via dataLayer)
         if (($tracking_mode === 'gtm_only' || $tracking_mode === 'hybrid') && Helpers\hic_is_gtm_enabled()) {
-          if (hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $sid)) {
+          if (hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid, $sid)) {
             $success_count++;
           } else {
             $error_count++;
@@ -408,7 +418,7 @@ function hic_process_booking_data(array $data): bool {
 
         // Facebook Integration
         if (Helpers\hic_get_fb_pixel_id() && Helpers\hic_get_fb_access_token()) {
-          if (hic_send_to_fb($data, $gclid, $fbclid, $msclkid, $ttclid)) {
+          if (hic_send_to_fb($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid)) {
             $success_count++;
           } else {
             $error_count++;
@@ -419,7 +429,7 @@ function hic_process_booking_data(array $data): bool {
 
         // Brevo Integration - Unified approach to prevent duplicate events
         if (Helpers\hic_is_brevo_enabled() && Helpers\hic_get_brevo_api_key()) {
-          $brevo_success = hic_send_unified_brevo_events($data, $gclid, $fbclid, $msclkid, $ttclid);
+          $brevo_success = hic_send_unified_brevo_events($data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid);
           if ($brevo_success) {
             $success_count++;
           } else {

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -118,4 +118,4 @@ define('HIC_PLUGIN_VERSION', '3.1.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
 define('HIC_MIN_WP_VERSION', '5.0');
-define('HIC_DB_VERSION', '1.5');
+define('HIC_DB_VERSION', '1.6');

--- a/includes/database-optimizer.php
+++ b/includes/database-optimizer.php
@@ -191,6 +191,8 @@ class DatabaseOptimizer {
             fbclid VARCHAR(255),
             msclkid VARCHAR(255),
             ttclid VARCHAR(255),
+            gbraid VARCHAR(255),
+            wbraid VARCHAR(255),
             sid VARCHAR(255),
             utm_source VARCHAR(255),
             utm_medium VARCHAR(255),
@@ -372,8 +374,8 @@ class DatabaseOptimizer {
             // Insert batch into archive table
             $insert_query = $wpdb->prepare("
                 INSERT INTO {$archive_table} 
-                (original_id, gclid, fbclid, msclkid, ttclid, sid, utm_source, utm_medium, utm_campaign, utm_content, utm_term, created_at)
-                SELECT id, gclid, fbclid, msclkid, ttclid, sid, utm_source, utm_medium, utm_campaign, utm_content, utm_term, created_at
+                (original_id, gclid, fbclid, msclkid, ttclid, gbraid, wbraid, sid, utm_source, utm_medium, utm_campaign, utm_content, utm_term, created_at)
+                SELECT id, gclid, fbclid, msclkid, ttclid, gbraid, wbraid, sid, utm_source, utm_medium, utm_campaign, utm_content, utm_term, created_at
                 FROM {$main_table} 
                 WHERE created_at < %s 
                 LIMIT %d

--- a/includes/helpers-tracking.php
+++ b/includes/helpers-tracking.php
@@ -162,13 +162,13 @@ function hic_erase_tracking_data($email_address, $page = 1) {
  * Retrieve tracking IDs (gclid and fbclid) for a given SID from database.
  *
  * @param string $sid Session identifier
- * @return array{gclid:?string, fbclid:?string, msclkid:?string, ttclid:?string}
+ * @return array{gclid:?string, fbclid:?string, msclkid:?string, ttclid:?string, gbraid:?string, wbraid:?string}
 */
 function hic_get_tracking_ids_by_sid($sid) {
     static $cache = [];
     $sid = sanitize_text_field($sid);
     if (empty($sid)) {
-        return ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
+        return ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
     }
 
     if (array_key_exists($sid, $cache)) {
@@ -178,7 +178,7 @@ function hic_get_tracking_ids_by_sid($sid) {
     global $wpdb;
     if (!$wpdb) {
         hic_log('hic_get_tracking_ids_by_sid: wpdb is not available');
-        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
+        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
     }
 
     $table = $wpdb->prefix . 'hic_gclids';
@@ -187,13 +187,13 @@ function hic_get_tracking_ids_by_sid($sid) {
     $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
     if (!$table_exists) {
         hic_log('hic_get_tracking_ids_by_sid: Table does not exist: ' . $table);
-        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
+        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
     }
-    $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid, msclkid, ttclid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $sid));
+    $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid, msclkid, ttclid, gbraid, wbraid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $sid));
 
     if ($wpdb->last_error) {
         hic_log('hic_get_tracking_ids_by_sid: Database error retrieving tracking IDs: ' . $wpdb->last_error);
-        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
+        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
     }
 
     if ($row) {
@@ -202,10 +202,12 @@ function hic_get_tracking_ids_by_sid($sid) {
             'fbclid' => $row->fbclid,
             'msclkid' => $row->msclkid,
             'ttclid' => $row->ttclid,
+            'gbraid' => $row->gbraid,
+            'wbraid' => $row->wbraid,
         ];
     }
 
-    return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
+    return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
 }
 
 /**

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -7,7 +7,7 @@ namespace FpHic;
 if (!defined('ABSPATH')) exit;
 
 /* ============ Meta CAPI (Purchase + bucket) ============ */
-function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''){
+function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gbraid = '', $wbraid = ''){
   if (!Helpers\hic_get_fb_pixel_id() || !Helpers\hic_get_fb_access_token()) {
     hic_log('FB Pixel non configurato.');
     return false;
@@ -75,6 +75,8 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''){
   if (!empty($fbclid))  { $custom_data['fbclid']  = sanitize_text_field($fbclid); }
   if (!empty($msclkid)) { $custom_data['msclkid'] = sanitize_text_field($msclkid); }
   if (!empty($ttclid))  { $custom_data['ttclid']  = sanitize_text_field($ttclid); }
+  if (!empty($gbraid))  { $custom_data['gbraid']  = sanitize_text_field($gbraid); }
+  if (!empty($wbraid))  { $custom_data['wbraid']  = sanitize_text_field($wbraid); }
 
   // Attach UTM parameters if available
   if (!empty($data['sid'])) {
@@ -101,7 +103,7 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''){
   ];
 
   // Allow payload customization before encoding
-  $payload = apply_filters('hic_fb_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid);
+  $payload = apply_filters('hic_fb_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid);
 
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);
@@ -154,7 +156,7 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''){
 /**
  * Send refund event to Meta with negative value
  */
-function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''){
+function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gbraid = '', $wbraid = ''){
   if (!Helpers\hic_get_fb_pixel_id() || !Helpers\hic_get_fb_access_token()) {
     hic_log('FB refund: Pixel ID o Access Token mancanti.');
     return false;
@@ -218,6 +220,8 @@ function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '')
   if (!empty($fbclid))  { $custom_data['fbclid']  = sanitize_text_field($fbclid); }
   if (!empty($msclkid)) { $custom_data['msclkid'] = sanitize_text_field($msclkid); }
   if (!empty($ttclid))  { $custom_data['ttclid']  = sanitize_text_field($ttclid); }
+  if (!empty($gbraid))  { $custom_data['gbraid']  = sanitize_text_field($gbraid); }
+  if (!empty($wbraid))  { $custom_data['wbraid']  = sanitize_text_field($wbraid); }
 
   if (!empty($data['sid'])) {
     $utm = Helpers\hic_get_utm_params_by_sid($data['sid']);
@@ -242,7 +246,7 @@ function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '')
     ]]
   ];
 
-  $payload = apply_filters('hic_fb_refund_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid);
+  $payload = apply_filters('hic_fb_refund_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid);
 
   $json_payload = wp_json_encode($payload);
   if ($json_payload === false) {
@@ -332,6 +336,8 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
   $fbclid = '';
   $msclkid = '';
   $ttclid = '';
+  $gbraid = '';
+  $wbraid = '';
   $lookup_id = $sid !== '' ? $sid : $transaction_id;
   if (!empty($lookup_id)) {
     $tracking = Helpers\hic_get_tracking_ids_by_sid($lookup_id);
@@ -339,6 +345,8 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
     $fbclid = $tracking['fbclid'] ?? '';
     $msclkid = $tracking['msclkid'] ?? '';
     $ttclid = $tracking['ttclid'] ?? '';
+    $gbraid = $tracking['gbraid'] ?? '';
+    $wbraid = $tracking['wbraid'] ?? '';
   }
 
   $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
@@ -383,6 +391,8 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
   if (!empty($fbclid))  { $custom_data['fbclid']  = sanitize_text_field($fbclid); }
   if (!empty($msclkid)) { $custom_data['msclkid'] = sanitize_text_field($msclkid); }
   if (!empty($ttclid))  { $custom_data['ttclid']  = sanitize_text_field($ttclid); }
+  if (!empty($gbraid))  { $custom_data['gbraid']  = sanitize_text_field($gbraid); }
+  if (!empty($wbraid))  { $custom_data['wbraid']  = sanitize_text_field($wbraid); }
 
   // Add UTM parameters if available
   $utm_lookup = $sid !== '' ? $sid : $transaction_id;
@@ -419,7 +429,7 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
   ];
 
   // Allow payload customization before encoding
-  $payload = apply_filters('hic_fb_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid);
+  $payload = apply_filters('hic_fb_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid);
 
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -7,7 +7,7 @@ namespace FpHic;
 if (!defined('ABSPATH')) exit;
 
 /* ============ GA4 (purchase + bucket) ============ */
-function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $sid = null) {
+function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gbraid = '', $wbraid = '', $sid = null) {
   // Validate configuration
   $measurement_id = Helpers\hic_get_measurement_id();
   $api_secret = Helpers\hic_get_api_secret();
@@ -64,6 +64,8 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $s
   if (!empty($fbclid))  { $params['fbclid']  = sanitize_text_field($fbclid); }
   if (!empty($msclkid)) { $params['msclkid'] = sanitize_text_field($msclkid); }
   if (!empty($ttclid))  { $params['ttclid']  = sanitize_text_field($ttclid); }
+  if (!empty($gbraid))  { $params['gbraid']  = sanitize_text_field($gbraid); }
+  if (!empty($wbraid))  { $params['wbraid']  = sanitize_text_field($wbraid); }
 
   // Append UTM parameters if available
   if ($sid !== '') {
@@ -84,7 +86,7 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $s
   ];
 
   // Allow external modification of the GA4 payload
-  $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $sid);
+  $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid, $sid);
 
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);
@@ -127,7 +129,7 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $s
 /**
  * Send refund event to GA4 with negative value
  */
-function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $sid = null) {
+function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gbraid = '', $wbraid = '', $sid = null) {
   $measurement_id = Helpers\hic_get_measurement_id();
   $api_secret = Helpers\hic_get_api_secret();
 
@@ -180,6 +182,8 @@ function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''
   if (!empty($fbclid))  { $params['fbclid']  = sanitize_text_field($fbclid); }
   if (!empty($msclkid)) { $params['msclkid'] = sanitize_text_field($msclkid); }
   if (!empty($ttclid))  { $params['ttclid']  = sanitize_text_field($ttclid); }
+  if (!empty($gbraid))  { $params['gbraid']  = sanitize_text_field($gbraid); }
+  if (!empty($wbraid))  { $params['wbraid']  = sanitize_text_field($wbraid); }
 
   if ($sid !== '') {
     $utm = Helpers\hic_get_utm_params_by_sid($sid);
@@ -198,7 +202,7 @@ function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''
     ]]
   ];
 
-  $payload = apply_filters('hic_ga4_refund_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $sid);
+  $payload = apply_filters('hic_ga4_refund_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid, $sid);
 
   $json_payload = wp_json_encode($payload);
   if ($json_payload === false) {
@@ -283,6 +287,8 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
   $fbclid = '';
   $msclkid = '';
   $ttclid = '';
+  $gbraid = '';
+  $wbraid = '';
   $lookup_id = $sid !== '' ? $sid : $transaction_id;
   if (!empty($lookup_id)) {
     $tracking = Helpers\hic_get_tracking_ids_by_sid($lookup_id);
@@ -290,6 +296,8 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
     $fbclid = $tracking['fbclid'] ?? '';
     $msclkid = $tracking['msclkid'] ?? '';
     $ttclid = $tracking['ttclid'] ?? '';
+    $gbraid = $tracking['gbraid'] ?? '';
+    $wbraid = $tracking['wbraid'] ?? '';
   }
 
   $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
@@ -321,6 +329,8 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
   if (!empty($fbclid))  { $params['fbclid']  = sanitize_text_field($fbclid); }
   if (!empty($msclkid)) { $params['msclkid'] = sanitize_text_field($msclkid); }
   if (!empty($ttclid))  { $params['ttclid']  = sanitize_text_field($ttclid); }
+  if (!empty($gbraid))  { $params['gbraid']  = sanitize_text_field($gbraid); }
+  if (!empty($wbraid))  { $params['wbraid']  = sanitize_text_field($wbraid); }
 
   // Attach UTM parameters if available
   $utm_lookup = $sid !== '' ? $sid : $transaction_id;
@@ -350,7 +360,7 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
   ];
 
   // Allow external modification of the GA4 payload
-  $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $sid);
+  $payload = apply_filters('hic_ga4_payload', $payload, $data, $gclid, $fbclid, $msclkid, $ttclid, $gbraid, $wbraid, $sid);
 
   // Validate JSON encoding
   $json_payload = wp_json_encode($payload);

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -10,7 +10,7 @@ if (!defined('ABSPATH')) exit;
  * Send conversion data to GTM Data Layer
  * This pushes data to the client-side dataLayer for GTM to process
  */
-function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $sid = null) {
+function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gbraid = '', $wbraid = '', $sid = null) {
     // Only proceed if GTM is enabled
     if (!Helpers\hic_is_gtm_enabled()) {
         return false;
@@ -70,6 +70,18 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $sid = null) {
     }
     if (!empty($fbclid)) {
         $gtm_data['fbclid'] = sanitize_text_field($fbclid);
+    }
+    if (!empty($msclkid)) {
+        $gtm_data['msclkid'] = sanitize_text_field($msclkid);
+    }
+    if (!empty($ttclid)) {
+        $gtm_data['ttclid'] = sanitize_text_field($ttclid);
+    }
+    if (!empty($gbraid)) {
+        $gtm_data['gbraid'] = sanitize_text_field($gbraid);
+    }
+    if (!empty($wbraid)) {
+        $gtm_data['wbraid'] = sanitize_text_field($wbraid);
     }
 
     // Include UTM parameters if available
@@ -345,11 +357,19 @@ function hic_dispatch_gtm_reservation($data, $sid = '') {
     // Get gclid/fbclid for bucket normalization if available
     $gclid = '';
     $fbclid = '';
+    $msclkid = '';
+    $ttclid = '';
+    $gbraid = '';
+    $wbraid = '';
     $lookup_id = $sid !== '' ? $sid : $transaction_id;
     if (!empty($lookup_id)) {
         $tracking = Helpers\hic_get_tracking_ids_by_sid($lookup_id);
         $gclid = $tracking['gclid'] ?? '';
         $fbclid = $tracking['fbclid'] ?? '';
+        $msclkid = $tracking['msclkid'] ?? '';
+        $ttclid = $tracking['ttclid'] ?? '';
+        $gbraid = $tracking['gbraid'] ?? '';
+        $wbraid = $tracking['wbraid'] ?? '';
     }
 
     $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
@@ -391,6 +411,18 @@ function hic_dispatch_gtm_reservation($data, $sid = '') {
     }
     if (!empty($fbclid)) {
         $gtm_data['fbclid'] = sanitize_text_field($fbclid);
+    }
+    if (!empty($msclkid)) {
+        $gtm_data['msclkid'] = sanitize_text_field($msclkid);
+    }
+    if (!empty($ttclid)) {
+        $gtm_data['ttclid'] = sanitize_text_field($ttclid);
+    }
+    if (!empty($gbraid)) {
+        $gtm_data['gbraid'] = sanitize_text_field($gbraid);
+    }
+    if (!empty($wbraid)) {
+        $gtm_data['wbraid'] = sanitize_text_field($wbraid);
     }
 
     $utm_lookup = $sid !== '' ? $sid : $transaction_id;

--- a/tests/BrevoSidUtmTest.php
+++ b/tests/BrevoSidUtmTest.php
@@ -69,6 +69,8 @@ final class BrevoSidUtmTest extends TestCase
                         'fbclid' => null,
                         'msclkid' => null,
                         'ttclid' => null,
+                        'gbraid' => 'GBRAID-123',
+                        'wbraid' => 'WBRAID-789',
                         'utm_source' => null,
                         'utm_medium' => null,
                         'utm_campaign' => null,
@@ -92,6 +94,8 @@ final class BrevoSidUtmTest extends TestCase
                         'fbclid' => null,
                         'msclkid' => null,
                         'ttclid' => null,
+                        'gbraid' => null,
+                        'wbraid' => null,
                     ];
                 }
 
@@ -150,5 +154,7 @@ final class BrevoSidUtmTest extends TestCase
         $this->assertSame('retargeting', $payload['properties']['utm_campaign']);
         $this->assertSame('carousel', $payload['properties']['utm_content']);
         $this->assertSame('hotel+rome', $payload['properties']['utm_term']);
+        $this->assertSame('GBRAID-123', $payload['properties']['gbraid']);
+        $this->assertSame('WBRAID-789', $payload['properties']['wbraid']);
     }
 }

--- a/tests/CaptureTrackingParamsTest.php
+++ b/tests/CaptureTrackingParamsTest.php
@@ -224,6 +224,8 @@ final class CaptureTrackingParamsTest extends TestCase
             fbclid TEXT,
             msclkid TEXT,
             ttclid TEXT,
+            gbraid TEXT,
+            wbraid TEXT,
             sid TEXT,
             utm_source TEXT,
             utm_medium TEXT,
@@ -255,6 +257,10 @@ final class CaptureTrackingParamsTest extends TestCase
         $_GET = [
             'gclid' => 'test-gclid-12345',
             'fbclid' => 'fbclid-67890',
+            'msclkid' => 'msclkid-1234567890',
+            'ttclid' => 'ttclid-1234567890',
+            'gbraid' => 'GBRAID-abc1234567',
+            'wbraid' => 'WBRAID-def7654321',
             'utm_source' => 'google',
             'utm_medium' => 'cpc',
             'utm_campaign' => 'spring',
@@ -273,6 +279,13 @@ final class CaptureTrackingParamsTest extends TestCase
         $tracking = Helpers\hic_get_tracking_ids_by_sid($sid);
         $this->assertSame('test-gclid-12345', $tracking['gclid']);
         $this->assertSame('fbclid-67890', $tracking['fbclid']);
+        $this->assertSame('msclkid-1234567890', $tracking['msclkid']);
+        $this->assertSame('ttclid-1234567890', $tracking['ttclid']);
+        $this->assertSame('GBRAID-abc1234567', $tracking['gbraid']);
+        $this->assertSame('WBRAID-def7654321', $tracking['wbraid']);
+
+        $this->assertSame('GBRAID-abc1234567', $_COOKIE['hic_gbraid']);
+        $this->assertSame('WBRAID-def7654321', $_COOKIE['hic_wbraid']);
 
         $utm = Helpers\hic_get_utm_params_by_sid($sid);
         $this->assertSame('google', $utm['utm_source']);
@@ -286,6 +299,7 @@ final class CaptureTrackingParamsTest extends TestCase
     {
         $_GET = [
             'gclid' => 'booking-gclid-12345',
+            'gbraid' => 'booking-gbraid-12345',
             'utm_source' => 'meta',
         ];
 
@@ -302,6 +316,7 @@ final class CaptureTrackingParamsTest extends TestCase
 
         $trackingBeforeBooking = Helpers\hic_get_tracking_ids_by_sid($sid);
         $this->assertSame('booking-gclid-12345', $trackingBeforeBooking['gclid']);
+        $this->assertSame('booking-gbraid-12345', $trackingBeforeBooking['gbraid']);
         $result = \FpHic\hic_process_booking_data([
             'email' => 'guest@example.com',
             'sid' => $sid,

--- a/tests/CurrencyPropagationTest.php
+++ b/tests/CurrencyPropagationTest.php
@@ -2,7 +2,7 @@
 namespace FpHic\Helpers {
     if (!function_exists(__NAMESPACE__ . '\\hic_get_tracking_ids_by_sid')) {
         function hic_get_tracking_ids_by_sid($sid) {
-            return ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null];
+            return ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
         }
     }
 

--- a/tests/TrackingIdsTest.php
+++ b/tests/TrackingIdsTest.php
@@ -57,21 +57,21 @@ final class TrackingIdsTest extends TestCase
     {
         global $wpdb;
         $wpdb = new MockWpdb();
-        $wpdb->exec("CREATE TABLE wp_hic_gclids (id INTEGER PRIMARY KEY AUTOINCREMENT, gclid TEXT, fbclid TEXT, msclkid TEXT, ttclid TEXT, sid TEXT, utm_source TEXT, utm_medium TEXT, utm_campaign TEXT, utm_content TEXT, utm_term TEXT);");
-        $wpdb->exec("INSERT INTO wp_hic_gclids (gclid, fbclid, msclkid, ttclid, sid) VALUES ('g1', 'f1', 'm1', 't1', 'SID123');");
+        $wpdb->exec("CREATE TABLE wp_hic_gclids (id INTEGER PRIMARY KEY AUTOINCREMENT, gclid TEXT, fbclid TEXT, msclkid TEXT, ttclid TEXT, gbraid TEXT, wbraid TEXT, sid TEXT, utm_source TEXT, utm_medium TEXT, utm_campaign TEXT, utm_content TEXT, utm_term TEXT);");
+        $wpdb->exec("INSERT INTO wp_hic_gclids (gclid, fbclid, msclkid, ttclid, gbraid, wbraid, sid) VALUES ('g1', 'f1', 'm1', 't1', 'gb1', 'wb1', 'SID123');");
         $wpdb->exec("INSERT INTO wp_hic_gclids (sid, utm_source, utm_medium, utm_campaign, utm_content, utm_term) VALUES ('SIDUTM', 'google', 'cpc', 'camp', 'content', 'term');");
     }
 
     public function testRetrievesTrackingIds()
     {
         $result = Helpers\hic_get_tracking_ids_by_sid('SID123');
-        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1', 'msclkid' => 'm1', 'ttclid' => 't1'], $result);
+        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1', 'msclkid' => 'm1', 'ttclid' => 't1', 'gbraid' => 'gb1', 'wbraid' => 'wb1'], $result);
     }
 
     public function testSanitizesSid()
     {
         $result = Helpers\hic_get_tracking_ids_by_sid('<script>SID123</script>');
-        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1', 'msclkid' => 'm1', 'ttclid' => 't1'], $result);
+        $this->assertSame(['gclid' => 'g1', 'fbclid' => 'f1', 'msclkid' => 'm1', 'ttclid' => 't1', 'gbraid' => 'gb1', 'wbraid' => 'wb1'], $result);
     }
 
     public function testReturnsNullWhenNotFound()
@@ -81,6 +81,8 @@ final class TrackingIdsTest extends TestCase
         $this->assertNull($result['fbclid']);
         $this->assertNull($result['msclkid']);
         $this->assertNull($result['ttclid']);
+        $this->assertNull($result['gbraid']);
+        $this->assertNull($result['wbraid']);
     }
 
     public function testRetrievesUtmParams()

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -417,7 +417,7 @@ class HICFunctionsTest {
         // GA4 room name + SID usage
         $data = ['room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
         $sid = 'sid123';
-        \FpHic\hic_send_to_ga4($data, null, null, null, null, $sid);
+        \FpHic\hic_send_to_ga4($data, null, null, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Camera Deluxe', 'GA4 should use room name');
         assert($payload['client_id'] === $sid, 'GA4 should use SID as client_id');
@@ -425,13 +425,13 @@ class HICFunctionsTest {
 
         // GA4 accommodation_name fallback
         $data = ['accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_ga4($data, null, null, null, null, $sid);
+        \FpHic\hic_send_to_ga4($data, null, null, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Suite', 'GA4 should use accommodation name');
 
         // GA4 default
         $data = ['currency' => 'EUR', 'amount' => 100];
-        \FpHic\hic_send_to_ga4($data, null, null, null, null, $sid);
+        \FpHic\hic_send_to_ga4($data, null, null, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Prenotazione', 'GA4 should default to Prenotazione');
 


### PR DESCRIPTION
## Summary
- add gbraid/wbraid columns to the tracking table, upgrade routine, and capture helpers
- propagate the new identifiers through helper lookups, booking processing, and GA4/GTM/Facebook/Brevo dispatchers
- extend automated tests to cover the new cookies, database fields, and payload expectations

## Testing
- vendor/bin/phpunit

------
https://chatgpt.com/codex/tasks/task_e_68d0f5b14a48832fbdd9eb3b6d87f511