### PR TITLE
Ensure Facebook event timestamps use UTC

### DIFF
--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -61,7 +61,7 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gb
   }
 
   if ($fbclid) {
-    $fbc = 'fb.1.' . current_time('timestamp') . '.' . $fbclid;
+    $fbc = 'fb.1.' . current_time('timestamp', true) . '.' . $fbclid;
     $user_data['fbc'] = [$fbc];
   }
   if (!empty($_COOKIE['_fbp'])) {
@@ -97,7 +97,7 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gb
   $payload = [
     'data' => [[
       'event_name'       => 'Purchase',      // evento standard Meta
-      'event_time'       => current_time('timestamp'),
+      'event_time'       => current_time('timestamp', true),
       'event_id'         => $event_id,
       'action_source'    => 'website',
       'event_source_url' => home_url(),
@@ -212,7 +212,7 @@ function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '',
   }
 
   if ($fbclid) {
-    $fbc = 'fb.1.' . current_time('timestamp') . '.' . $fbclid;
+    $fbc = 'fb.1.' . current_time('timestamp', true) . '.' . $fbclid;
     $user_data['fbc'] = [$fbc];
   }
   if (!empty($_COOKIE['_fbp'])) {
@@ -247,7 +247,7 @@ function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '',
   $payload = [
     'data' => [[
       'event_name'       => 'Refund',
-      'event_time'       => current_time('timestamp'),
+      'event_time'       => current_time('timestamp', true),
       'event_id'         => $event_id,
       'action_source'    => 'website',
       'event_source_url' => home_url(),
@@ -378,7 +378,7 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
     $user_data['ph'] = [hash('sha256', preg_replace('/\D/', '', $data['phone']))];
   }
   if ($fbclid) {
-    $fbc = 'fb.1.' . current_time('timestamp') . '.' . $fbclid;
+    $fbc = 'fb.1.' . current_time('timestamp', true) . '.' . $fbclid;
     $user_data['fbc'] = [$fbc];
   }
   if (!empty($_COOKIE['_fbp'])) {
@@ -429,7 +429,7 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
   $payload = [
     'data' => [[
       'event_name' => 'Purchase',
-      'event_time' => current_time('timestamp'),
+      'event_time' => current_time('timestamp', true),
       'event_id' => $transaction_id,
       'action_source' => 'website',
       'event_source_url' => home_url(),

--- a/tests/FacebookEventTimestampTest.php
+++ b/tests/FacebookEventTimestampTest.php
@@ -1,0 +1,76 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class FacebookEventTimestampTest extends TestCase
+{
+    /** @var callable|null */
+    private $payloadFilter;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Ensure Facebook credentials are set for the integration to run.
+        update_option('hic_fb_pixel_id', '1234567890');
+        update_option('hic_fb_access_token', 'test-access-token');
+        \FpHic\Helpers\hic_clear_option_cache();
+
+        // Simulate a positive timezone installation.
+        update_option('timezone_string', 'Europe/Rome');
+        update_option('gmt_offset', 2);
+
+        // Freeze time with distinct UTC and local values.
+        $GLOBALS['hic_test_current_time'] = [
+            'timestamp_gmt'   => 1700000000,
+            'timestamp_local' => 1700000000 + 7200,
+            'value'           => 1700000000,
+        ];
+
+        $_SERVER['REMOTE_ADDR'] = '127.0.0.1';
+        $_SERVER['HTTP_USER_AGENT'] = 'PHPUnit';
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        if ($this->payloadFilter !== null) {
+            remove_filter('hic_fb_payload', $this->payloadFilter);
+            $this->payloadFilter = null;
+        }
+
+        unset($GLOBALS['hic_test_current_time']);
+    }
+
+    public function test_event_time_and_fbc_use_utc_timestamp_with_positive_timezone(): void
+    {
+        $capturedPayload = null;
+        $this->payloadFilter = function ($payload) use (&$capturedPayload) {
+            $capturedPayload = $payload;
+            return $payload;
+        };
+        add_filter('hic_fb_payload', $this->payloadFilter);
+
+        $data = [
+            'email'    => 'user@example.com',
+            'value'    => '199.99',
+            'currency' => 'EUR',
+            'room'     => 'Suite',
+        ];
+
+        $result = \FpHic\hic_send_to_fb($data, '', 'FBCLID123');
+
+        $this->assertTrue($result, 'The Meta event dispatch should succeed in tests.');
+        $this->assertNotNull($capturedPayload, 'The Facebook payload should be captured for assertions.');
+
+        $event = $capturedPayload['data'][0];
+
+        $this->assertSame(1700000000, $event['event_time'], 'Event time must use the UTC timestamp override.');
+        $this->assertSame(
+            'fb.1.1700000000.FBCLID123',
+            $event['user_data']['fbc'][0],
+            'The fbc parameter must include the UTC timestamp.'
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- update Meta CAPI integration to generate event_time and fbc values with UTC-based timestamps
- expand the PHPUnit WordPress current_time stub to support UTC overrides and emulate gmt_offset behaviour
- add a regression test that verifies Facebook events use UTC timestamps when the site timezone is positive

## Testing
- `composer test`
- `php -d auto_prepend_file=tests/preload.php ./vendor/bin/phpunit tests/FacebookEventTimestampTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68d2e2ed65a0832fa411e1e80e712964