### PR TITLE
Fix admin asset URLs to use plugin_dir_url

### DIFF
--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -1057,7 +1057,7 @@ class AutomatedReportingManager {
         
         wp_enqueue_script(
             'hic-reporting',
-            plugins_url('assets/js/reporting.js', dirname(__FILE__, 2)),
+            plugin_dir_url(dirname(__DIR__) . '/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php') . 'assets/js/reporting.js',
             ['jquery'],
             '3.1.0',
             true

--- a/includes/circuit-breaker.php
+++ b/includes/circuit-breaker.php
@@ -880,7 +880,7 @@ class CircuitBreakerManager {
         
         wp_enqueue_script(
             'hic-circuit-breaker',
-            plugins_url('assets/js/circuit-breaker.js', dirname(__FILE__, 2)),
+            plugin_dir_url(dirname(__DIR__) . '/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php') . 'assets/js/circuit-breaker.js',
             ['jquery'],
             '3.1.0',
             true

--- a/includes/google-ads-enhanced.php
+++ b/includes/google-ads-enhanced.php
@@ -1289,7 +1289,7 @@ class GoogleAdsEnhancedConversions {
         
         wp_enqueue_script(
             'hic-enhanced-conversions',
-            plugins_url('assets/js/enhanced-conversions.js', dirname(__FILE__, 2)),
+            plugin_dir_url(dirname(__DIR__) . '/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php') . 'assets/js/enhanced-conversions.js',
             ['jquery'],
             '3.1.0',
             true

--- a/includes/realtime-dashboard.php
+++ b/includes/realtime-dashboard.php
@@ -205,18 +205,19 @@ class RealtimeDashboard {
         );
         
         // Enqueue dashboard JavaScript
+        $plugin_base_url = plugin_dir_url(dirname(__DIR__) . '/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php');
         wp_enqueue_script(
             'hic-realtime-dashboard',
-            plugins_url('assets/js/realtime-dashboard.js', dirname(__FILE__, 2)),
+            $plugin_base_url . 'assets/js/realtime-dashboard.js',
             ['jquery', 'chart-js'],
             '3.1.0',
             true
         );
-        
+
         // Enqueue dashboard CSS
         wp_enqueue_style(
             'hic-realtime-dashboard',
-            plugins_url('assets/css/realtime-dashboard.css', dirname(__FILE__, 2)),
+            $plugin_base_url . 'assets/css/realtime-dashboard.css',
             [],
             '3.1.0'
         );


### PR DESCRIPTION
## Summary
- replace plugins_url-based admin asset enqueues with plugin_dir_url anchored to the plugin bootstrap file across Google Ads Enhanced, Circuit Breaker, Reporting and Realtime Dashboard modules
- reuse a shared plugin base URL when loading the realtime dashboard script and stylesheet

## Testing
- php -l includes/google-ads-enhanced.php
- php -l includes/circuit-breaker.php
- php -l includes/realtime-dashboard.php
- php -l includes/automated-reporting.php

------
https://chatgpt.com/codex/tasks/task_e_68d2e19f9e5c832fb01a1bee9d9d3bd6