### PR TITLE
Format Google Ads conversion timestamps with colon offset

### DIFF
--- a/includes/google-ads-enhanced.php
+++ b/includes/google-ads-enhanced.php
@@ -1102,7 +1102,7 @@ class GoogleAdsEnhancedConversions {
             $date = new \DateTimeImmutable('now', $timezone);
         }
 
-        return $date->setTimezone($timezone)->format('Y-m-d H:i:sO');
+        return $date->setTimezone($timezone)->format('Y-m-d H:i:sP');
     }
 
     /**

--- a/tests/GoogleAdsEnhancedConversionsApiRequestTest.php
+++ b/tests/GoogleAdsEnhancedConversionsApiRequestTest.php
@@ -116,7 +116,7 @@ namespace {
                 'refresh_token' => 'refresh-token',
                 'conversion_action_id' => '987654321',
             ]);
-            update_option('timezone_string', 'UTC');
+            update_option('timezone_string', 'Europe/Rome');
 
             $conversion = [
                 'id' => 1,
@@ -166,9 +166,10 @@ namespace {
             $this->assertSame('EUR', $conversion_payload['currencyCode']);
             $this->assertEquals(199.99, $conversion_payload['conversionValue']);
             $this->assertMatchesRegularExpression(
-                '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{4}/',
+                '/\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}[+-]\d{2}:\d{2}/',
                 $conversion_payload['conversionDateTime']
             );
+            $this->assertSame('2024-01-10 12:00:00+01:00', $conversion_payload['conversionDateTime']);
         }
 
         public function test_upload_preserves_non_eur_currency(): void

--- a/tests/GoogleAdsEnhancedConversionsDateFormattingTest.php
+++ b/tests/GoogleAdsEnhancedConversionsDateFormattingTest.php
@@ -33,9 +33,9 @@ final class GoogleAdsEnhancedConversionsDateFormattingTest extends TestCase
 
         $formatted = $method->invoke($enhanced, '2024-03-01 10:00:00');
 
-        $this->assertSame('2024-03-01 10:00:00+0100', $formatted);
-        $parsed = DateTime::createFromFormat('Y-m-d H:i:sO', $formatted);
+        $this->assertSame('2024-03-01 10:00:00+01:00', $formatted);
+        $parsed = DateTime::createFromFormat('Y-m-d H:i:sP', $formatted);
         $this->assertInstanceOf(DateTime::class, $parsed);
-        $this->assertSame('+0100', $parsed->format('O'));
+        $this->assertSame('+01:00', $parsed->format('P'));
     }
 }


### PR DESCRIPTION
## Summary
- format Google Ads conversion timestamps with the colon-separated timezone offset required by the API
- update enhanced conversion date formatting test expectations for the new `±HH:MM` suffix
- ensure the Google Ads upload test checks for a known `+01:00` offset in the request payload

## Testing
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/GoogleAdsEnhancedConversionsDateFormattingTest.php
- php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit tests/GoogleAdsEnhancedConversionsApiRequestTest.php

------
https://chatgpt.com/codex/tasks/task_e_68d3adbd4c94832f8237b59ca569879a