### PR TITLE
Handle missing webhook content type

### DIFF
--- a/includes/api/webhook.php
+++ b/includes/api/webhook.php
@@ -52,7 +52,14 @@ function hic_webhook_handler(WP_REST_Request $request) {
 
   // Validate Content-Type header
   $content_type = $request->get_header('content-type');
-  if ( stripos($content_type, 'application/json') === false ) {
+
+  if (!is_string($content_type)) {
+    $content_type = '';
+  } else {
+    $content_type = trim($content_type);
+  }
+
+  if ($content_type === '' || stripos($content_type, 'application/json') === false) {
     return new \WP_Error('invalid_content_type', 'Content-Type non supportato', ['status' => 415]);
   }
 


### PR DESCRIPTION
## Summary
- validate the webhook Content-Type header is a non-empty string before inspecting it
- return the existing 415 error when the header is missing or not JSON instead of letting stripos() crash
- cover the missing Content-Type scenario with a dedicated webhook test

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter WebhookInvalidJsonTest

------
https://chatgpt.com/codex/tasks/task_e_68d2d665189c832faca863776f134007