### PR TITLE
Fix CLI reset helper reference

### DIFF
--- a/includes/cli.php
+++ b/includes/cli.php
@@ -101,7 +101,7 @@ if (defined('WP_CLI') && WP_CLI) {
             delete_option('hic_last_reliable_poll');
             
             // Clear scheduled events
-            Helpers\hic_safe_wp_clear_scheduled_hook('hic_reliable_poll_event');
+            \FpHic\Helpers\hic_safe_wp_clear_scheduled_hook('hic_reliable_poll_event');
             
             WP_CLI::success('Polling state reset successfully');
         }


### PR DESCRIPTION
## Summary
- ensure the CLI reset command resolves the scheduled hook helper with its fully qualified name

## Testing
- wp hic reset --confirm *(fails: `wp` not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d11728c414832f928d5f68cb55f1c6