### PR TITLE
Ensure status update processing caches new aliases

### DIFF
--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -467,6 +467,7 @@ function hic_should_process_reservation($reservation) {
         if (Helpers\hic_allow_status_updates()) {
             $presence = $reservation['presence'] ?? '';
             if (in_array($presence, ['arrived', 'departed'])) {
+                Helpers\hic_mark_reservation_processed_by_id($aliases);
                 hic_log("Reservation $log_uid: status update allowed for presence=$presence");
                 return true;
             }
@@ -1341,6 +1342,10 @@ function hic_process_reservations_batch($reservations) {
                                     hic_log("Reservation $dedup_uid: status update processed with partial failures$failed_message", HIC_LOG_LEVEL_WARNING);
                                 } else {
                                     hic_log("Reservation $dedup_uid: status update processed");
+                                }
+
+                                if ($status_value === 'success' || ($status_value === 'partial' && !empty($status_result['should_mark_processed']))) {
+                                    hic_mark_reservation_processed($reservation);
                                 }
                             }
                         } finally {


### PR DESCRIPTION
## Summary
- mark status-update payloads as processed when they pass the arrived/departed filter so all aliases are cached
- persist deduplication aliases after successful or partially successful status-update dispatches
- cover status-update alias learning in ReservationCodeDeduplicationTest

## Testing
- composer test -- --filter ReservationCodeDeduplicationTest

------
https://chatgpt.com/codex/tasks/task_e_68d188f6e1c0832fbea25280067f1edc