### PR TITLE
Handle admin email failures without blocking dispatch

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -897,8 +897,14 @@ function hic_dispatch_reservation($transformed, $original) {
             $admin_email = Helpers\hic_get_admin_email();
             if (!empty($admin_email) && Helpers\hic_is_valid_email($admin_email)) {
                 $email_result = Helpers\hic_send_admin_email($admin_data, $gclid, $fbclid, (string) $email_identifier);
-                hic_log('Admin email dispatch result for reservation ' . $uid . ': ' . ($email_result ? 'success' : 'failure'));
-                $record_result('Admin email', $email_result ? 'success' : 'failed');
+                if ($email_result) {
+                    hic_log('Admin email dispatch succeeded for reservation ' . $uid);
+                    $record_result('Admin email', 'success');
+                } else {
+                    $warning_message = 'Admin email dispatch failed for reservation ' . $uid . ' - marking as skipped. Check SMTP or wp_mail configuration.';
+                    hic_log($warning_message, HIC_LOG_LEVEL_WARNING);
+                    $record_result('Admin email', 'skipped', 'send failed');
+                }
             } else {
                 $record_result('Admin email', 'skipped');
             }

--- a/includes/booking-processor.php
+++ b/includes/booking-processor.php
@@ -459,7 +459,9 @@ function hic_process_booking_data(array $data): bool {
           if (Helpers\hic_send_admin_email($data, $gclid, $fbclid, $sid)) {
             $success_count++;
           } else {
-            $error_count++;
+            $skipped_count++;
+            $safe_sid = $sid !== null ? $sid : 'N/A';
+            hic_log('hic_process_booking_data: Admin email sending failed, marking as skipped (SID: ' . $safe_sid . ')', HIC_LOG_LEVEL_WARNING);
           }
         } else {
           hic_log('hic_process_booking_data: Admin email not configured or invalid, skipping');


### PR DESCRIPTION
## Summary
- treat admin email send failures during polling dispatch as skipped with warning logs so the reservation is not retried
- adjust booking processor to count admin email failures as skipped events instead of errors while logging the SMTP issue

## Testing
- composer test *(fails: requires WordPress test doubles such as HIC_Booking_Poller and REST server functions)*

------
https://chatgpt.com/codex/tasks/task_e_68d119106aa0832f9b8f3a4fb838d20b