### PR TITLE
Allow webhook requests without email

### DIFF
--- a/includes/input-validator.php
+++ b/includes/input-validator.php
@@ -52,24 +52,26 @@ class HIC_Input_Validator {
         
         $errors = [];
         
-        // Required fields validation
-        $required_fields = ['email'];
-        foreach ($required_fields as $field) {
-            if (!isset($data[$field]) || empty($data[$field])) {
-                $errors[] = "Campo obbligatorio mancante: $field";
-            }
-        }
-        
         // Email validation
-        if (isset($data['email'])) {
-            $email_validation = self::validate_email($data['email']);
-            if (is_wp_error($email_validation)) {
-                $errors[] = $email_validation->get_error_message();
+        if (array_key_exists('email', $data)) {
+            $email_value = $data['email'];
+
+            if (is_string($email_value)) {
+                $email_value = trim($email_value);
+            }
+
+            if ($email_value === '' || $email_value === null) {
+                unset($data['email']);
             } else {
-                $data['email'] = $email_validation;
+                $email_validation = self::validate_email($email_value);
+                if (is_wp_error($email_validation)) {
+                    $errors[] = $email_validation->get_error_message();
+                } else {
+                    $data['email'] = $email_validation;
+                }
             }
         }
-        
+
         // Amount validation
         if (isset($data['amount'])) {
             $amount_validation = self::validate_amount($data['amount']);

--- a/tests/WebhookConversionTrackingTest.php
+++ b/tests/WebhookConversionTrackingTest.php
@@ -176,13 +176,23 @@ class WebhookConversionTrackingTest extends WP_UnitTestCase {
         $result = hic_validate_webhook_payload($valid_payload);
         $this->assertTrue($result);
         
-        // Test payload senza email (dovrebbe fallire)
-        $invalid_payload = [
+        // Test payload senza email (ora accettato)
+        $missing_email_payload = [
+            'reservation_id' => 'MISSING_EMAIL_123',
+            'amount' => 100.00
+        ];
+
+        $result = hic_validate_webhook_payload($missing_email_payload);
+        $this->assertTrue($result);
+
+        // Test payload con email non valida
+        $invalid_email_payload = [
+            'email' => 'invalid-email',
             'reservation_id' => 'INVALID_123',
             'amount' => 100.00
         ];
-        
-        $result = hic_validate_webhook_payload($invalid_payload);
+
+        $result = hic_validate_webhook_payload($invalid_email_payload);
         $this->assertInstanceOf('WP_Error', $result);
         $this->assertEquals('invalid_email', $result->get_error_code());
     }

--- a/tests/WebhookInvalidJsonTest.php
+++ b/tests/WebhookInvalidJsonTest.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/../includes/api/webhook.php';
+require_once __DIR__ . '/../includes/input-validator.php';
 
 if (!class_exists('MockPhpStream')) {
     class MockPhpStream {
@@ -98,4 +99,74 @@ final class WebhookInvalidJsonTest extends TestCase {
         $this->assertInstanceOf(WP_Error::class, $result);
         $this->assertSame('invalid_json', $result->get_error_code());
     }
+
+
+    public function test_webhook_allows_missing_email_payload(): void {
+        $logFile = sys_get_temp_dir() . '/hic-webhook-missing-email.log';
+        if (file_exists($logFile)) {
+            unlink($logFile);
+        }
+
+        update_option('hic_log_file', $logFile);
+        \FpHic\Helpers\hic_clear_option_cache('log_file');
+        unset($GLOBALS['hic_log_manager']);
+
+        $capturedLogs = [];
+        $logFilter = function ($message) use (&$capturedLogs) {
+            if (is_array($message) || is_object($message)) {
+                $message = json_encode($message, JSON_UNESCAPED_UNICODE);
+            } elseif (!is_string($message)) {
+                $message = (string) $message;
+            }
+
+            $capturedLogs[] = $message;
+
+            return $message;
+        };
+        add_filter('hic_log_message', $logFilter, 20, 2);
+
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', MockPhpStream::class);
+
+        $payload = [
+            'reservation_id' => 'MISSING_EMAIL_TEST',
+            'amount' => 99.95,
+            'currency' => 'EUR',
+        ];
+        MockPhpStream::$content = wp_json_encode($payload);
+
+        $request = new WP_REST_Request('POST', '/hic/v1/conversion');
+        $request->set_param('token', 'secret');
+        $request->set_header('content-type', 'application/json');
+
+        $response = null;
+
+        try {
+            $response = hic_webhook_handler($request);
+        } finally {
+            stream_wrapper_restore('php');
+            unset($GLOBALS['hic_test_filters']['hic_log_message']);
+        }
+
+        if (file_exists($logFile)) {
+            unlink($logFile);
+        }
+
+        $this->assertIsArray($response);
+        $this->assertSame('ok', $response['status']);
+        $this->assertArrayHasKey('processed', $response);
+        $this->assertFalse($response['processed']);
+        $this->assertSame('missing_email', $response['reason']);
+
+        $logFound = false;
+        foreach ($capturedLogs as $entry) {
+            if (strpos($entry, 'hic_process_booking_data: campo obbligatorio mancante - email') !== false) {
+                $logFound = true;
+                break;
+            }
+        }
+
+        $this->assertTrue($logFound, 'hic_process_booking_data should log missing email when email is absent.');
+    }
+
 }


### PR DESCRIPTION
## Summary
- allow `HIC_Input_Validator::validate_reservation_data()` and `hic_validate_webhook_payload()` to accept payloads without an email address while still validating non-empty values
- update the webhook route/handler to treat the email argument as optional, reuse validated request emails only when valid, and return a 200 status with a reason when the processor runs without an email
- expand the webhook tests to cover optional email handling and add a new missing-email scenario that confirms `hic_process_booking_data()` is invoked

## Testing
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/WebhookInvalidJsonTest.php`

------
https://chatgpt.com/codex/tasks/task_e_68d1309fdba4832f961538562caab82b