### PR TITLE
Validate Google Ads token settings before refresh

### DIFF
--- a/tests/GoogleAdsEnhancedConversionsApiRequestTest.php
+++ b/tests/GoogleAdsEnhancedConversionsApiRequestTest.php
@@ -129,6 +129,27 @@ namespace {
                 $conversion_payload['conversionDateTime']
             );
         }
+
+        public function test_get_google_ads_access_token_aborts_when_credentials_missing(): void
+        {
+            global $hic_test_google_ads_requests;
+
+            update_option('hic_google_ads_enhanced_settings', [
+                'client_id' => '',
+                'client_secret' => '',
+                'refresh_token' => null,
+            ]);
+
+            $enhanced = new GoogleAdsEnhancedConversions();
+
+            $method = new \ReflectionMethod($enhanced, 'get_google_ads_access_token');
+            $method->setAccessible(true);
+
+            $result = $method->invoke($enhanced);
+
+            $this->assertFalse($result);
+            $this->assertSame([], $hic_test_google_ads_requests, 'Token request should not be made when credentials are incomplete');
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- ensure Google Ads credential settings are validated before attempting to refresh an access token
- add a unit test that covers the early return path when credentials are missing so no HTTP request is performed

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter GoogleAdsEnhancedConversionsApiRequestTest

------
https://chatgpt.com/codex/tasks/task_e_68d2d3c01f64832f812ffc41a6ea6b7e