### PR TITLE
Preserve setup wizard password characters

### DIFF
--- a/includes/enterprise-management-suite.php
+++ b/includes/enterprise-management-suite.php
@@ -979,12 +979,24 @@ class EnterpriseManagementSuite {
      * Save HIC credentials
      */
     private function save_hic_credentials() {
+        $raw_password = $_POST['password'] ?? '';
+
+        if (\function_exists('\\hic_preserve_password_field')) {
+            $password = \hic_preserve_password_field($raw_password);
+        } else {
+            if (\is_array($raw_password) || \is_object($raw_password) || $raw_password === null) {
+                $password = '';
+            } else {
+                $password = \wp_unslash((string) $raw_password);
+            }
+        }
+
         $settings = [
             'prop_id' => sanitize_text_field($_POST['prop_id'] ?? ''),
             'email' => sanitize_email($_POST['email'] ?? ''),
-            'password' => sanitize_text_field($_POST['password'] ?? '')
+            'password' => $password
         ];
-        
+
         update_option('hic_settings', $settings);
     }
     


### PR DESCRIPTION
## Summary
- reuse the admin password sanitizer when saving setup wizard credentials so special characters persist
- fall back to the same unslash-and-cast logic if the helper is unavailable while keeping prop/email sanitization unchanged

## Testing
- composer test *(fails: WordPress test dependencies such as rest_get_server() are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d161433698832f95fa29918ec1d0b4