### PR TITLE
Fix API test cache key collision and add tests

### DIFF
--- a/includes/api/polling-cache-helpers.php
+++ b/includes/api/polling-cache-helpers.php
@@ -1,0 +1,26 @@
+<?php declare(strict_types=1);
+
+namespace FpHic;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Build cache key used for API connection tests.
+ *
+ * @param string $endpoint Fully qualified API endpoint URL.
+ * @param string $email    API account email.
+ * @param string $password API account password.
+ *
+ * @return string
+ */
+if (!function_exists(__NAMESPACE__ . '\\hic_get_api_test_cache_key')) {
+    function hic_get_api_test_cache_key($endpoint, $email, $password) {
+        $endpoint_key = sprintf('api_test_%s', $endpoint);
+        $credentials_hash = md5($email . '|' . $password);
+
+        return sprintf('%s|%s', $endpoint_key, $credentials_hash);
+    }
+}
+

--- a/includes/api/polling.php
+++ b/includes/api/polling.php
@@ -9,6 +9,8 @@ use \WP_Error;
 
 if (!defined('ABSPATH')) exit;
 
+require_once __DIR__ . '/polling-cache-helpers.php';
+
 /**
  * Validate and sanitize timestamp for API requests
  * Ensures timestamp is within acceptable range for HIC API
@@ -1988,7 +1990,13 @@ if (!function_exists(__NAMESPACE__ . '\\hic_test_api_connection')) {
         $test_url = add_query_arg($test_args, $endpoint);
 
         // Check for cached response first (for test connections, cache for 5 minutes)
-        $cache_key = "api_test_$endpoint" . md5($email . $password);
+        $cache_key = hic_get_api_test_cache_key($endpoint, (string) $email, (string) $password);
+        $legacy_cache_key = "api_test_$endpoint" . md5((string) $email . (string) $password);
+
+        if ($legacy_cache_key !== $cache_key) {
+            \FpHic\HIC_Cache_Manager::delete($legacy_cache_key);
+        }
+
         $cached_response = \FpHic\HIC_Cache_Manager::get($cache_key);
 
         if ($cached_response !== null) {

--- a/tests/ApiConnectionCacheKeyTest.php
+++ b/tests/ApiConnectionCacheKeyTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+use function FpHic\hic_get_api_test_cache_key;
+
+require_once __DIR__ . '/bootstrap.php';
+require_once __DIR__ . '/../includes/api/polling-cache-helpers.php';
+
+final class ApiConnectionCacheKeyTest extends TestCase
+{
+    public function test_different_credentials_with_same_concatenation_yield_distinct_cache_keys(): void
+    {
+        $endpoint = 'https://api.example.com/reservations/property';
+
+        $emailOne = 'foo@example.com';
+        $passwordOne = 'bar';
+
+        $emailTwo = 'foo@example.co';
+        $passwordTwo = 'mbar';
+
+        // Guard: legacy cache keys would collide for these credentials.
+        $legacyKeyOne = "api_test_{$endpoint}" . md5($emailOne . $passwordOne);
+        $legacyKeyTwo = "api_test_{$endpoint}" . md5($emailTwo . $passwordTwo);
+
+        $this->assertSame($legacyKeyOne, $legacyKeyTwo);
+
+        $cacheKeyOne = hic_get_api_test_cache_key($endpoint, $emailOne, $passwordOne);
+        $cacheKeyTwo = hic_get_api_test_cache_key($endpoint, $emailTwo, $passwordTwo);
+
+        $this->assertNotSame($cacheKeyOne, $cacheKeyTwo);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a helper for building the API test cache key that hashes the credentials with an explicit separator
- switch `hic_test_api_connection()` to the new helper and clear legacy cache entries before reading
- add a PHPUnit test that proves ambiguous email/password concatenations now generate distinct cache keys

## Testing
- composer test *(fails: suite expects a full WordPress/REST environment and database access)*

------
https://chatgpt.com/codex/tasks/task_e_68d24d6519a4832f8870adcac41e2107