### PR TITLE
Use namespaced HIC_Booking_Poller references

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -3,6 +3,7 @@
  * HIC Plugin Diagnostics and Monitoring
  */
 
+use FpHic\HIC_Booking_Poller;
 use function FpHic\hic_send_to_ga4;
 use function FpHic\hic_send_to_gtm_datalayer;
 use function FpHic\hic_send_to_fb;
@@ -69,7 +70,7 @@ function hic_get_internal_scheduler_status() {
         hic_has_basic_auth_credentials();
     
     // Get stats from WP-Cron scheduler if available
-    if (class_exists('HIC_Booking_Poller')) {
+    if (class_exists(HIC_Booking_Poller::class)) {
         $poller = new HIC_Booking_Poller();
         $poller_stats = $poller->get_stats();
         
@@ -342,7 +343,7 @@ function hic_force_restart_internal_scheduler() {
         $results['polling_timestamps_reset'] = 'Timestamps reset for immediate execution';
         
         // Clear and reschedule WP-Cron events for fresh start
-        if (class_exists('HIC_Booking_Poller')) {
+        if (class_exists(HIC_Booking_Poller::class)) {
             $poller = new HIC_Booking_Poller();
             $poller->clear_all_scheduled_events();
             
@@ -377,7 +378,7 @@ function hic_trigger_watchdog_check() {
     
     $results = array();
     
-    if (class_exists('HIC_Booking_Poller')) {
+    if (class_exists(HIC_Booking_Poller::class)) {
         $poller = new HIC_Booking_Poller();
         $poller->run_watchdog_check();
         $results['watchdog_executed'] = 'Watchdog check completed';
@@ -996,7 +997,7 @@ function hic_ajax_force_polling() {
         $force = isset($_POST['force']) && wp_unslash( $_POST['force'] ) === 'true';
 
         // Check if poller class exists
-        if (!class_exists('HIC_Booking_Poller')) {
+        if (!class_exists(HIC_Booking_Poller::class)) {
             wp_send_json_error( [ 'message' => __( 'Classe HIC_Booking_Poller non trovata', 'hotel-in-cloud' ) ] );
         }
 
@@ -1099,7 +1100,7 @@ function hic_ajax_reset_timestamps() {
         hic_log('Admin Timestamp Reset: Manual timestamp reset initiated');
 
         // Execute timestamp recovery using the new method
-        if (class_exists('HIC_Booking_Poller')) {
+        if (class_exists(HIC_Booking_Poller::class)) {
             $poller = new HIC_Booking_Poller();
 
             // Check if the method exists
@@ -1273,7 +1274,7 @@ function hic_diagnostics_page() {
                         <h3>🌐 Monitoraggio Traffico Web</h3>
                         <?php
                         // Get web traffic monitoring statistics 
-                        $poller = new \FpHic\HIC_Booking_Poller();
+                        $poller = new HIC_Booking_Poller();
                         $web_stats = $poller->get_web_traffic_stats();
                         ?>
                         <table class="hic-status-table">
@@ -1785,7 +1786,7 @@ function hic_ajax_test_web_traffic_monitoring() {
         hic_log('Manual Web Traffic Test: Starting manual web traffic monitoring test');
         
         // Simulate web traffic polling checks
-        $poller = new \FpHic\HIC_Booking_Poller();
+        $poller = new HIC_Booking_Poller();
         
         // Record current state
         $current_time = time();
@@ -1837,7 +1838,7 @@ function hic_ajax_get_web_traffic_stats() {
     }
 
     try {
-        $poller = new \FpHic\HIC_Booking_Poller();
+        $poller = new HIC_Booking_Poller();
         $web_stats = $poller->get_web_traffic_stats();
         
         wp_send_json_success( array(

--- a/includes/cli.php
+++ b/includes/cli.php
@@ -1,4 +1,6 @@
 <?php declare(strict_types=1);
+
+use FpHic\HIC_Booking_Poller;
 use function FpHic\hic_process_booking_data;
 /**
  * WP-CLI commands for HIC Plugin
@@ -28,7 +30,7 @@ if (defined('WP_CLI') && WP_CLI) {
         public function poll($args, $assoc_args) {
             $force = isset($assoc_args['force']) && $assoc_args['force'];
             
-            if (!class_exists('HIC_Booking_Poller')) {
+            if (!class_exists(HIC_Booking_Poller::class)) {
                 WP_CLI::error('HIC_Booking_Poller class not found');
                 return;
             }
@@ -64,7 +66,7 @@ if (defined('WP_CLI') && WP_CLI) {
          * @param array $assoc_args
          */
         public function stats($args, $assoc_args) {
-            if (!class_exists('HIC_Booking_Poller')) {
+            if (!class_exists(HIC_Booking_Poller::class)) {
                 WP_CLI::error('HIC_Booking_Poller class not found');
                 return;
             }

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -1,10 +1,12 @@
 <?php declare(strict_types=1);
 /**
  * Health Monitoring System for HIC Plugin
- * 
+ *
  * Provides comprehensive health checks and monitoring capabilities
  * for the Hotel in Cloud integration plugin.
  */
+
+use FpHic\HIC_Booking_Poller;
 
 if (!defined('ABSPATH')) exit;
 
@@ -100,7 +102,7 @@ class HIC_Health_Monitor {
             'details' => [
                 'functions_loaded' => function_exists('hic_log'),
                 'constants_loaded' => defined('HIC_PLUGIN_VERSION'),
-                'classes_loaded' => class_exists('HIC_Booking_Poller')
+                'classes_loaded' => class_exists(HIC_Booking_Poller::class)
             ]
         ];
     }

--- a/tests/ApiConnectionAliasTest.php
+++ b/tests/ApiConnectionAliasTest.php
@@ -1,5 +1,7 @@
 <?php
 
+use FpHic\HIC_Booking_Poller;
+
 class ApiConnectionAliasTest extends WP_UnitTestCase {
 
     protected function setUp(): void {
@@ -51,7 +53,7 @@ class ApiConnectionAliasTest extends WP_UnitTestCase {
             'Scheduler gate should allow polling. State: ' . json_encode($state)
         );
 
-        $poller = new \FpHic\HIC_Booking_Poller();
+        $poller = new HIC_Booking_Poller();
         $stats = $poller->get_stats();
         $this->assertArrayHasKey('should_poll', $stats);
         $this->assertTrue(

--- a/tests/BookingPollerSchedulerTest.php
+++ b/tests/BookingPollerSchedulerTest.php
@@ -42,6 +42,7 @@ namespace FpHic {
 }
 
 namespace {
+    use FpHic\HIC_Booking_Poller;
     use PHPUnit\Framework\TestCase;
 
     require_once __DIR__ . '/../includes/booking-poller.php';
@@ -54,19 +55,19 @@ namespace {
         }
 
         public function test_execute_continuous_polling_calls_namespaced_function(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $poller->execute_continuous_polling();
             $this->assertContains('continuous', $GLOBALS['poll_calls']);
         }
 
         public function test_execute_deep_check_calls_namespaced_function(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $poller->execute_deep_check();
             $this->assertContains('deep', $GLOBALS['poll_calls']);
         }
 
         public function test_execute_deep_check_updates_timestamp_on_success(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             update_option('hic_last_deep_check', 0);
 
             $poller->execute_deep_check();
@@ -75,7 +76,7 @@ namespace {
         }
 
         public function test_execute_deep_check_failure_does_not_update_timestamp(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $old = time() - 100;
             update_option('hic_last_deep_check', $old);
 
@@ -87,7 +88,7 @@ namespace {
         }
 
         public function test_execute_deep_check_skipped_does_not_update_timestamp(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $old = time() - 100;
             update_option('hic_last_deep_check', $old);
 
@@ -99,7 +100,7 @@ namespace {
         }
 
         public function test_execute_deep_check_exception_is_handled(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             update_option('hic_deep_check_failures', 0);
 
             $GLOBALS['simulate_deep_exception'] = true;
@@ -111,7 +112,7 @@ namespace {
         }
 
         public function test_deep_check_recovers_after_exception(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             update_option('hic_deep_check_failures', 0);
             update_option('hic_last_deep_check', 0);
 
@@ -126,7 +127,7 @@ namespace {
         }
 
         public function test_execute_continuous_polling_updates_timestamp_on_success(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             update_option('hic_last_continuous_poll', 0);
 
             $poller->execute_continuous_polling();
@@ -136,7 +137,7 @@ namespace {
         }
 
         public function test_execute_continuous_polling_skipped_does_not_update_timestamp(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $old = time() - 100;
             $old_success = time() - 50;
             update_option('hic_last_continuous_poll', $old);
@@ -151,7 +152,7 @@ namespace {
         }
 
         public function test_execute_continuous_polling_exception_is_handled(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             update_option('hic_continuous_poll_failures', 0);
             update_option('hic_last_continuous_poll', 0);
             update_option('hic_last_successful_poll', 0);
@@ -165,7 +166,7 @@ namespace {
         }
 
         public function test_continuous_polling_recovers_after_exception(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             update_option('hic_continuous_poll_failures', 0);
             update_option('hic_last_continuous_poll', 0);
             update_option('hic_last_successful_poll', 0);
@@ -182,7 +183,7 @@ namespace {
         }
 
         public function test_watchdog_detects_polling_failure(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $old = time() - (HIC_WATCHDOG_THRESHOLD + 10);
             $old_success = time();
             update_option('hic_last_continuous_poll', $old);
@@ -204,7 +205,7 @@ namespace {
         }
 
         public function test_watchdog_not_blocked_with_deep_check_only(): void {
-            $poller = new \HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $sentinel = 123;
             update_option('hic_last_updates_since', $sentinel);
             update_option('hic_last_successful_poll', time() - 7200);

--- a/tests/SelfHealingRecoveryTest.php
+++ b/tests/SelfHealingRecoveryTest.php
@@ -1,5 +1,6 @@
 <?php
 namespace {
+    use FpHic\HIC_Booking_Poller;
     use PHPUnit\Framework\TestCase;
 
     require_once __DIR__ . '/../includes/booking-poller.php';
@@ -67,7 +68,7 @@ namespace {
         public function test_recovery_schedules_cleanup_events_with_daily_recurrence(): void {
             global $recovery_log_messages, $wp_scheduled_events;
 
-            $poller = new \FpHic\HIC_Booking_Poller();
+            $poller = new HIC_Booking_Poller();
             $poller->execute_self_healing_recovery();
 
             $cleanupEvents = array_values(array_filter(

--- a/tests/WebTrafficMonitoringTest.php
+++ b/tests/WebTrafficMonitoringTest.php
@@ -83,6 +83,7 @@ if (!function_exists('wp_doing_ajax')) {
 // Include required constants and helpers - carefully
 require_once __DIR__ . '/../includes/constants.php';
 
+use FpHic\HIC_Booking_Poller;
 use PHPUnit\Framework\TestCase;
 
 class WebTrafficMonitoringTest extends TestCase {
@@ -112,7 +113,7 @@ class WebTrafficMonitoringTest extends TestCase {
         require_once __DIR__ . '/../includes/booking-poller.php';
         
         // Initialize the booking poller
-        $this->poller = new \FpHic\HIC_Booking_Poller();
+        $this->poller = new HIC_Booking_Poller();
         
         // Start with clean state
         $this->original_stats = array();


### PR DESCRIPTION
## Summary
- import the namespaced booking poller in CLI, diagnostics, and health monitor and update class checks to use `::class`
- instantiate the poller through the imported class in diagnostics and associated AJAX handlers
- align test suites with the namespaced poller by importing it instead of referencing the global symbol

## Testing
- composer test *(fails: suite depends on WordPress test helpers that are not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d13d5f2c88832fa70778d30fa1ab22