### PR TITLE
Normalize currency codes across integrations

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -311,18 +311,85 @@ function hic_normalize_price($value) {
     }
 
     $result = floatval($normalized);
-    
+
     // Validate reasonable price range
     if ($result < 0) {
         hic_log('hic_normalize_price: Negative price detected: ' . $result . ' (original: ' . $value . ')');
         return 0.0;
     }
-    
+
     if ($result > 999999.99) {
         hic_log('hic_normalize_price: Unusually high price detected: ' . $result . ' (original: ' . $value . ')');
     }
-    
+
     return $result;
+}
+
+/**
+ * Retrieve the list of supported ISO 4217 currency codes.
+ *
+ * @return string[]
+ */
+function hic_get_iso4217_currency_codes(): array {
+    static $cache = null;
+
+    if (is_array($cache)) {
+        return $cache;
+    }
+
+    if (function_exists('get_woocommerce_currencies')) {
+        $currencies = array_keys((array) get_woocommerce_currencies());
+        $cache = array_map('strtoupper', $currencies);
+        return $cache;
+    }
+
+    $cache = [
+        'AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG', 'AZN',
+        'BAM', 'BBD', 'BDT', 'BGN', 'BHD', 'BIF', 'BMD', 'BND', 'BOB', 'BOV',
+        'BRL', 'BSD', 'BTN', 'BWP', 'BYN', 'BZD', 'CAD', 'CDF', 'CHE', 'CHF',
+        'CHW', 'CLF', 'CLP', 'CNY', 'COP', 'COU', 'CRC', 'CUC', 'CUP', 'CVE',
+        'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'EUR', 'FJD',
+        'FKP', 'GBP', 'GEL', 'GHS', 'GIP', 'GMD', 'GNF', 'GTQ', 'GYD', 'HKD',
+        'HNL', 'HRK', 'HTG', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK',
+        'JMD', 'JOD', 'JPY', 'KES', 'KGS', 'KHR', 'KMF', 'KPW', 'KRW', 'KWD',
+        'KYD', 'KZT', 'LAK', 'LBP', 'LKR', 'LRD', 'LSL', 'LYD', 'MAD', 'MDL',
+        'MGA', 'MKD', 'MMK', 'MNT', 'MOP', 'MRU', 'MUR', 'MVR', 'MWK', 'MXN',
+        'MXV', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR',
+        'PAB', 'PEN', 'PGK', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD',
+        'RUB', 'RWF', 'SAR', 'SBD', 'SCR', 'SDG', 'SEK', 'SGD', 'SHP', 'SLE',
+        'SLL', 'SOS', 'SRD', 'SSP', 'STN', 'SVC', 'SYP', 'SZL', 'THB', 'TJS', 'TMT',
+        'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'USD', 'USN',
+        'UYI', 'UYU', 'UYW', 'UZS', 'VED', 'VES', 'VND', 'VUV', 'WST', 'XAF',
+        'XAG', 'XAU', 'XBA', 'XBB', 'XBC', 'XBD', 'XCD', 'XDR', 'XOF', 'XPD',
+        'XPF', 'XPT', 'XSU', 'XTS', 'XUA', 'XXX', 'YER', 'ZAR', 'ZMW', 'ZWL',
+    ];
+
+    return $cache;
+}
+
+/**
+ * Normalize a currency code to a valid ISO 4217 representation.
+ *
+ * @param mixed $currency Raw currency input.
+ */
+function hic_normalize_currency_code($currency): string {
+    $fallback = 'EUR';
+
+    if (!is_scalar($currency)) {
+        return $fallback;
+    }
+
+    $normalized = strtoupper(sanitize_text_field((string) $currency));
+
+    if ($normalized === '' || !preg_match('/^[A-Z]{3}$/', $normalized)) {
+        return $fallback;
+    }
+
+    if (!in_array($normalized, hic_get_iso4217_currency_codes(), true)) {
+        return $fallback;
+    }
+
+    return $normalized;
 }
 
 function hic_is_valid_email($email) {

--- a/includes/input-validator.php
+++ b/includes/input-validator.php
@@ -230,33 +230,7 @@ class HIC_Input_Validator {
             return self::$iso4217Currencies;
         }
 
-        if (function_exists('get_woocommerce_currencies')) {
-            $currencies = array_keys((array) get_woocommerce_currencies());
-            self::$iso4217Currencies = array_map('strtoupper', $currencies);
-
-            return self::$iso4217Currencies;
-        }
-
-        self::$iso4217Currencies = [
-            'AED', 'AFN', 'ALL', 'AMD', 'ANG', 'AOA', 'ARS', 'AUD', 'AWG', 'AZN',
-            'BAM', 'BBD', 'BDT', 'BGN', 'BHD', 'BIF', 'BMD', 'BND', 'BOB', 'BOV',
-            'BRL', 'BSD', 'BTN', 'BWP', 'BYN', 'BZD', 'CAD', 'CDF', 'CHE', 'CHF',
-            'CHW', 'CLF', 'CLP', 'CNY', 'COP', 'COU', 'CRC', 'CUC', 'CUP', 'CVE',
-            'CZK', 'DJF', 'DKK', 'DOP', 'DZD', 'EGP', 'ERN', 'ETB', 'EUR', 'FJD',
-            'FKP', 'GBP', 'GEL', 'GHS', 'GIP', 'GMD', 'GNF', 'GTQ', 'GYD', 'HKD',
-            'HNL', 'HRK', 'HTG', 'HUF', 'IDR', 'ILS', 'INR', 'IQD', 'IRR', 'ISK',
-            'JMD', 'JOD', 'JPY', 'KES', 'KGS', 'KHR', 'KMF', 'KPW', 'KRW', 'KWD',
-            'KYD', 'KZT', 'LAK', 'LBP', 'LKR', 'LRD', 'LSL', 'LYD', 'MAD', 'MDL',
-            'MGA', 'MKD', 'MMK', 'MNT', 'MOP', 'MRU', 'MUR', 'MVR', 'MWK', 'MXN',
-            'MXV', 'MYR', 'MZN', 'NAD', 'NGN', 'NIO', 'NOK', 'NPR', 'NZD', 'OMR',
-            'PAB', 'PEN', 'PGK', 'PHP', 'PKR', 'PLN', 'PYG', 'QAR', 'RON', 'RSD',
-            'RUB', 'RWF', 'SAR', 'SBD', 'SCR', 'SDG', 'SEK', 'SGD', 'SHP', 'SLE',
-            'SLL', 'SOS', 'SRD', 'SSP', 'STN', 'SVC', 'SYP', 'SZL', 'THB', 'TJS', 'TMT',
-            'TND', 'TOP', 'TRY', 'TTD', 'TWD', 'TZS', 'UAH', 'UGX', 'USD', 'USN',
-            'UYI', 'UYU', 'UYW', 'UZS', 'VED', 'VES', 'VND', 'VUV', 'WST', 'XAF',
-            'XAG', 'XAU', 'XBA', 'XBB', 'XBC', 'XBD', 'XCD', 'XDR', 'XOF', 'XPD',
-            'XPF', 'XPT', 'XSU', 'XTS', 'XUA', 'XXX', 'YER', 'ZAR', 'ZMW', 'ZWL',
-        ];
+        self::$iso4217Currencies = Helpers\hic_get_iso4217_currency_codes();
 
         return self::$iso4217Currencies;
     }

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -53,6 +53,8 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
     $amount = Helpers\hic_normalize_price($amount_source);
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
+
   $body = array(
     'email' => $email,
     'attributes' => array(
@@ -68,7 +70,7 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
       'WBRAID'    => isset($wbraid) ? $wbraid : '',
       'DATE'      => isset($data['date']) ? $data['date'] : wp_date('Y-m-d'),
       'AMOUNT'    => $amount,
-      'CURRENCY'  => isset($data['currency']) ? $data['currency'] : 'EUR',
+      'CURRENCY'  => $currency_code,
       'WHATSAPP'  => $normalized_phone,
       'LANGUAGE'  => $lang,
       // Legacy alias for LANGUAGE
@@ -130,13 +132,15 @@ function hic_send_brevo_event($reservation, $gclid, $fbclid, $msclkid = '', $ttc
     $amount = Helpers\hic_normalize_price($amount_source);
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($reservation['currency'] ?? null);
+
   $event_data = array(
     'event' => 'purchase', // puoi rinominare in 'hic_booking' se preferisci
     'email' => isset($reservation['email']) ? $reservation['email'] : '',
     'properties' => array(
       'reservation_id' => isset($reservation['reservation_id']) ? $reservation['reservation_id'] : (isset($reservation['id']) ? $reservation['id'] : ''),
       'amount'         => $amount,
-      'currency'       => isset($reservation['currency']) ? $reservation['currency'] : 'EUR',
+      'currency'       => $currency_code,
       'date'           => isset($reservation['date']) ? $reservation['date'] : wp_date('Y-m-d'),
       'phone'          => isset($reservation['phone']) ? $reservation['phone'] : '',
       'language'       => isset($reservation['language']) ? $reservation['language'] : '',
@@ -206,13 +210,15 @@ function hic_send_brevo_refund_event($reservation, $gclid, $fbclid, $msclkid = '
     $amount = -abs(Helpers\hic_normalize_price($amount_source));
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($reservation['currency'] ?? null);
+
   $event_data = array(
     'event' => 'refund',
     'email' => isset($reservation['email']) ? $reservation['email'] : '',
     'properties' => array(
       'reservation_id' => isset($reservation['reservation_id']) ? $reservation['reservation_id'] : (isset($reservation['id']) ? $reservation['id'] : ''),
       'amount'         => $amount,
-      'currency'       => isset($reservation['currency']) ? $reservation['currency'] : 'EUR',
+      'currency'       => $currency_code,
       'date'           => isset($reservation['date']) ? $reservation['date'] : wp_date('Y-m-d'),
       'phone'          => isset($reservation['phone']) ? $reservation['phone'] : '',
       'language'       => isset($reservation['language']) ? $reservation['language'] : '',
@@ -344,6 +350,8 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     if (empty($wbraid))  { $wbraid  = $tracking['wbraid'] ?? ''; }
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
+
   $attributes = array(
     // Standard contact attributes (shared)
     'FIRSTNAME' => isset($data['guest_first_name']) ? $data['guest_first_name'] : '',
@@ -378,7 +386,7 @@ function hic_dispatch_brevo_reservation($data, $is_enrichment = false, $gclid = 
     'WBRAID' => $wbraid,
     'DATE' => isset($data['from_date']) ? $data['from_date'] : wp_date('Y-m-d'),
     'AMOUNT' => isset($data['original_price']) ? Helpers\hic_normalize_price($data['original_price']) : 0,
-    'CURRENCY' => isset($data['currency']) ? $data['currency'] : 'EUR',
+    'CURRENCY' => $currency_code,
     'WHATSAPP' => $data['whatsapp'] ?? '',
     'LINGUA' => $language
   );
@@ -615,7 +623,7 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
       'reservation_id' => isset($data['transaction_id']) ? $data['transaction_id'] : '',
       'reservation_code' => isset($data['reservation_code']) ? $data['reservation_code'] : '',
       'amount' => isset($data['original_price']) ? Helpers\hic_normalize_price($data['original_price']) : 0,
-      'currency' => isset($data['currency']) ? $data['currency'] : 'EUR',
+      'currency' => $currency_code,
       'from_date' => isset($data['from_date']) ? $data['from_date'] : '',
       'to_date' => isset($data['to_date']) ? $data['to_date'] : '',
       'guests' => isset($data['guests']) ? $data['guests'] : '',
@@ -1037,6 +1045,8 @@ function hic_transform_webhook_data_for_brevo($webhook_data) {
     }
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($webhook_data['currency'] ?? null);
+
   $transformed = array(
     'transaction_id' => hic_resolve_brevo_transaction_id($webhook_data, $sid),
     'reservation_code' => isset($webhook_data['reservation_code']) ? $webhook_data['reservation_code'] : '',
@@ -1045,7 +1055,7 @@ function hic_transform_webhook_data_for_brevo($webhook_data) {
     'guest_last_name' => $last ?? '',
     'phone' => isset($webhook_data['whatsapp']) ? $webhook_data['whatsapp'] : (isset($webhook_data['phone']) ? $webhook_data['phone'] : ''),
     'original_price' => isset($webhook_data['amount']) ? Helpers\hic_normalize_price($webhook_data['amount']) : 0,
-    'currency' => isset($webhook_data['currency']) ? $webhook_data['currency'] : 'EUR',
+    'currency' => $currency_code,
     'from_date' => $webhook_data['date'] ?? $webhook_data['checkin'] ?? '',
     'to_date'   => $webhook_data['to_date'] ?? $webhook_data['checkout'] ?? '',
     'accommodation_name' => isset($webhook_data['room']) ? $webhook_data['room'] : '',

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -83,8 +83,10 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gb
     $user_data['fbp'] = [sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) )];
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
+
   $custom_data = [
-    'currency'     => sanitize_text_field($data['currency'] ?? 'EUR'),
+    'currency'     => $currency_code,
     'value'        => $amount,
     'order_id'     => $event_id,
     'bucket'       => $bucket,           // per creare custom conversions per fbads/organic/gads
@@ -249,8 +251,10 @@ function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '',
     $user_data['fbp'] = [sanitize_text_field( wp_unslash( $_COOKIE['_fbp'] ) )];
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
+
   $custom_data = [
-    'currency'     => sanitize_text_field($data['currency'] ?? 'EUR'),
+    'currency'     => $currency_code,
     'value'        => $amount,
     'order_id'     => $event_id,
     'bucket'       => $bucket,
@@ -366,7 +370,7 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
   
   $transaction_id = sanitize_text_field($data['transaction_id']);
   $value = Helpers\hic_normalize_price($data['value']);
-  $currency = sanitize_text_field($data['currency']);
+  $currency = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
 
   $sid = !empty($sid) ? \sanitize_text_field((string) $sid) : '';
   if ($sid === '' && !empty($data['sid']) && is_scalar($data['sid'])) {

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -225,9 +225,11 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $g
     $client_id = $transaction_id;
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
+
   $params = [
     'transaction_id' => $transaction_id,
-    'currency'       => sanitize_text_field($data['currency'] ?? 'EUR'),
+    'currency'       => $currency_code,
     'value'          => $amount,
     'items'          => [[
       'item_name' => sanitize_text_field($data['room'] ?? $data['accommodation_name'] ?? 'Prenotazione'),
@@ -349,9 +351,11 @@ function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''
     $client_id = $transaction_id;
   }
 
+  $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
+
   $params = [
     'transaction_id' => $transaction_id,
-    'currency'       => sanitize_text_field($data['currency'] ?? 'EUR'),
+    'currency'       => $currency_code,
     'value'          => $amount,
     'items'          => [[
       'item_name' => sanitize_text_field($data['room'] ?? $data['accommodation_name'] ?? 'Prenotazione'),
@@ -483,7 +487,7 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
   }
 
   $value = Helpers\hic_normalize_price($data['value']);
-  $currency = sanitize_text_field($data['currency']);
+  $currency = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
 
   // Get tracking IDs for bucket normalization if available
   $gclid = '';

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -78,7 +78,7 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $msclkid = '', $ttcli
             'transaction_id' => $transaction_id,
             'affiliation' => 'HotelInCloud',
             'value' => $amount,
-            'currency' => sanitize_text_field($data['currency'] ?? 'EUR'),
+            'currency' => Helpers\hic_normalize_currency_code($data['currency'] ?? null),
             'items' => [[
                 'item_id' => $item_id,
                 'item_name' => $item_name,
@@ -393,7 +393,7 @@ function hic_dispatch_gtm_reservation($data, $sid = '') {
     }
     $data['transaction_id'] = $transaction_id;
     $value = Helpers\hic_normalize_price($data['value']);
-    $currency = sanitize_text_field($data['currency']);
+    $currency = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
 
     $sid = !empty($sid) ? \sanitize_text_field((string) $sid) : '';
     if ($sid === '' && !empty($data['sid']) && is_scalar($data['sid'])) {

--- a/tests/BrevoReservationFieldsTest.php
+++ b/tests/BrevoReservationFieldsTest.php
@@ -28,6 +28,7 @@ final class BrevoReservationFieldsTest extends TestCase {
             'room_name' => 'Room 1',
             'offer' => 'OFF1',
             'valid' => 1,
+            'currency' => 'usd',
             'relocations' => [['from' => '2024-01-01', 'to' => '2024-01-05']]
         ];
 
@@ -44,6 +45,7 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame('OFF1', $payload['attributes']['HIC_OFFER']);
         $this->assertSame(1, $payload['attributes']['HIC_VALID']);
         $this->assertSame(wp_json_encode($data['relocations']), $payload['attributes']['HIC_RELOCATIONS']);
+        $this->assertSame('USD', $payload['attributes']['CURRENCY']);
     }
 
     public function testReservationCreatedEventSendsFields() {
@@ -54,7 +56,7 @@ final class BrevoReservationFieldsTest extends TestCase {
             'email' => 'tag@example.com',
             'transaction_id' => 'R1',
             'original_price' => 100,
-            'currency' => 'EUR',
+            'currency' => 'eur',
             'presence' => 1,
             'unpaid_balance' => 50.5,
             'tags' => ['vip', 'promo'],
@@ -85,6 +87,7 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame('Rossi', $payload['properties']['guest_last_name']);
         $this->assertSame(1, $payload['properties']['valid']);
         $this->assertSame(wp_json_encode($reservation['relocations']), $payload['properties']['relocations']);
+        $this->assertSame('EUR', $payload['properties']['currency']);
     }
 
     public function testPhoneAndWhatsappSeparated() {
@@ -153,7 +156,7 @@ final class BrevoReservationFieldsTest extends TestCase {
             'email' => 'empty@example.com',
             'transaction_id' => 'E1',
             'original_price' => 10,
-            'currency' => 'EUR',
+            'currency' => 'eur',
             'tags' => []
         ];
 
@@ -164,6 +167,7 @@ final class BrevoReservationFieldsTest extends TestCase {
         $this->assertSame([], $payload['tags']);
         $this->assertArrayHasKey('tags', $payload['properties']);
         $this->assertSame('', $payload['properties']['tags']);
+        $this->assertSame('EUR', $payload['properties']['currency']);
     }
 
     public function testReservationCreatedEventSynthesizesMissingId() {
@@ -173,7 +177,7 @@ final class BrevoReservationFieldsTest extends TestCase {
         $webhook = [
             'email' => 'deterministic@example.com',
             'amount' => 120,
-            'currency' => 'EUR',
+            'currency' => 'eur',
             'date' => '2024-05-01',
         ];
 

--- a/tests/CurrencyPropagationTest.php
+++ b/tests/CurrencyPropagationTest.php
@@ -159,37 +159,48 @@ final class CurrencyPropagationTest extends TestCase
         $transformed = \FpHic\hic_transform_reservation($reservation);
         $this->assertSame('CHF', $transformed['currency']);
 
+        $ga_payload_source = $transformed;
+        $ga_payload_source['currency'] = strtolower($ga_payload_source['currency']);
+
         // GA4 dispatch
         $hic_last_request = null;
-        $this->assertTrue(\FpHic\hic_dispatch_ga4_reservation($transformed));
+        $this->assertTrue(\FpHic\hic_dispatch_ga4_reservation($ga_payload_source));
         $this->assertNotNull($hic_last_request);
         $ga_payload = json_decode($hic_last_request['args']['body'], true);
         $this->assertSame('CHF', $ga_payload['events'][0]['params']['currency']);
 
         // GTM dispatch
         update_option('hic_gtm_queued_events', []);
-        $this->assertTrue(\FpHic\hic_dispatch_gtm_reservation($transformed));
+        $gtm_payload_source = $transformed;
+        $gtm_payload_source['currency'] = strtolower($gtm_payload_source['currency']);
+        $this->assertTrue(\FpHic\hic_dispatch_gtm_reservation($gtm_payload_source));
         $gtm_events = get_option('hic_gtm_queued_events', []);
         $this->assertNotEmpty($gtm_events);
         $this->assertSame('CHF', $gtm_events[0]['ecommerce']['currency']);
 
         // Meta Pixel dispatch
         $hic_last_request = null;
-        $this->assertTrue(\FpHic\hic_dispatch_pixel_reservation($transformed));
+        $pixel_payload_source = $transformed;
+        $pixel_payload_source['currency'] = strtolower($pixel_payload_source['currency']);
+        $this->assertTrue(\FpHic\hic_dispatch_pixel_reservation($pixel_payload_source));
         $this->assertNotNull($hic_last_request);
         $fb_payload = json_decode($hic_last_request['args']['body'], true);
         $this->assertSame('CHF', $fb_payload['data'][0]['custom_data']['currency']);
 
         // Brevo contact dispatch
         $hic_last_request = null;
-        $this->assertTrue(\FpHic\hic_dispatch_brevo_reservation($transformed));
+        $brevo_contact_source = $transformed;
+        $brevo_contact_source['currency'] = strtolower($brevo_contact_source['currency']);
+        $this->assertTrue(\FpHic\hic_dispatch_brevo_reservation($brevo_contact_source));
         $this->assertNotNull($hic_last_request);
         $brevo_contact_payload = json_decode($hic_last_request['args']['body'], true);
         $this->assertSame('CHF', $brevo_contact_payload['attributes']['CURRENCY']);
 
         // Brevo reservation_created event
         $hic_last_request = null;
-        $result = \FpHic\hic_send_brevo_reservation_created_event($transformed);
+        $brevo_event_source = $transformed;
+        $brevo_event_source['currency'] = strtolower($brevo_event_source['currency']);
+        $result = \FpHic\hic_send_brevo_reservation_created_event($brevo_event_source);
         $this->assertTrue($result['success']);
         $this->assertNotNull($hic_last_request);
         $brevo_event_payload = json_decode($hic_last_request['args']['body'], true);

--- a/tests/test-functions.php
+++ b/tests/test-functions.php
@@ -554,43 +554,49 @@ class HICFunctionsTest {
         global $hic_last_request;
 
         // GA4 room name + SID usage
-        $data = ['room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
+        $data = ['room' => 'Camera Deluxe', 'currency' => 'eur', 'amount' => 100];
         $sid = 'sid123';
         \FpHic\hic_send_to_ga4($data, null, null, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Camera Deluxe', 'GA4 should use room name');
         assert($payload['client_id'] === $sid, 'GA4 should use SID as client_id');
         assert($payload['events'][0]['params']['transaction_id'] === $sid, 'GA4 should use SID as transaction_id');
+        assert($payload['events'][0]['params']['currency'] === 'EUR', 'GA4 should normalize currency codes');
 
         // GA4 accommodation_name fallback
-        $data = ['accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
+        $data = ['accommodation_name' => 'Suite', 'currency' => 'eur', 'amount' => 100];
         \FpHic\hic_send_to_ga4($data, null, null, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Suite', 'GA4 should use accommodation name');
+        assert($payload['events'][0]['params']['currency'] === 'EUR', 'GA4 should keep normalized currency');
 
         // GA4 default
-        $data = ['currency' => 'EUR', 'amount' => 100];
+        $data = ['currency' => 'eur', 'amount' => 100];
         \FpHic\hic_send_to_ga4($data, null, null, null, null, null, null, $sid);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['events'][0]['params']['items'][0]['item_name'] === 'Prenotazione', 'GA4 should default to Prenotazione');
+        assert($payload['events'][0]['params']['currency'] === 'EUR', 'GA4 should default to EUR when missing or invalid');
 
         // FB room name
-        $data = ['email' => 'user@example.com', 'room' => 'Camera Deluxe', 'currency' => 'EUR', 'amount' => 100];
+        $data = ['email' => 'user@example.com', 'room' => 'Camera Deluxe', 'currency' => 'eur', 'amount' => 100];
         \FpHic\hic_send_to_fb($data, null, null, null, null);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Camera Deluxe', 'FB should use room name');
+        assert($payload['data'][0]['custom_data']['currency'] === 'EUR', 'FB should normalize currency codes');
 
         // FB accommodation_name fallback
-        $data = ['email' => 'user@example.com', 'accommodation_name' => 'Suite', 'currency' => 'EUR', 'amount' => 100];
+        $data = ['email' => 'user@example.com', 'accommodation_name' => 'Suite', 'currency' => 'eur', 'amount' => 100];
         \FpHic\hic_send_to_fb($data, null, null, null, null);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Suite', 'FB should use accommodation name');
+        assert($payload['data'][0]['custom_data']['currency'] === 'EUR', 'FB should keep normalized currency');
 
         // FB default
-        $data = ['email' => 'user@example.com', 'currency' => 'EUR', 'amount' => 100];
+        $data = ['email' => 'user@example.com', 'currency' => 'eur', 'amount' => 100];
         \FpHic\hic_send_to_fb($data, null, null, null, null);
         $payload = json_decode($hic_last_request['args']['body'], true);
         assert($payload['data'][0]['custom_data']['content_name'] === 'Prenotazione', 'FB should default to Prenotazione');
+        assert($payload['data'][0]['custom_data']['currency'] === 'EUR', 'FB should default to EUR when missing or invalid');
 
         echo "✅ Event room name fallback tests passed\n";
     }


### PR DESCRIPTION
## Summary
- add a shared `hic_normalize_currency_code` helper that uppercases valid ISO 4217 codes and falls back to EUR
- update GA4, Meta Pixel, GTM, and Brevo dispatchers to use the helper when building payloads
- extend existing tests with lowercase currency inputs to assert integrations emit normalized codes

## Testing
- `composer test` *(fails: suite expects WordPress database helpers and REST server stubs that are unavailable in the container)*

------
https://chatgpt.com/codex/tasks/task_e_68d41aadd934832fb5e06571c2f5a6a5