### PR TITLE
Normalize reservation identifiers across deduplication

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -432,8 +432,7 @@ function hic_should_process_reservation($reservation) {
         ? Helpers\hic_collect_reservation_ids($reservation)
         : array();
     if (empty($aliases) && $uid !== '') {
-        $sanitized_uid = \sanitize_text_field((string) $uid);
-        $sanitized_uid = trim($sanitized_uid);
+        $sanitized_uid = Helpers\hic_normalize_reservation_id((string) $uid);
         if ($sanitized_uid !== '') {
             $aliases[] = $sanitized_uid;
         }


### PR DESCRIPTION
## Summary
- add a shared `hic_normalize_reservation_id()` helper and apply it when collecting, storing, and checking processed reservation identifiers so the cache always uses canonical casing
- collapse mixed-case duplicates when rebuilding the processed identifier set and normalize the polling fallback UID path
- extend the webhook deduplication test suite with an uppercase/lowercase scenario to ensure mixed-case payloads are skipped after the first dispatch

## Testing
- `composer test` *(fails in this environment because the WordPress test doubles do not provide full database and REST helpers)*
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter ReservationCodeDeduplicationTest`


------
https://chatgpt.com/codex/tasks/task_e_68d17b091540832fbb03892a5ae732bd