### PR TITLE
Ensure circuit breaker retries respect boolean results

### DIFF
--- a/includes/circuit-breaker.php
+++ b/includes/circuit-breaker.php
@@ -693,20 +693,36 @@ class CircuitBreakerManager {
     
     /**
      * Retry booking sync
+     *
+     * Allows custom handlers to process queued booking synchronization payloads.
+     * The `hic_retry_booking_sync` filter should return `true` when the retry
+     * completed successfully or `false` to keep the item queued for another
+     * attempt. If no callbacks are registered the retry is treated as successful.
+     *
+     * @param mixed $payload Stored payload for the booking sync retry.
+     * @return bool True when the retry is considered completed.
      */
     private function retry_booking_sync($payload) {
-        // Implementation depends on your booking sync logic
-        // This is a placeholder
-        return do_action('hic_retry_booking_sync', $payload);
+        $result = apply_filters('hic_retry_booking_sync', true, $payload);
+
+        return (bool) $result;
     }
-    
+
     /**
      * Retry analytics event
+     *
+     * Allows custom handlers to process queued analytics payloads. The
+     * `hic_retry_analytics_event` filter should return `true` when the retry
+     * completed successfully or `false` to keep the event queued. Without
+     * registered callbacks the retry defaults to success.
+     *
+     * @param mixed $payload Stored payload for the analytics retry.
+     * @return bool True when the analytics retry is completed successfully.
      */
     private function retry_analytics_event($payload) {
-        // Implementation depends on your analytics integration
-        // This is a placeholder
-        return do_action('hic_retry_analytics_event', $payload);
+        $result = apply_filters('hic_retry_analytics_event', true, $payload);
+
+        return (bool) $result;
     }
     
     /**


### PR DESCRIPTION
## Summary
- convert the booking sync and analytics retry handlers to filters that default to success while allowing callbacks to return `false`
- document the boolean return expectation on both hooks
- add retry queue coverage proving filters can keep items queued or mark them as completed

## Testing
- :x: `composer test` *(fails: WordPress test stubs in this environment lack numerous functions such as rest_get_server, wpdb::get_var, etc.)*
- :white_check_mark: `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/CircuitBreakerRetryQueueTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68d2ba931470832fa7a17addd5ec910f