### PR TITLE
Disable autoload for enhanced conversions queue

### DIFF
--- a/includes/google-ads-enhanced.php
+++ b/includes/google-ads-enhanced.php
@@ -641,7 +641,7 @@ class GoogleAdsEnhancedConversions {
             $queue = array_slice($queue, -1000);
         }
         
-        update_option('hic_enhanced_conversions_queue', $queue);
+        update_option('hic_enhanced_conversions_queue', $queue, false);
         
         $this->log("Queued enhanced conversion {$conversion_id} for batch upload");
     }
@@ -669,7 +669,7 @@ class GoogleAdsEnhancedConversions {
         }
         
         $batch = array_splice($queue, 0, $batch_size);
-        update_option('hic_enhanced_conversions_queue', $queue);
+        update_option('hic_enhanced_conversions_queue', $queue, false);
         
         $this->log("Processing batch of " . count($batch) . " enhanced conversions");
         

--- a/tests/EnhancedConversionsQueueAutoloadTest.php
+++ b/tests/EnhancedConversionsQueueAutoloadTest.php
@@ -1,0 +1,58 @@
+<?php declare(strict_types=1);
+
+use FpHic\GoogleAdsEnhanced\GoogleAdsEnhancedConversions;
+use PHPUnit\Framework\TestCase;
+
+if (!defined('ARRAY_A')) {
+    define('ARRAY_A', 'ARRAY_A');
+}
+
+require_once __DIR__ . '/../includes/google-ads-enhanced.php';
+
+final class EnhancedConversionsQueueAutoloadTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $hic_test_options, $hic_test_option_autoload;
+
+        $hic_test_options = [];
+        $hic_test_option_autoload = [];
+    }
+
+    public function test_queue_and_batch_updates_disable_autoload(): void
+    {
+        global $hic_test_options, $hic_test_option_autoload, $wpdb;
+
+        $wpdb = new class {
+            public string $prefix = 'wp_';
+
+            public function prepare($query, ...$args)
+            {
+                return $query;
+            }
+
+            public function get_results($query, $output = ARRAY_A)
+            {
+                return [];
+            }
+        };
+
+        $enhanced = new GoogleAdsEnhancedConversions();
+
+        $queueForBatchUpload = new ReflectionMethod($enhanced, 'queue_for_batch_upload');
+        $queueForBatchUpload->setAccessible(true);
+        $queueForBatchUpload->invoke($enhanced, 123);
+
+        $this->assertSame([123], $hic_test_options['hic_enhanced_conversions_queue']);
+        $this->assertArrayHasKey('hic_enhanced_conversions_queue', $hic_test_option_autoload);
+        $this->assertFalse($hic_test_option_autoload['hic_enhanced_conversions_queue']);
+
+        $enhanced->batch_upload_enhanced_conversions();
+
+        $this->assertSame([], $hic_test_options['hic_enhanced_conversions_queue']);
+        $this->assertArrayHasKey('hic_enhanced_conversions_queue', $hic_test_option_autoload);
+        $this->assertFalse($hic_test_option_autoload['hic_enhanced_conversions_queue']);
+    }
+}

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -19,6 +19,7 @@ if (file_exists('/tmp/wordpress-tests-lib/includes/functions.php')) {
 // Mock WordPress options handling for basic testing
 if (!function_exists('get_option')) {
     $GLOBALS['hic_test_options'] = [];
+    $GLOBALS['hic_test_option_autoload'] = [];
 
     function get_option($option, $default = false) {
         global $hic_test_options;
@@ -28,8 +29,25 @@ if (!function_exists('get_option')) {
 
 if (!function_exists('update_option')) {
     function update_option($option, $value, $autoload = null) {
-        global $hic_test_options;
+        global $hic_test_options, $hic_test_option_autoload;
+
+        if (!is_array($hic_test_option_autoload ?? null)) {
+            $hic_test_option_autoload = [];
+        }
+
         $hic_test_options[$option] = $value;
+        $hic_test_option_autoload[$option] = $autoload;
+
+        return true;
+    }
+}
+
+if (!function_exists('delete_option')) {
+    function delete_option($option) {
+        global $hic_test_options, $hic_test_option_autoload;
+
+        unset($hic_test_options[$option], $hic_test_option_autoload[$option]);
+
         return true;
     }
 }

--- a/tests/preload.php
+++ b/tests/preload.php
@@ -187,7 +187,19 @@ if (!function_exists('delete_transient')) {
     }
 }
 
-if (!function_exists('delete_option')) { function delete_option($option) { global $hic_test_options; unset($hic_test_options[$option]); return true; } }
+if (!function_exists('delete_option')) {
+    function delete_option($option) {
+        global $hic_test_options, $hic_test_option_autoload;
+
+        unset($hic_test_options[$option]);
+
+        if (is_array($hic_test_option_autoload ?? null)) {
+            unset($hic_test_option_autoload[$option]);
+        }
+
+        return true;
+    }
+}
 if (!function_exists('wp_upload_dir')) { function wp_upload_dir($path = null) { return ['basedir' => sys_get_temp_dir(), 'baseurl' => '']; } }
 if (!function_exists('plugin_basename')) { function plugin_basename($file) { return $file; } }
 if (!function_exists('sanitize_text_field')) {


### PR DESCRIPTION
## Summary
- set the enhanced conversions queue option to never autoload when enqueueing or after batch uploads
- extend the WordPress option stubs used in tests to track autoload flags and clean them up on deletion
- add a PHPUnit test that asserts the queue option keeps autoload disabled throughout its lifecycle

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter EnhancedConversionsQueueAutoloadTest

------
https://chatgpt.com/codex/tasks/task_e_68d26866dc84832f8439a453f785089e