### PR TITLE
Persist dedup aliases when skipping processed reservations

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -471,6 +471,7 @@ function hic_should_process_reservation($reservation) {
                 return true;
             }
         }
+        Helpers\hic_mark_reservation_processed_by_id($aliases);
         hic_log("Reservation $log_uid already processed, skipping");
         return false;
     }
@@ -1348,6 +1349,7 @@ function hic_process_reservations_batch($reservations) {
                         continue;
                     }
                 }
+                Helpers\hic_mark_reservation_processed_by_id($aliases);
                 $skipped_count++;
                 hic_log("Reservation $dedup_uid: skipped (already processed)");
                 continue;

--- a/includes/api/webhook.php
+++ b/includes/api/webhook.php
@@ -124,6 +124,7 @@ function hic_webhook_handler(WP_REST_Request $request) {
 
   // Check for duplication to prevent double processing
   if (!empty($reservation_ids) && hic_is_reservation_already_processed($reservation_ids)) {
+    hic_mark_reservation_processed_by_id($reservation_ids);
     $log_id = $reservation_id !== '' ? $reservation_id : implode(', ', $reservation_ids);
     hic_log("Webhook skipped: reservation $log_id already processed");
     return ['status'=>'ok', 'processed' => false, 'reason' => 'already_processed'];


### PR DESCRIPTION
## Summary
- mark duplicate reservations as processed when skipping them in polling and webhook handlers so new aliases are retained
- add regression coverage ensuring duplicate batches persist aliases discovered in follow-up payloads

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/ReservationCodeDeduplicationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d183a99634832f8b3143871e44ee84