### PR TITLE
Normalize real-time reservation IDs

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -118,4 +118,4 @@ define('HIC_PLUGIN_VERSION', '3.1.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
 define('HIC_MIN_WP_VERSION', '5.0');
-define('HIC_DB_VERSION', '1.6');
+define('HIC_DB_VERSION', '1.7');

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -853,8 +853,16 @@ function hic_send_unified_brevo_events($data, $gclid, $fbclid, $msclkid = '', $t
 
   // Send event for new reservations, allowing override via filter
   $event_sent = false;
-  $reservation_id = Helpers\hic_extract_reservation_id($data);
-  if (!empty($reservation_id)) {
+  $reservation_id = '';
+  $raw_reservation_id = Helpers\hic_extract_reservation_id($data);
+  if (!empty($raw_reservation_id)) {
+    $reservation_id = Helpers\hic_normalize_reservation_id((string) $raw_reservation_id);
+    if ($reservation_id === '') {
+      hic_log('Unified Brevo: reservation ID normalization failed');
+    }
+  }
+
+  if ($reservation_id !== '') {
     $is_new = hic_is_reservation_new_for_realtime($reservation_id);
     if ($is_new) {
       $send_event = apply_filters('hic_brevo_send_event', true, $data);


### PR DESCRIPTION
## Summary
- normalize reservation IDs at the entry point of the realtime sync helpers and add a cleanup migration that reindexes legacy rows with canonical IDs
- bump the database schema version to 1.7 and reuse the new reindexer during upgrades
- normalize reservation identifiers once in polling and Brevo dispatch flows before invoking the realtime helper layer

## Testing
- composer test *(fails: WordPress test doubles such as $wpdb and REST helpers are unavailable in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d19f39d124832fa5c90c6b612ab0d2