### PR TITLE
Ensure booking poller catches global exceptions

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -2,6 +2,8 @@
 
 namespace FpHic;
 
+use \Exception;
+
 /**
  * Internal Booking Scheduler - WP-Cron System
  */


### PR DESCRIPTION
## Summary
- import the global Exception class in the booking poller so its catch blocks target the intended type

## Testing
- php -l includes/booking-poller.php
- php /tmp/test_poller.php

------
https://chatgpt.com/codex/tasks/task_e_68d1272cdb80832fa4e22097b3cbd262