### PR TITLE
Raise minimum supported WordPress version to 5.8

### DIFF
--- a/includes/constants.php
+++ b/includes/constants.php
@@ -117,5 +117,5 @@ define('HIC_DIAGNOSTIC_FULL', 'full');
 define('HIC_PLUGIN_VERSION', '3.1.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
-define('HIC_MIN_WP_VERSION', '5.0');
+define('HIC_MIN_WP_VERSION', '5.8');
 define('HIC_DB_VERSION', '1.7');

--- a/tests/ActivationVersionCheckTest.php
+++ b/tests/ActivationVersionCheckTest.php
@@ -14,6 +14,11 @@ if (!function_exists('plugin_basename')) {
         return $file;
     }
 }
+if (!function_exists('did_action')) {
+    function did_action($hook) {
+        return 0;
+    }
+}
 if (!function_exists('wp_die')) {
     function wp_die($message) {
         throw new Exception($message);
@@ -38,6 +43,7 @@ class ActivationVersionCheckTest extends TestCase
             $this->fail('Activation should have been blocked.');
         } catch (Exception $e) {
             $this->assertStringContainsString('Richiede almeno PHP', $e->getMessage());
+            $this->assertStringContainsString('WordPress 5.8', $e->getMessage());
             $this->assertEquals(
                 realpath(__DIR__ . '/../FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php'),
                 $GLOBALS['deactivated_plugin'] ?? null


### PR DESCRIPTION
## Summary
- update the plugin's minimum WordPress version constant to 5.8
- extend the activation guard test to assert the wp_die message mentions WordPress 5.8

## Testing
- composer test *(fails: numerous missing WordPress dependencies and mocks in the test suite)*

------
https://chatgpt.com/codex/tasks/task_e_68d2ce904310832f929168d7b66a2172