### PR TITLE
Improve export download path resolution

### DIFF
--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -1138,9 +1138,24 @@ class AutomatedReportingManager {
             wp_send_json_error('Insufficient permissions');
         }
 
+        $base_path = realpath($this->export_dir);
+
+        if ($base_path === false) {
+            $this->log('Export directory missing or inaccessible: ' . $this->export_dir);
+            wp_die('File not found');
+        }
+
         $filepath = realpath($this->export_dir . $filename);
 
-        if (!$filepath || strpos($filepath, realpath($this->export_dir)) !== 0 || !file_exists($filepath)) {
+        if ($filepath === false) {
+            $this->log('Requested export file could not be resolved: ' . $filename);
+            wp_die('File not found');
+        }
+
+        $base_prefix = rtrim($base_path, DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+
+        if (strpos($filepath, $base_prefix) !== 0 || !file_exists($filepath)) {
+            $this->log('Blocked export download outside export directory: ' . $filepath);
             wp_die('File not found');
         }
 

--- a/tests/AutomatedReportingDownloadTest.php
+++ b/tests/AutomatedReportingDownloadTest.php
@@ -1,0 +1,82 @@
+<?php declare(strict_types=1);
+
+namespace {
+
+use PHPUnit\Framework\TestCase;
+
+require_once __DIR__ . '/bootstrap.php';
+
+if (!function_exists('wp_upload_dir')) {
+    function wp_upload_dir($path = null) {
+        return ['basedir' => sys_get_temp_dir(), 'baseurl' => ''];
+    }
+}
+
+if (!function_exists('sanitize_file_name')) {
+    function sanitize_file_name($filename) {
+        $sanitized = preg_replace('/[^A-Za-z0-9.\-_]/', '', (string) $filename);
+        return is_string($sanitized) ? $sanitized : '';
+    }
+}
+
+if (!function_exists('check_ajax_referer')) {
+    function check_ajax_referer($action, $arg = false, $die = true) {
+        return true;
+    }
+}
+
+if (!function_exists('wp_die')) {
+    function wp_die($message) {
+        throw new \Exception($message);
+    }
+}
+
+require_once __DIR__ . '/../includes/automated-reporting.php';
+
+final class AutomatedReportingDownloadTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        $this->resetManagerInstance();
+        $_GET = [];
+    }
+
+    protected function tearDown(): void
+    {
+        $this->resetManagerInstance();
+        $_GET = [];
+    }
+
+    public function test_handle_download_export_with_missing_directory_returns_error(): void
+    {
+        $_GET['file'] = 'report.csv';
+        $_GET['nonce'] = 'valid';
+
+        $manager = \FpHic\AutomatedReporting\AutomatedReportingManager::instance();
+
+        $missingExportDir = sys_get_temp_dir() . '/hic-missing-' . uniqid('', true) . DIRECTORY_SEPARATOR;
+        $managerReflection = new \ReflectionClass($manager);
+        $exportDirProperty = $managerReflection->getProperty('export_dir');
+        $exportDirProperty->setAccessible(true);
+        $exportDirProperty->setValue($manager, $missingExportDir);
+
+        try {
+            $manager->handle_download_export();
+            $this->fail('Expected wp_die to be triggered for missing export directory.');
+        } catch (\Throwable $exception) {
+            $this->assertSame('File not found', $exception->getMessage());
+        }
+    }
+
+    private function resetManagerInstance(): void
+    {
+        $managerReflection = new \ReflectionClass(\FpHic\AutomatedReporting\AutomatedReportingManager::class);
+        if ($managerReflection->hasProperty('instance')) {
+            $property = $managerReflection->getProperty('instance');
+            $property->setAccessible(true);
+            $property->setValue(null, null);
+        }
+    }
+}
+
+}


### PR DESCRIPTION
## Summary
- resolve the export directory once during download requests and bail gracefully when the directory or file cannot be resolved
- ensure the export download check compares canonical paths with a directory separator so traversal attempts are blocked
- add a PHPUnit test covering the missing export directory scenario for `AutomatedReportingManager::handle_download_export`

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter AutomatedReportingDownloadTest


------
https://chatgpt.com/codex/tasks/task_e_68d147deabf0832f8757a54745ce8367