### PR TITLE
Fix misuse of wpdb->prepare in reporting and health diagnostics

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -138,12 +138,14 @@ function hic_get_internal_scheduler_status() {
     
     // Real-time sync stats (keep existing functionality)  
     $realtime_table = $wpdb->prefix . 'hic_realtime_sync';
+    $escaped_realtime_table = esc_sql($realtime_table);
+    $realtime_table_sql = "`{$escaped_realtime_table}`";
     if ($wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $realtime_table)) === $realtime_table) {
-        $status['realtime_sync']['total_tracked'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . esc_sql($realtime_table)));
-        $status['realtime_sync']['notified'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . esc_sql($realtime_table) . " WHERE sync_status = %s", 'notified'));
-        $status['realtime_sync']['failed'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . esc_sql($realtime_table) . " WHERE sync_status = %s", 'failed'));
-        $status['realtime_sync']['permanent_failure'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . esc_sql($realtime_table) . " WHERE sync_status = %s", 'permanent_failure'));
-        $status['realtime_sync']['new'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . esc_sql($realtime_table) . " WHERE sync_status = %s", 'new'));
+        $status['realtime_sync']['total_tracked'] = $wpdb->get_var("SELECT COUNT(*) FROM {$realtime_table_sql}");
+        $status['realtime_sync']['notified'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$realtime_table_sql} WHERE sync_status = %s", 'notified'));
+        $status['realtime_sync']['failed'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$realtime_table_sql} WHERE sync_status = %s", 'failed'));
+        $status['realtime_sync']['permanent_failure'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$realtime_table_sql} WHERE sync_status = %s", 'permanent_failure'));
+        $status['realtime_sync']['new'] = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM {$realtime_table_sql} WHERE sync_status = %s", 'new'));
     } else {
         $status['realtime_sync']['table_exists'] = false;
     }

--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -1172,10 +1172,10 @@ class AutomatedReportingManager {
     private function get_raw_data_for_period($period) {
         global $wpdb;
         
-        $main_table = $wpdb->prefix . 'hic_gclids';
+        $table_name = \esc_sql($wpdb->prefix . 'hic_gclids');
         $date_condition = $this->get_date_condition_for_period($period);
-        
-        return $wpdb->get_results($wpdb->prepare("
+
+        $sql = "
             SELECT
                 id,
                 gclid,
@@ -1191,10 +1191,12 @@ class AutomatedReportingManager {
                 utm_content,
                 utm_term,
                 created_at
-            FROM {$main_table} 
+            FROM `{$table_name}`
             WHERE {$date_condition}
             ORDER BY created_at DESC
-        "), ARRAY_A);
+        ";
+
+        return $wpdb->get_results($sql, ARRAY_A);
     }
     
     /**

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -317,6 +317,8 @@ class HIC_Health_Monitor {
         global $wpdb;
         
         $table_name = $wpdb->prefix . 'hic_sid_gclid_mapping';
+        $escaped_table_name = esc_sql($table_name);
+        $table_sql = "`{$escaped_table_name}`";
         $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table_name)) === $table_name;
         
         if (!$table_exists) {
@@ -327,7 +329,7 @@ class HIC_Health_Monitor {
             ];
         }
         
-        $row_count = $wpdb->get_var($wpdb->prepare("SELECT COUNT(*) FROM " . esc_sql($table_name)));
+        $row_count = $wpdb->get_var("SELECT COUNT(*) FROM {$table_sql}");
         
         return [
             'status' => 'pass',


### PR DESCRIPTION
## Summary
- replace the static raw export query with a literal SQL string that escapes the table name before executing
- sanitize the realtime sync table name and use direct/parameterized queries appropriately in diagnostics
- run the health monitor database count with a sanitized identifier instead of a placeholder-less prepare()

## Testing
- composer test *(fails: relies on WordPress test doubles that are not available in this environment)*
- temporary PHP harnesses to confirm reporting exports, diagnostics, and health database checks execute without `_doing_it_wrong` warnings under `WP_DEBUG`


------
https://chatgpt.com/codex/tasks/task_e_68d15a4401ac832fa07e29fcedc625eb