### PR TITLE
Ensure amount field survives polling transformations

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -676,6 +676,7 @@ function hic_transform_reservation($reservation) {
         'transaction_id' => $transaction_id,
         'reservation_code' => isset($reservation['reservation_code']) ? $reservation['reservation_code'] : '',
         'value' => $value,
+        'amount' => $value,
         'currency' => $currency,
         'accommodation_id' => $accommodation_id,
         'accommodation_name' => $accommodation_name,

--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -676,6 +676,7 @@ function hic_transform_reservation($reservation) {
         'transaction_id' => $transaction_id,
         'reservation_code' => isset($reservation['reservation_code']) ? $reservation['reservation_code'] : '',
         'value' => $value,
+        // Both 'value' and 'amount' are required by different consumers/APIs; currently, they are set to the same value.
         'amount' => $value,
         'currency' => $currency,
         'accommodation_id' => $accommodation_id,

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -42,6 +42,17 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
   }
   $list_ids = array_filter($list_ids);
 
+  $amount = 0;
+  $amount_source = null;
+  if (isset($data['amount']) && (is_numeric($data['amount']) || is_string($data['amount']))) {
+    $amount_source = $data['amount'];
+  } elseif (isset($data['value']) && (is_numeric($data['value']) || is_string($data['value']))) {
+    $amount_source = $data['value'];
+  }
+  if ($amount_source !== null) {
+    $amount = Helpers\hic_normalize_price($amount_source);
+  }
+
   $body = array(
     'email' => $email,
     'attributes' => array(
@@ -56,7 +67,7 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
       'GBRAID'    => isset($gbraid) ? $gbraid : '',
       'WBRAID'    => isset($wbraid) ? $wbraid : '',
       'DATE'      => isset($data['date']) ? $data['date'] : wp_date('Y-m-d'),
-      'AMOUNT'    => isset($data['amount']) ? Helpers\hic_normalize_price($data['amount']) : 0,
+      'AMOUNT'    => $amount,
       'CURRENCY'  => isset($data['currency']) ? $data['currency'] : 'EUR',
       'WHATSAPP'  => $normalized_phone,
       'LANGUAGE'  => $lang,
@@ -108,12 +119,23 @@ function hic_send_brevo_event($reservation, $gclid, $fbclid, $msclkid = '', $ttc
   if (!Helpers\hic_get_brevo_api_key()) { return; }
   $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
 
+  $amount = 0;
+  $amount_source = null;
+  if (isset($reservation['amount']) && (is_numeric($reservation['amount']) || is_string($reservation['amount']))) {
+    $amount_source = $reservation['amount'];
+  } elseif (isset($reservation['value']) && (is_numeric($reservation['value']) || is_string($reservation['value']))) {
+    $amount_source = $reservation['value'];
+  }
+  if ($amount_source !== null) {
+    $amount = Helpers\hic_normalize_price($amount_source);
+  }
+
   $event_data = array(
     'event' => 'purchase', // puoi rinominare in 'hic_booking' se preferisci
     'email' => isset($reservation['email']) ? $reservation['email'] : '',
     'properties' => array(
       'reservation_id' => isset($reservation['reservation_id']) ? $reservation['reservation_id'] : (isset($reservation['id']) ? $reservation['id'] : ''),
-      'amount'         => isset($reservation['amount']) ? Helpers\hic_normalize_price($reservation['amount']) : 0,
+      'amount'         => $amount,
       'currency'       => isset($reservation['currency']) ? $reservation['currency'] : 'EUR',
       'date'           => isset($reservation['date']) ? $reservation['date'] : wp_date('Y-m-d'),
       'phone'          => isset($reservation['phone']) ? $reservation['phone'] : '',
@@ -173,12 +195,23 @@ function hic_send_brevo_refund_event($reservation, $gclid, $fbclid, $msclkid = '
   if (!Helpers\hic_get_brevo_api_key()) { return false; }
   $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
 
+  $amount = 0;
+  $amount_source = null;
+  if (isset($reservation['amount']) && (is_numeric($reservation['amount']) || is_string($reservation['amount']))) {
+    $amount_source = $reservation['amount'];
+  } elseif (isset($reservation['value']) && (is_numeric($reservation['value']) || is_string($reservation['value']))) {
+    $amount_source = $reservation['value'];
+  }
+  if ($amount_source !== null) {
+    $amount = -abs(Helpers\hic_normalize_price($amount_source));
+  }
+
   $event_data = array(
     'event' => 'refund',
     'email' => isset($reservation['email']) ? $reservation['email'] : '',
     'properties' => array(
       'reservation_id' => isset($reservation['reservation_id']) ? $reservation['reservation_id'] : (isset($reservation['id']) ? $reservation['id'] : ''),
-      'amount'         => isset($reservation['amount']) ? -abs(Helpers\hic_normalize_price($reservation['amount'])) : 0,
+      'amount'         => $amount,
       'currency'       => isset($reservation['currency']) ? $reservation['currency'] : 'EUR',
       'date'           => isset($reservation['date']) ? $reservation['date'] : wp_date('Y-m-d'),
       'phone'          => isset($reservation['phone']) ? $reservation['phone'] : '',

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -34,8 +34,14 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gb
 
   // Validate and sanitize amount
   $amount = 0;
+  $amount_source = null;
   if (isset($data['amount']) && (is_numeric($data['amount']) || is_string($data['amount']))) {
-    $amount = Helpers\hic_normalize_price($data['amount']);
+    $amount_source = $data['amount'];
+  } elseif (isset($data['value']) && (is_numeric($data['value']) || is_string($data['value']))) {
+    $amount_source = $data['value'];
+  }
+  if ($amount_source !== null) {
+    $amount = Helpers\hic_normalize_price($amount_source);
   }
 
   $user_data = [
@@ -180,8 +186,14 @@ function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '',
   }
 
   $amount = 0;
+  $amount_source = null;
   if (isset($data['amount']) && (is_numeric($data['amount']) || is_string($data['amount']))) {
-    $amount = -abs(Helpers\hic_normalize_price($data['amount']));
+    $amount_source = $data['amount'];
+  } elseif (isset($data['value']) && (is_numeric($data['value']) || is_string($data['value']))) {
+    $amount_source = $data['value'];
+  }
+  if ($amount_source !== null) {
+    $amount = -abs(Helpers\hic_normalize_price($amount_source));
   }
 
   $user_data = [

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -29,8 +29,14 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $g
 
   // Validate and normalize amount
   $amount = 0;
+  $amount_source = null;
   if (isset($data['amount']) && (is_numeric($data['amount']) || is_string($data['amount']))) {
-    $amount = Helpers\hic_normalize_price($data['amount']);
+    $amount_source = $data['amount'];
+  } elseif (isset($data['value']) && (is_numeric($data['value']) || is_string($data['value']))) {
+    $amount_source = $data['value'];
+  }
+  if ($amount_source !== null) {
+    $amount = Helpers\hic_normalize_price($amount_source);
   }
 
   // Generate transaction ID using consistent extraction
@@ -148,8 +154,14 @@ function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''
   $sid = !empty($sid) ? sanitize_text_field($sid) : '';
 
   $amount = 0;
+  $amount_source = null;
   if (isset($data['amount']) && (is_numeric($data['amount']) || is_string($data['amount']))) {
-    $amount = -abs(Helpers\hic_normalize_price($data['amount']));
+    $amount_source = $data['amount'];
+  } elseif (isset($data['value']) && (is_numeric($data['value']) || is_string($data['value']))) {
+    $amount_source = $data['value'];
+  }
+  if ($amount_source !== null) {
+    $amount = -abs(Helpers\hic_normalize_price($amount_source));
   }
 
   $transaction_id = Helpers\hic_extract_reservation_id($data);

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -27,8 +27,14 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $msclkid = '', $ttcli
 
     // Validate and normalize amount
     $amount = 0;
+    $amount_source = null;
     if (isset($data['amount']) && (is_numeric($data['amount']) || is_string($data['amount']))) {
-        $amount = Helpers\hic_normalize_price($data['amount']);
+        $amount_source = $data['amount'];
+    } elseif (isset($data['value']) && (is_numeric($data['value']) || is_string($data['value']))) {
+        $amount_source = $data['value'];
+    }
+    if ($amount_source !== null) {
+        $amount = Helpers\hic_normalize_price($amount_source);
     }
 
     // Generate transaction ID using consistent extraction


### PR DESCRIPTION
## Summary
- add the `amount` field to the reservation payload produced by `hic_transform_reservation()` so downstream dispatchers receive the normalized amount
- normalize GA4, GTM, Facebook and Brevo dispatchers to fall back to `value` when `amount` is absent, maintaining support for legacy payloads

## Testing
- `composer test` *(fails: relies on WordPress classes/functions not available in the container test environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d110fc3b40832fb5e5df9a8edd8926