### PR TITLE
Store all reservation ID aliases for deduplication

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -1008,21 +1008,26 @@ function hic_dispatch_reservation($transformed, $original) {
  */
 
 function hic_mark_reservation_processed($reservation) {
-    $uid = Helpers\hic_booking_uid($reservation);
-    if (empty($uid)) return;
-    
-    $synced = get_option('hic_synced_res_ids', array());
-    if (!in_array($uid, $synced)) {
-        $synced[] = $uid;
-        
-        // Keep only last 10k entries (FIFO)
-        if (count($synced) > 10000) {
-            $synced = array_slice($synced, -10000);
+    if (!is_array($reservation)) {
+        $uid = Helpers\hic_booking_uid($reservation);
+        if ($uid === '') {
+            return;
         }
-        
-        update_option('hic_synced_res_ids', $synced, false); // autoload=false
-        Helpers\hic_clear_option_cache('hic_synced_res_ids');
+
+        Helpers\hic_mark_reservation_processed_by_id($uid);
+        return;
     }
+
+    $ids = Helpers\hic_collect_reservation_ids($reservation);
+    if (empty($ids)) {
+        $uid = Helpers\hic_booking_uid($reservation);
+        if ($uid === '') {
+            return;
+        }
+        $ids = array($uid);
+    }
+
+    Helpers\hic_mark_reservation_processed_by_id($ids);
 }
 
 // Wrapper function - now simplified to use continuous polling by default

--- a/tests/WebhookInvalidJsonTest.php
+++ b/tests/WebhookInvalidJsonTest.php
@@ -217,7 +217,7 @@ final class WebhookInvalidJsonTest extends TestCase {
 
         $synced = get_option('hic_synced_res_ids', []);
         $this->assertIsArray($synced);
-        $this->assertContains('MISSING_EMAIL_TEST', $synced, 'Reservation should be marked as processed even without email.');
+        $this->assertArrayHasKey('MISSING_EMAIL_TEST', $synced, 'Reservation should be marked as processed even without email.');
 
         $logFound = false;
         foreach ($capturedLogs as $entry) {

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -207,6 +207,11 @@ if (!function_exists('wp_safe_remote_request')) {
         global $hic_last_request, $hic_test_http_error, $hic_test_http_error_urls, $hic_test_http_mock;
         $hic_last_request = ['url' => $url, 'args' => $args];
 
+        $preempt = apply_filters('pre_http_request', false, $args, $url);
+        if ($preempt !== false) {
+            return $preempt;
+        }
+
         if (isset($hic_test_http_mock) && is_callable($hic_test_http_mock)) {
             $mock_response = call_user_func($hic_test_http_mock, $url, $args);
             if ($mock_response !== null) {

--- a/tests/preload.php
+++ b/tests/preload.php
@@ -20,6 +20,29 @@ if (!function_exists('add_filter')) {
         ];
     }
 }
+if (!function_exists('remove_filter')) {
+    function remove_filter($hook, $callback, $priority = 10) {
+        if (empty($GLOBALS['hic_test_filters'][$hook][$priority])) {
+            return false;
+        }
+
+        foreach ($GLOBALS['hic_test_filters'][$hook][$priority] as $index => $cb) {
+            if ($cb['function'] === $callback) {
+                unset($GLOBALS['hic_test_filters'][$hook][$priority][$index]);
+            }
+        }
+
+        if (empty($GLOBALS['hic_test_filters'][$hook][$priority])) {
+            unset($GLOBALS['hic_test_filters'][$hook][$priority]);
+        }
+
+        if (empty($GLOBALS['hic_test_filters'][$hook])) {
+            unset($GLOBALS['hic_test_filters'][$hook]);
+        }
+
+        return true;
+    }
+}
 if (!function_exists('apply_filters')) {
     function apply_filters($hook, $value, ...$args) {
         if (empty($GLOBALS['hic_test_filters'][$hook])) {
@@ -86,6 +109,15 @@ if (!function_exists('do_action')) {
 }
 if (!function_exists('wp_doing_cron')) { function wp_doing_cron() { return defined('HIC_TEST_DOING_CRON') && HIC_TEST_DOING_CRON; } }
 if (!function_exists('is_ssl')) { function is_ssl() { return false; } }
+if (!function_exists('home_url')) {
+    function home_url($path = '') {
+        if (!is_string($path)) {
+            $path = '';
+        }
+
+        return 'https://example.com' . $path;
+    }
+}
 if (!function_exists('wp_unslash')) { function wp_unslash($value) { return $value; } }
 if (!function_exists('is_wp_error')) { function is_wp_error($thing) { return $thing instanceof \WP_Error; } }
 if (!function_exists('wp_error')) { function wp_error($code = '', $message = '', $data = null) { return new \WP_Error($code, $message, $data); } }
@@ -172,6 +204,18 @@ if (!function_exists('sanitize_text_field')) {
         }
 
         return trim($value);
+    }
+}
+if (!function_exists('sanitize_key')) {
+    function sanitize_key($key) {
+        if (!is_scalar($key)) {
+            return '';
+        }
+
+        $key = strtolower((string) $key);
+        $key = preg_replace('/[^a-z0-9_]/', '', $key);
+
+        return $key ?? '';
     }
 }
 if (!function_exists('wp_date')) {


### PR DESCRIPTION
## Summary
- collect every reservation identifier alias and normalize the deduplication option into an associative set for O(1) lookups
- update polling and webhook flows to persist every sanitized alias when marking a booking as processed
- expand regression coverage and test stubs so alias changes are skipped and WordPress helpers used in tests are available

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/ReservationCodeDeduplicationTest.php
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/WebhookInvalidJsonTest.php
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit *(fails: numerous WordPress/database stubs missing in test harness)*

------
https://chatgpt.com/codex/tasks/task_e_68d16a9473b8832fb4b0092ce1d17768