### PR TITLE
Normalize Meta phone hashing with shared helper

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -11,6 +11,8 @@ if (!defined('ABSPATH')) {
     exit;
 }
 
+const HIC_PHONE_DEFAULT_COUNTRY = 'IT';
+
 /* ================= CONFIG FUNCTIONS ================= */
 function &hic_option_cache() {
     static $cache = [];
@@ -385,6 +387,642 @@ function hic_detect_phone_language($phone) {
     }
 
     return ['phone' => $normalized, 'language' => 'en'];
+}
+
+/**
+ * Retrieve the list of supported telephone calling codes keyed by ISO country.
+ *
+ * @return array<string,string>
+ */
+function hic_phone_country_calling_codes(): array {
+    static $codes = null;
+
+    if ($codes === null) {
+        $codes = [
+            'IT' => '39',
+            'SM' => '378',
+            'VA' => '379',
+            'US' => '1',
+            'CA' => '1',
+            'GB' => '44',
+            'UK' => '44',
+            'IE' => '353',
+            'FR' => '33',
+            'DE' => '49',
+            'ES' => '34',
+            'PT' => '351',
+            'NL' => '31',
+            'BE' => '32',
+            'CH' => '41',
+            'AT' => '43',
+            'DK' => '45',
+            'SE' => '46',
+            'NO' => '47',
+            'FI' => '358',
+            'PL' => '48',
+            'CZ' => '420',
+            'SK' => '421',
+            'HU' => '36',
+            'RO' => '40',
+            'HR' => '385',
+            'SI' => '386',
+            'BG' => '359',
+            'RS' => '381',
+            'GR' => '30',
+            'TR' => '90',
+            'BR' => '55',
+            'AR' => '54',
+            'CL' => '56',
+            'MX' => '52',
+            'AU' => '61',
+            'NZ' => '64',
+            'JP' => '81',
+            'CN' => '86',
+            'IN' => '91',
+            'ZA' => '27',
+            'AE' => '971',
+            'RU' => '7',
+            'UA' => '380',
+            'IL' => '972',
+            'LU' => '352',
+            'IS' => '354',
+            'MT' => '356',
+            'CY' => '357',
+            'EE' => '372',
+            'LV' => '371',
+            'LT' => '370',
+            'LI' => '423',
+            'SG' => '65',
+        ];
+    }
+
+    return $codes;
+}
+
+/**
+ * Map language hints to default ISO countries.
+ *
+ * @return array<string,string>
+ */
+function hic_phone_language_country_map(): array {
+    static $map = null;
+
+    if ($map === null) {
+        $map = [
+            'it' => 'IT',
+            'en' => 'GB',
+            'fr' => 'FR',
+            'de' => 'DE',
+            'es' => 'ES',
+            'pt' => 'PT',
+            'nl' => 'NL',
+            'be' => 'BE',
+            'da' => 'DK',
+            'sv' => 'SE',
+            'no' => 'NO',
+            'fi' => 'FI',
+            'pl' => 'PL',
+            'cs' => 'CZ',
+            'sk' => 'SK',
+            'hu' => 'HU',
+            'ro' => 'RO',
+            'hr' => 'HR',
+            'sl' => 'SI',
+            'bg' => 'BG',
+            'sr' => 'RS',
+            'el' => 'GR',
+            'tr' => 'TR',
+            'ru' => 'RU',
+            'uk' => 'UA',
+            'he' => 'IL',
+            'ar' => 'AE',
+            'ja' => 'JP',
+            'zh' => 'CN',
+            'hi' => 'IN',
+            'ptbr' => 'BR',
+            'esmx' => 'MX',
+            'enus' => 'US',
+            'engb' => 'GB',
+            'enau' => 'AU',
+            'ennz' => 'NZ',
+            'frca' => 'CA',
+            'deat' => 'AT',
+            'dech' => 'CH',
+        ];
+    }
+
+    return $map;
+}
+
+/**
+ * Normalize a country hint into a structured representation.
+ *
+ * @param mixed $value
+ * @return array{type:string,value:string}|null
+ */
+function hic_phone_normalize_country_value($value): ?array {
+    if (!is_scalar($value)) {
+        return null;
+    }
+
+    $candidate = trim((string) $value);
+    if ($candidate === '') {
+        return null;
+    }
+
+    if (preg_match('/^\+?\d{1,6}$/', $candidate)) {
+        return ['type' => 'code', 'value' => ltrim($candidate, '+')];
+    }
+
+    $upper = strtoupper($candidate);
+
+    if (preg_match('/^[A-Z]{2}$/', $upper)) {
+        if ($upper === 'UK') {
+            $upper = 'GB';
+        }
+
+        return ['type' => 'country', 'value' => $upper];
+    }
+
+    if (preg_match('/^[A-Z]{3}$/', $upper)) {
+        $map = [
+            'ITA' => 'IT',
+            'SMR' => 'SM',
+            'VAT' => 'VA',
+            'USA' => 'US',
+            'GBR' => 'GB',
+            'IRL' => 'IE',
+            'FRA' => 'FR',
+            'DEU' => 'DE',
+            'ESP' => 'ES',
+            'PRT' => 'PT',
+            'NLD' => 'NL',
+            'BEL' => 'BE',
+            'CHE' => 'CH',
+            'AUT' => 'AT',
+            'DNK' => 'DK',
+            'SWE' => 'SE',
+            'NOR' => 'NO',
+            'FIN' => 'FI',
+            'POL' => 'PL',
+            'CZE' => 'CZ',
+            'SVK' => 'SK',
+            'HUN' => 'HU',
+            'ROU' => 'RO',
+            'HRV' => 'HR',
+            'SVN' => 'SI',
+            'BGR' => 'BG',
+            'SRB' => 'RS',
+            'GRC' => 'GR',
+            'TUR' => 'TR',
+            'RUS' => 'RU',
+            'UKR' => 'UA',
+            'BRA' => 'BR',
+            'ARG' => 'AR',
+            'CHL' => 'CL',
+            'MEX' => 'MX',
+            'AUS' => 'AU',
+            'NZL' => 'NZ',
+            'JPN' => 'JP',
+            'CHN' => 'CN',
+            'IND' => 'IN',
+            'ZAF' => 'ZA',
+            'ARE' => 'AE',
+            'ISR' => 'IL',
+            'LUX' => 'LU',
+            'MLT' => 'MT',
+            'CYP' => 'CY',
+            'EST' => 'EE',
+            'LVA' => 'LV',
+            'LTU' => 'LT',
+            'LIE' => 'LI',
+            'CAN' => 'CA',
+            'SGP' => 'SG',
+        ];
+
+        if (isset($map[$upper])) {
+            return ['type' => 'country', 'value' => $map[$upper]];
+        }
+    }
+
+    $normalized = preg_replace('/[^A-Z]/', '', $upper);
+    if ($normalized === '') {
+        return null;
+    }
+
+    $names = [
+        'ITALIA' => 'IT',
+        'ITALY' => 'IT',
+        'ITALIEN' => 'IT',
+        'SANMARINO' => 'SM',
+        'VATICAN' => 'VA',
+        'VATICANCITY' => 'VA',
+        'UNITEDKINGDOM' => 'GB',
+        'REGNOUNITO' => 'GB',
+        'ENGLAND' => 'GB',
+        'SCOTLAND' => 'GB',
+        'WALES' => 'GB',
+        'IRELAND' => 'IE',
+        'IRLANDA' => 'IE',
+        'UNITEDSTATES' => 'US',
+        'STATIUNITI' => 'US',
+        'FRANCE' => 'FR',
+        'GERMANY' => 'DE',
+        'DEUTSCHLAND' => 'DE',
+        'SPAIN' => 'ES',
+        'ESPANA' => 'ES',
+        'PORTUGAL' => 'PT',
+        'PORTOGALLO' => 'PT',
+        'NETHERLANDS' => 'NL',
+        'PAESIBASSI' => 'NL',
+        'BELGIUM' => 'BE',
+        'BELGIO' => 'BE',
+        'SWITZERLAND' => 'CH',
+        'SVIZZERA' => 'CH',
+        'AUSTRIA' => 'AT',
+        'DENMARK' => 'DK',
+        'DANIMARCA' => 'DK',
+        'SWEDEN' => 'SE',
+        'SVEZIA' => 'SE',
+        'NORWAY' => 'NO',
+        'NORVEGIA' => 'NO',
+        'FINLAND' => 'FI',
+        'FINLANDIA' => 'FI',
+        'POLAND' => 'PL',
+        'POLONIA' => 'PL',
+        'CZECHREPUBLIC' => 'CZ',
+        'REPUBBLICACECA' => 'CZ',
+        'SLOVAKIA' => 'SK',
+        'SLOVACCHIA' => 'SK',
+        'HUNGARY' => 'HU',
+        'UNGHERIA' => 'HU',
+        'ROMANIA' => 'RO',
+        'GREECE' => 'GR',
+        'GRECIA' => 'GR',
+        'TURKEY' => 'TR',
+        'TURCHIA' => 'TR',
+        'RUSSIA' => 'RU',
+        'RUSSIANFEDERATION' => 'RU',
+        'UKRAINE' => 'UA',
+        'BRAZIL' => 'BR',
+        'BRASILE' => 'BR',
+        'MEXICO' => 'MX',
+        'MESSICO' => 'MX',
+        'ARGENTINA' => 'AR',
+        'CHILE' => 'CL',
+        'AUSTRALIA' => 'AU',
+        'NUOVAZELANDA' => 'NZ',
+        'NEWZEALAND' => 'NZ',
+        'JAPAN' => 'JP',
+        'GIAPPONE' => 'JP',
+        'CHINA' => 'CN',
+        'CINA' => 'CN',
+        'INDIA' => 'IN',
+        'SOUTHAFRICA' => 'ZA',
+        'SUDAFRICA' => 'ZA',
+        'EMIRATIARABIUNITI' => 'AE',
+        'UNITEDARABEMIRATES' => 'AE',
+        'ISRAEL' => 'IL',
+        'LUXEMBOURG' => 'LU',
+        'LUSSEMBURGO' => 'LU',
+        'MALTA' => 'MT',
+        'CYPRES' => 'CY',
+        'CIPRO' => 'CY',
+        'ESTONIA' => 'EE',
+        'LETTONIA' => 'LV',
+        'LATVIA' => 'LV',
+        'LITUANIA' => 'LT',
+        'LITHUANIA' => 'LT',
+        'LIECHTENSTEIN' => 'LI',
+        'CANADA' => 'CA',
+        'SINGAPORE' => 'SG',
+    ];
+
+    if (isset($names[$normalized])) {
+        return ['type' => 'country', 'value' => $names[$normalized]];
+    }
+
+    return null;
+}
+
+/**
+ * Resolve a language or locale into a country hint.
+ *
+ * @param mixed $language
+ * @return array{type:string,value:string}|null
+ */
+function hic_phone_map_language_to_country($language): ?array {
+    if (!is_scalar($language)) {
+        return null;
+    }
+
+    $value = strtolower(trim((string) $language));
+    if ($value === '') {
+        return null;
+    }
+
+    $value = str_replace([' ', '_'], '-', $value);
+    $parts = explode('-', $value);
+
+    if (isset($parts[1])) {
+        $region_candidate = hic_phone_normalize_country_value($parts[1]);
+        if ($region_candidate !== null) {
+            return $region_candidate;
+        }
+    }
+
+    $primary = preg_replace('/[^a-z]/', '', $parts[0]);
+    if ($primary === '') {
+        return null;
+    }
+
+    $map = hic_phone_language_country_map();
+    if (isset($map[$primary])) {
+        return ['type' => 'country', 'value' => $map[$primary]];
+    }
+
+    return null;
+}
+
+/**
+ * Resolve the telephone calling code for a normalized country hint.
+ *
+ * @param array{type:string,value:string} $country
+ */
+function hic_phone_resolve_calling_code(array $country): ?string {
+    if (empty($country['type']) || empty($country['value'])) {
+        return null;
+    }
+
+    if ($country['type'] === 'code') {
+        $digits = preg_replace('/\D/', '', $country['value']);
+        return $digits !== '' ? $digits : null;
+    }
+
+    $iso = strtoupper($country['value']);
+    $codes = hic_phone_country_calling_codes();
+
+    return $codes[$iso] ?? null;
+}
+
+/**
+ * Determine whether the national trunk zero should be retained for the given country.
+ *
+ * @param array{type:string,value:string} $country
+ */
+function hic_phone_should_retain_trunk_zero(array $country): bool {
+    if (($country['type'] ?? '') === 'code') {
+        return true;
+    }
+
+    $iso = strtoupper($country['value'] ?? '');
+    $retain = ['IT', 'SM', 'VA'];
+
+    return in_array($iso, $retain, true);
+}
+
+/**
+ * Determine the default country hint for phone normalization.
+ *
+ * @return array{type:string,value:string}|null
+ */
+function hic_phone_get_default_country(): ?array {
+    $settings = function_exists('get_option') ? get_option('hic_google_ads_enhanced_settings', []) : [];
+
+    if (is_array($settings) && array_key_exists('default_phone_country', $settings)) {
+        $stored = $settings['default_phone_country'];
+
+        if (!is_scalar($stored)) {
+            return null;
+        }
+
+        $stored_value = (string) $stored;
+        if ($stored_value === '') {
+            return null;
+        }
+
+        return hic_phone_normalize_country_value($stored_value);
+    }
+
+    return hic_phone_normalize_country_value(HIC_PHONE_DEFAULT_COUNTRY);
+}
+
+/**
+ * Normalize a phone number to E.164 format using booking/customer context.
+ *
+ * @param mixed $phone
+ * @param array<string,mixed> $context
+ */
+function hic_normalize_phone_for_hash($phone, array $context = []): ?string {
+    if (!is_scalar($phone)) {
+        return null;
+    }
+
+    $raw_phone = trim((string) $phone);
+    if ($raw_phone === '') {
+        return null;
+    }
+
+    $customer_data = [];
+    if (!empty($context['customer_data']) && is_array($context['customer_data'])) {
+        $customer_data = $context['customer_data'];
+    }
+
+    $booking_data = [];
+    if (!empty($context['booking_data']) && is_array($context['booking_data'])) {
+        $booking_data = $context['booking_data'];
+    }
+
+    $details = hic_detect_phone_language($raw_phone);
+    $helper_phone = $details['phone'] ?? null;
+    $detected_language = $details['language'] ?? null;
+
+    $normalized_phone = preg_replace('/[^0-9+]/', '', $helper_phone ?? $raw_phone);
+    if ($normalized_phone === '') {
+        return null;
+    }
+
+    if (strpos($normalized_phone, '00') === 0) {
+        $normalized_phone = '+' . substr($normalized_phone, 2);
+    }
+
+    if ($normalized_phone !== '' && $normalized_phone[0] === '+') {
+        $digits = preg_replace('/\D/', '', substr($normalized_phone, 1));
+        return $digits !== '' ? '+' . $digits : null;
+    }
+
+    $numeric_phone = preg_replace('/\D/', '', $normalized_phone);
+    if ($numeric_phone === '') {
+        return null;
+    }
+
+    $country_candidates = [];
+    if (!empty($context['country_candidates']) && is_array($context['country_candidates'])) {
+        foreach ($context['country_candidates'] as $candidate) {
+            if (is_array($candidate) && isset($candidate['type'], $candidate['value'])) {
+                $country_candidates[] = $candidate;
+                continue;
+            }
+
+            $normalized_candidate = hic_phone_normalize_country_value($candidate);
+            if ($normalized_candidate !== null) {
+                $country_candidates[] = $normalized_candidate;
+            }
+        }
+    }
+
+    foreach ([$customer_data, $booking_data] as $dataset) {
+        if (!is_array($dataset)) {
+            continue;
+        }
+
+        foreach (['country_code', 'country', 'phone_country'] as $field) {
+            if (isset($dataset[$field]) && is_scalar($dataset[$field])) {
+                $candidate = hic_phone_normalize_country_value($dataset[$field]);
+                if ($candidate !== null) {
+                    $country_candidates[] = $candidate;
+                }
+            }
+        }
+    }
+
+    $sid = '';
+    if (array_key_exists('sid', $context) && is_scalar($context['sid'])) {
+        $sid = (string) $context['sid'];
+    } elseif (isset($booking_data['sid']) && is_scalar($booking_data['sid'])) {
+        $sid = (string) $booking_data['sid'];
+    }
+
+    if ($sid !== '' && function_exists('apply_filters')) {
+        $sid_country = apply_filters('hic_google_ads_phone_country_from_sid', null, $sid, $customer_data, $booking_data);
+        if (is_string($sid_country) && $sid_country !== '') {
+            $candidate = hic_phone_normalize_country_value($sid_country);
+            if ($candidate !== null) {
+                $country_candidates[] = $candidate;
+            }
+        }
+    }
+
+    $language_sources = [];
+    if (is_string($detected_language) && $detected_language !== '') {
+        $language_sources[] = $detected_language;
+    }
+
+    if (!empty($context['language_candidates']) && is_array($context['language_candidates'])) {
+        foreach ($context['language_candidates'] as $language_candidate) {
+            if (is_scalar($language_candidate)) {
+                $language_sources[] = (string) $language_candidate;
+            }
+        }
+    }
+
+    foreach ([$customer_data, $booking_data] as $dataset) {
+        if (!is_array($dataset)) {
+            continue;
+        }
+
+        foreach (['phone_language', 'language', 'locale'] as $field) {
+            if (!empty($dataset[$field]) && is_scalar($dataset[$field])) {
+                $language_sources[] = (string) $dataset[$field];
+            }
+        }
+    }
+
+    foreach ($language_sources as $language_candidate) {
+        $language_country = hic_phone_map_language_to_country($language_candidate);
+        if ($language_country !== null) {
+            $country_candidates[] = $language_country;
+        }
+    }
+
+    $default_country = null;
+    if (array_key_exists('default_country', $context)) {
+        $hint = $context['default_country'];
+        if (is_array($hint) && isset($hint['type'], $hint['value'])) {
+            $default_country = $hint;
+        } else {
+            $default_country = hic_phone_normalize_country_value($hint);
+        }
+    }
+
+    if ($default_country === null) {
+        $default_country = hic_phone_get_default_country();
+    }
+
+    if ($default_country !== null) {
+        $country_candidates[] = $default_country;
+    }
+
+    $selected_country = null;
+    $calling_code = null;
+    foreach ($country_candidates as $candidate) {
+        if (!is_array($candidate) || empty($candidate['type']) || empty($candidate['value'])) {
+            continue;
+        }
+
+        $code = hic_phone_resolve_calling_code($candidate);
+        if ($code !== null) {
+            $selected_country = $candidate;
+            $calling_code = $code;
+            break;
+        }
+    }
+
+    $logger = null;
+    if (isset($context['logger']) && is_callable($context['logger'])) {
+        $logger = $context['logger'];
+    }
+
+    $warn = static function (string $message) use ($logger): void {
+        $level = defined('HIC_LOG_LEVEL_WARNING') ? HIC_LOG_LEVEL_WARNING : 'warning';
+        if (is_callable($logger)) {
+            $logger($message, $level);
+            return;
+        }
+
+        if (function_exists('\\FpHic\\hic_log')) {
+            \FpHic\hic_log($message, $level);
+        }
+    };
+
+    if ($calling_code === null) {
+        $warn(sprintf('Unable to determine country prefix for phone "%s"; skipping phone hash.', $raw_phone));
+        return null;
+    }
+
+    if (strpos($numeric_phone, $calling_code) === 0 && strlen($numeric_phone) > strlen($calling_code) + 2) {
+        return '+' . $numeric_phone;
+    }
+
+    $national_number = $numeric_phone;
+    if ($selected_country !== null && !hic_phone_should_retain_trunk_zero($selected_country)) {
+        $trimmed = preg_replace('/^0+/', '', $national_number);
+        if ($trimmed !== '') {
+            $national_number = $trimmed;
+        }
+    }
+
+    if ($national_number === '') {
+        $warn(sprintf('Normalized phone number became empty for "%s"; skipping phone hash.', $raw_phone));
+        return null;
+    }
+
+    return '+' . $calling_code . $national_number;
+}
+
+/**
+ * Normalize and hash a phone number for external APIs.
+ *
+ * @param mixed $phone
+ * @param array<string,mixed> $context
+ */
+function hic_hash_normalized_phone($phone, array $context = []): ?string {
+    $normalized = hic_normalize_phone_for_hash($phone, $context);
+    if ($normalized === null) {
+        return null;
+    }
+
+    return hash('sha256', $normalized);
 }
 
 /**
@@ -1850,6 +2488,8 @@ namespace {
     function hic_is_valid_email($email) { return \FpHic\Helpers\hic_is_valid_email($email); }
     function hic_is_ota_alias_email($e) { return \FpHic\Helpers\hic_is_ota_alias_email($e); }
     function hic_detect_phone_language($phone) { return \FpHic\Helpers\hic_detect_phone_language($phone); }
+    function hic_normalize_phone_for_hash($phone, $context = []) { return \FpHic\Helpers\hic_normalize_phone_for_hash($phone, is_array($context) ? $context : []); }
+    function hic_hash_normalized_phone($phone, $context = []) { return \FpHic\Helpers\hic_hash_normalized_phone($phone, is_array($context) ? $context : []); }
     function hic_booking_uid($reservation) { return \FpHic\Helpers\hic_booking_uid($reservation); }
     function hic_mask_sensitive_data($message) { return \FpHic\Helpers\hic_mask_sensitive_data($message); }
     function hic_default_log_message_filter($message, $level) { return \FpHic\Helpers\hic_default_log_message_filter($message, $level); }


### PR DESCRIPTION
## Summary
- add shared phone normalization helpers to reuse enhanced E.164 logic and hashing
- refactor the Google Ads enhanced conversions class to call the helpers instead of duplicating phone parsing
- update Facebook Meta events to hash normalized phones and add a regression test covering multiple prefixes

## Testing
- php tests/test-functions.php

------
https://chatgpt.com/codex/tasks/task_e_68d305c1b29c832fb6d85a71a86c8ce5