### PR TITLE
Harden transaction fallbacks and recover tracking tables

### DIFF
--- a/includes/helpers-tracking.php
+++ b/includes/helpers-tracking.php
@@ -186,8 +186,18 @@ function hic_get_tracking_ids_by_sid($sid) {
     // Ensure table exists before querying
     $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
     if (!$table_exists) {
-        hic_log('hic_get_tracking_ids_by_sid: Table does not exist: ' . $table);
-        return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
+        static $rebuild_attempted = false;
+
+        if (!$rebuild_attempted && function_exists('\\hic_create_database_table')) {
+            $rebuild_attempted = true;
+            \hic_create_database_table();
+            $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
+        }
+
+        if (!$table_exists) {
+            hic_log('hic_get_tracking_ids_by_sid: Table does not exist: ' . $table);
+            return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
+        }
     }
     $row = $wpdb->get_row($wpdb->prepare("SELECT gclid, fbclid, msclkid, ttclid, gbraid, wbraid FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $sid));
 
@@ -238,8 +248,18 @@ function hic_get_utm_params_by_sid($sid) {
     // Ensure table exists before querying
     $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
     if (!$table_exists) {
-        hic_log('hic_get_utm_params_by_sid: Table does not exist: ' . $table);
-        return $cache[$sid] = ['utm_source' => null, 'utm_medium' => null, 'utm_campaign' => null, 'utm_content' => null, 'utm_term' => null];
+        static $utm_rebuild_attempted = false;
+
+        if (!$utm_rebuild_attempted && function_exists('\\hic_create_database_table')) {
+            $utm_rebuild_attempted = true;
+            \hic_create_database_table();
+            $table_exists = $wpdb->get_var($wpdb->prepare("SHOW TABLES LIKE %s", $table)) === $table;
+        }
+
+        if (!$table_exists) {
+            hic_log('hic_get_utm_params_by_sid: Table does not exist: ' . $table);
+            return $cache[$sid] = ['utm_source' => null, 'utm_medium' => null, 'utm_campaign' => null, 'utm_content' => null, 'utm_term' => null];
+        }
     }
 
     $row = $wpdb->get_row($wpdb->prepare("SELECT utm_source, utm_medium, utm_campaign, utm_content, utm_term FROM $table WHERE sid=%s ORDER BY id DESC LIMIT 1", $sid));

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -511,8 +511,19 @@ function hic_resolve_brevo_transaction_id(array $source, string $sid = ''): stri
     return \sanitize_text_field('hic_tx_' . $hash);
   }
 
-  $fallback_hash = substr(hash('sha256', 'hic_brevo_fallback'), 0, 32);
-  return \sanitize_text_field('hic_tx_' . $fallback_hash);
+  $serialized_payload = function_exists('maybe_serialize')
+    ? maybe_serialize($payload_for_hash)
+    : serialize($payload_for_hash);
+
+  if (is_string($serialized_payload) && $serialized_payload !== '') {
+    $hash = substr(hash('sha256', $serialized_payload), 0, 32);
+    return \sanitize_text_field('hic_tx_' . $hash);
+  }
+
+  $exported_payload = var_export($payload_for_hash, true);
+  $hash = substr(hash('sha256', $exported_payload), 0, 32);
+
+  return \sanitize_text_field('hic_tx_' . $hash);
 }
 
 /**

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -179,8 +179,10 @@ function hic_ga4_resolve_transaction_id(array $data, $sid = ''): string {
     return sanitize_text_field($fallback);
   }
 
-  $fallback_hash = substr(hash('sha256', 'hic_ga4_fallback'), 0, 32);
-  return sanitize_text_field('hic_tx_' . $fallback_hash);
+  $exported_payload = var_export($normalized_payload, true);
+  $hash = substr(hash('sha256', $exported_payload), 0, 32);
+
+  return sanitize_text_field('hic_tx_' . $hash);
 }
 
 /* ============ GA4 (purchase + bucket) ============ */


### PR DESCRIPTION
## Summary
- ensure `hic_ga4_resolve_transaction_id` always derives deterministic hashes even when JSON encoding fails
- reuse the same deterministic hashing logic for Brevo transaction IDs to avoid collisions
- teach the tracking lookups to recreate the `hic_gclids` table on demand so SID and UTM lookups recover automatically
- cover Brevo's fallback hashing with a regression test

## Testing
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter test_ga4_transaction_id_fallback_serializes_unencodable_payload tests/ReservationCodeDeduplicationTest.php`
- `php -d auto_prepend_file=tests/preload.php vendor/bin/phpunit --filter testResolveBrevoTransactionIdRemainsDeterministicWhenJsonEncodingFails tests/BrevoReservationFieldsTest.php`


------
https://chatgpt.com/codex/tasks/task_e_68d2608fa654832f971a8be8bd50af44