### PR TITLE
Handle reconciliation metrics when integrations unavailable

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -1527,8 +1527,14 @@ function hic_diagnostics_page() {
                         </div>
                     </div>
                 </div>
-                
-                <?php 
+
+                <p class="description hic-reconciliation-note">
+                    ℹ️ <strong>Riconciliazione:</strong> il controllo giornaliero confronta i dati HIC con i conteggi reali restituiti dalle API di GA4, Meta e Brevo.
+                    Finché le integrazioni non sono collegate (oppure non forniscono dati tramite i filtri <code>hic_reconciliation_*_event_count</code>)
+                    le righe della tabella verranno contrassegnate come <em>in attesa</em> senza inviare avvisi basati su valori casuali.
+                </p>
+
+                <?php
                 $downloaded_ids = hic_get_downloaded_booking_ids();
                 $downloaded_count = count($downloaded_ids);
                 ?>


### PR DESCRIPTION
## Summary
- update the enterprise reconciliation flow to skip external checks when metrics cannot be fetched and to accept real counts via new filters
- add structured metric helpers and contextual logging so GA4/Facebook/Brevo reconciliations only alert on real data
- surface the new pending behaviour inside the diagnostics screen so operators know why reconciliation is deferred

## Testing
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68d25cfdc5c8832fb7454f33e1e27628