### PR TITLE
Ensure option cache clears on add/delete events

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -32,6 +32,10 @@ function hic_clear_option_cache($key = null) {
         return;
     }
 
+    if (!is_string($key) || $key === '') {
+        return;
+    }
+
     if (strpos($key, 'hic_') === 0) {
         $key = substr($key, 4);
     }
@@ -80,7 +84,9 @@ function hic_safe_add_hook($type, $hook, $function, $priority = 10, $accepted_ar
  */
 function hic_init_helper_hooks() {
     // Trigger any deferred hook registrations
+    hic_safe_add_hook('action', 'added_option', __NAMESPACE__ . '\\hic_clear_option_cache', 10, 1);
     hic_safe_add_hook('action', 'updated_option', __NAMESPACE__ . '\\hic_clear_option_cache', 10, 1);
+    hic_safe_add_hook('action', 'deleted_option', __NAMESPACE__ . '\\hic_clear_option_cache', 10, 1);
 
     if (function_exists('add_action') && function_exists('add_filter')) {
         add_filter('wp_privacy_personal_data_exporters', __NAMESPACE__ . '\\hic_register_exporter');

--- a/tests/OptionCacheInvalidationTest.php
+++ b/tests/OptionCacheInvalidationTest.php
@@ -1,0 +1,42 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+
+use function FpHic\Helpers\hic_clear_option_cache;
+use function FpHic\Helpers\hic_get_option;
+use function FpHic\Helpers\hic_safe_add_hook;
+
+require_once __DIR__ . '/bootstrap.php';
+
+final class OptionCacheInvalidationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        global $hic_test_options, $hic_test_option_autoload, $hic_test_hooks;
+
+        $hic_test_options = [];
+        $hic_test_option_autoload = [];
+        $hic_test_hooks = [];
+
+        hic_clear_option_cache();
+
+        hic_safe_add_hook('action', 'added_option', 'FpHic\\Helpers\\hic_clear_option_cache', 10, 1);
+        hic_safe_add_hook('action', 'updated_option', 'FpHic\\Helpers\\hic_clear_option_cache', 10, 1);
+        hic_safe_add_hook('action', 'deleted_option', 'FpHic\\Helpers\\hic_clear_option_cache', 10, 1);
+    }
+
+    public function test_cache_refreshes_when_option_is_added_and_deleted(): void
+    {
+        $defaultValue = 'default-value';
+
+        $this->assertSame($defaultValue, hic_get_option('example_option', $defaultValue));
+
+        $this->assertTrue(add_option('hic_example_option', 'stored-value'));
+        $this->assertSame('stored-value', hic_get_option('example_option', $defaultValue));
+
+        $this->assertTrue(delete_option('hic_example_option'));
+        $this->assertSame($defaultValue, hic_get_option('example_option', $defaultValue));
+    }
+}


### PR DESCRIPTION
## Summary
- register the helper cache clearer for added and deleted option events and harden it against unexpected keys
- teach the WordPress option stubs to fire the relevant lifecycle hooks and add a unit test covering cache refresh after option add/delete

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/OptionCacheInvalidationTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d2d001d8e4832f855886a6df24e838