### PR TITLE
Refactor booking processor result handling

### DIFF
--- a/demo-without-enhanced.php
+++ b/demo-without-enhanced.php
@@ -56,22 +56,38 @@ namespace FpHic\Helpers {
 
 namespace FpHic {
     // Mock booking processor function
-    function hic_process_booking_data(array $data): bool {
+    function hic_process_booking_data(array $data): array {
         echo "📦 Processing booking data...\n";
-        
+
         // Basic validation
         if (empty($data['email']) || !\FpHic\Helpers\hic_is_valid_email($data['email'])) {
             echo "❌ Invalid email\n";
-            return false;
+            return [
+                'status' => 'failed',
+                'should_mark_processed' => false,
+                'integrations' => [],
+                'successful_integrations' => [],
+                'failed_integrations' => [],
+                'messages' => ['invalid_email'],
+            ];
         }
-        
+
         echo "✅ Email valid: {$data['email']}\n";
         echo "✅ Amount: €{$data['amount']}\n";
-        
+
         // Mock sending to integrations
         \hic_send_to_ga4($data, null, null, null, null, null, null, null);
-        
-        return true;
+
+        return [
+            'status' => 'success',
+            'should_mark_processed' => true,
+            'integrations' => [
+                'GA4' => ['status' => 'success'],
+            ],
+            'successful_integrations' => ['GA4'],
+            'failed_integrations' => [],
+            'messages' => [],
+        ];
     }
 }
 

--- a/tests/BookingProcessorErrorHandlingTest.php
+++ b/tests/BookingProcessorErrorHandlingTest.php
@@ -93,7 +93,9 @@ final class BookingProcessorErrorHandlingTest extends TestCase
 
         $result = \FpHic\hic_process_booking_data($bookingData);
 
-        $this->assertFalse($result, 'Booking processing should fail gracefully when GA4 throws');
+        $this->assertIsArray($result, 'Booking processing should return structured result on failure');
+        $this->assertSame('failed', $result['status'], 'Booking processing should report failure when GA4 throws');
+        $this->assertTrue(empty($result['should_mark_processed']), 'Failed bookings should not be marked as processed');
 
         $this->assertFileExists($this->logFile);
         $logContents = file_get_contents($this->logFile);

--- a/tests/BookingProcessorRefundTrackingTest.php
+++ b/tests/BookingProcessorRefundTrackingTest.php
@@ -51,12 +51,16 @@ final class BookingProcessorRefundTrackingTest extends TestCase
 
         $result = \FpHic\hic_process_booking_data($bookingData);
 
-        $this->assertTrue($result, 'Refund processing should succeed when tracking is disabled');
+        $this->assertIsArray($result, 'Refund processing should return structured result');
+        $this->assertSame('success', $result['status'], 'Refund processing should report success when tracking is disabled');
+        $this->assertTrue(!empty($result['should_mark_processed']), 'Refund bookings should be marked as processed when tracking is disabled');
+        $this->assertEmpty($result['failed_integrations'], 'No integrations should fail when refund tracking is disabled');
 
         $this->assertFileExists($this->logFile);
         $logContents = file_get_contents($this->logFile);
         $this->assertIsString($logContents);
         $this->assertStringContainsString('refund detected but tracking disabled, skipping refund events', $logContents);
-        $this->assertStringContainsString('Successi: 0, Errori: 0', $logContents);
+        $this->assertStringContainsString('Stato: success', $logContents);
+        $this->assertStringContainsString('refund tracking disabled', $logContents);
     }
 }

--- a/tests/BookingProcessorSkipFilterTest.php
+++ b/tests/BookingProcessorSkipFilterTest.php
@@ -55,12 +55,16 @@ final class BookingProcessorSkipFilterTest extends TestCase
 
         $result = \FpHic\hic_process_booking_data($bookingData);
 
-        $this->assertTrue($result, 'Expected booking processing to return true when tracking is skipped');
+        $this->assertIsArray($result, 'Expected structured result for skipped bookings');
+        $this->assertSame('success', $result['status'], 'Skipping tracking should not produce a failure status');
+        $this->assertTrue(!empty($result['should_mark_processed']), 'Skipped bookings should still be marked as processed');
+        $this->assertContains('tracking_skipped', $result['messages'], 'Tracking skip should be noted in result messages');
 
         $this->assertFileExists($this->logFile);
         $logContents = file_get_contents($this->logFile);
         $this->assertIsString($logContents);
         $this->assertStringContainsString('tracciamento ignorato da hic_should_track_reservation', $logContents);
-        $this->assertStringContainsString('Skippate: 1', $logContents);
+        $this->assertStringContainsString('Stato: success', $logContents);
+        $this->assertStringContainsString('Messages: tracking_skipped', $logContents);
     }
 }

--- a/tests/CaptureTrackingParamsTest.php
+++ b/tests/CaptureTrackingParamsTest.php
@@ -323,7 +323,12 @@ final class CaptureTrackingParamsTest extends TestCase
             'reservation_id' => 'ABC123',
         ]);
 
-        $this->assertTrue($result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('status', $result);
+        $this->assertTrue(
+            in_array($result['status'], ['success', 'partial'], true),
+            'La prenotazione deve essere processata con successo o parzialmente'
+        );
         $this->assertIsArray($capturedTracking);
         $this->assertSame('booking-gclid-12345', $capturedTracking['gclid']);
         $this->assertSame($sid, $capturedTracking['sid']);

--- a/tests/HybridModeTest.php
+++ b/tests/HybridModeTest.php
@@ -90,11 +90,15 @@ class HybridModeTest extends WP_UnitTestCase {
 
         // Test webhook processing
         $webhook_result = \FpHic\hic_process_booking_data($booking_data);
-        $this->assertTrue(is_bool($webhook_result));
+        $this->assertIsArray($webhook_result);
+        $this->assertArrayHasKey('status', $webhook_result);
+        $this->assertTrue(in_array($webhook_result['status'], ['success', 'partial'], true));
 
         // Test API processing (stesso dato, dovrebbe essere deduplicato)
         $api_result = \FpHic\hic_process_booking_data($booking_data);
-        $this->assertTrue(is_bool($api_result));
+        $this->assertIsArray($api_result);
+        $this->assertArrayHasKey('status', $api_result);
+        $this->assertTrue(in_array($api_result['status'], ['success', 'partial'], true));
         
         // Verifica che la reservation_id sia gestita correttamente
         $reservation_id = hic_extract_reservation_id($booking_data);

--- a/tests/SystemWithoutEnhancedConversionsTest.php
+++ b/tests/SystemWithoutEnhancedConversionsTest.php
@@ -44,7 +44,7 @@ class SystemWithoutEnhancedConversionsTest extends \PHPUnit\Framework\TestCase
         $output = ob_get_clean();
 
         // Test should not fail due to missing enhanced conversions
-        $this->assertIsBool($result, 'hic_process_booking_data deve restituire un boolean');
+        $this->assertBookingResultSuccessful($result, 'hic_process_booking_data deve restituire un risultato di successo');
         
         // Check no fatal errors occurred
         $this->assertStringNotContainsString(
@@ -80,7 +80,7 @@ class SystemWithoutEnhancedConversionsTest extends \PHPUnit\Framework\TestCase
             $result = \FpHic\hic_process_booking_data($booking_data);
             $output = ob_get_clean();
 
-            $this->assertIsBool(
+            $this->assertBookingResultSuccessful(
                 $result,
                 "Il sistema deve funzionare in modalità {$description} senza Google Ads Enhanced"
             );
@@ -131,7 +131,7 @@ class SystemWithoutEnhancedConversionsTest extends \PHPUnit\Framework\TestCase
         $result = \FpHic\hic_process_booking_data($booking_data);
         $output = ob_get_clean();
 
-        $this->assertIsBool(
+        $this->assertBookingResultSuccessful(
             $result,
             'Il sistema deve funzionare anche con GCLID presente ma Enhanced Conversions disabilitato'
         );
@@ -218,6 +218,25 @@ class SystemWithoutEnhancedConversionsTest extends \PHPUnit\Framework\TestCase
                 $value,
                 $retrieved,
                 "L'impostazione {$option} deve essere configurabile senza Enhanced Conversions"
+            );
+        }
+    }
+
+    private function assertBookingResultSuccessful($result, string $message = ''): void
+    {
+        $contextMessage = $message !== '' ? $message : 'Il risultato della prenotazione deve indicare successo o parziale successo';
+
+        $this->assertIsArray($result, $contextMessage);
+        $this->assertArrayHasKey('status', $result, 'Il risultato deve includere lo stato');
+        $this->assertTrue(
+            in_array($result['status'], ['success', 'partial'], true),
+            $contextMessage
+        );
+
+        if (array_key_exists('should_mark_processed', $result)) {
+            $this->assertTrue(
+                (bool) $result['should_mark_processed'],
+                'Le prenotazioni elaborate con successo devono essere segnate come processate'
             );
         }
     }

--- a/tests/WebhookConversionTrackingTest.php
+++ b/tests/WebhookConversionTrackingTest.php
@@ -126,9 +126,11 @@ class WebhookConversionTrackingTest extends WP_UnitTestCase {
 
         // Il webhook processing dovrebbe funzionare senza problemi
         $result = \FpHic\hic_process_booking_data($booking_data);
-        
+
         // Il processo non dovrebbe fallire per mancanza di redirect
-        $this->assertTrue(is_bool($result));
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('status', $result);
+        $this->assertTrue(in_array($result['status'], ['success', 'partial'], true));
         
         // Verifica che l'ID prenotazione sia estratto correttamente
         $reservation_id = hic_extract_reservation_id($booking_data);
@@ -152,7 +154,9 @@ class WebhookConversionTrackingTest extends WP_UnitTestCase {
         $this->assertSame(strtoupper($currency), $validated['currency']);
 
         $result = \FpHic\hic_process_booking_data($validated);
-        $this->assertIsBool($result);
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('status', $result);
+        $this->assertTrue(in_array($result['status'], ['success', 'partial'], true));
     }
 
     public static function extendedIsoCurrencyProvider(): array {
@@ -402,7 +406,9 @@ class WebhookConversionTrackingTest extends WP_UnitTestCase {
         $this->assertSame('alias-sid-123456', $validated['sid']);
 
         $result = \FpHic\hic_process_booking_data($validated);
-        $this->assertTrue(is_bool($result));
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('status', $result);
+        $this->assertTrue(in_array($result['status'], ['success', 'partial'], true));
         $this->assertNotNull($capturedTracking);
         $this->assertSame('alias-sid-123456', $capturedTracking['sid']);
         $this->assertSame('test-gclid-alias', $capturedTracking['gclid']);


### PR DESCRIPTION
## Summary
- refactor the booking processor to return structured integration results, aggregate per-integration statuses, and emit detailed logging
- update helper utilities, the webhook handler, CLI, and admin diagnostics to consume the structured result format and queue targeted retries for failed integrations
- refresh demo and PHPUnit coverage, including a regression test for partial-success webhook processing and adjustments for the new result shape

## Testing
- composer test *(fails: WordPress test scaffolding not available in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d14bde0fd8832fb9a3f446355c6f14