### PR TITLE
Harden database access and REST route fallback

### DIFF
--- a/includes/api/webhook.php
+++ b/includes/api/webhook.php
@@ -15,7 +15,7 @@ if (!defined('ABSPATH')) exit;
 add_action('rest_api_init', function () {
   // Registra webhook se siamo in modalità webhook O hybrid
   if (in_array(hic_get_connection_type(), ['webhook', 'hybrid'])) {
-    register_rest_route('hic/v1', '/conversion', [
+    $route_args = [
       'methods'             => 'POST',
       'callback'            => 'hic_webhook_handler',
       'permission_callback' => '__return_true',
@@ -30,8 +30,11 @@ add_action('rest_api_init', function () {
           'sanitize_callback' => 'sanitize_email',
           'description'       => 'Email del cliente associata alla prenotazione',
         ],
-      ],
-    ]);
+        ],
+    ];
+
+    register_rest_route('hic/v1', '/conversion', $route_args);
+    \FpHic\Helpers\hic_register_rest_route_fallback('hic/v1', '/conversion', $route_args);
   }
 });
 

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -8,6 +8,20 @@
 
 if (!defined('ABSPATH')) exit;
 
+// Provide fallbacks for WordPress time constants when the plugin is loaded
+// in non-WordPress environments (e.g. automated tests).
+if (!defined('MINUTE_IN_SECONDS')) {
+    define('MINUTE_IN_SECONDS', 60);
+}
+
+if (!defined('HOUR_IN_SECONDS')) {
+    define('HOUR_IN_SECONDS', 60 * MINUTE_IN_SECONDS);
+}
+
+if (!defined('DAY_IN_SECONDS')) {
+    define('DAY_IN_SECONDS', 24 * HOUR_IN_SECONDS);
+}
+
 // === POLLING INTERVALS ===
 define('HIC_CONTINUOUS_POLLING_INTERVAL', 30);    // 30 seconds for near real-time polling (optimized for limited hosting)
 define('HIC_DEEP_CHECK_INTERVAL', 1800);          // 30 minutes for deep check (re-enabled for safety)

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -38,7 +38,7 @@ class HIC_Health_Monitor {
      * Register REST API endpoint for health checks
      */
     public function register_health_endpoint() {
-        register_rest_route('hic/v1', '/health', [
+        $route_args = [
             'methods' => 'GET',
             'callback' => [$this, 'rest_health_check'],
             'permission_callback' => [$this, 'rest_token_permission'],
@@ -48,7 +48,10 @@ class HIC_Health_Monitor {
                     'type' => 'string'
                 ],
             ]
-        ]);
+        ];
+
+        register_rest_route('hic/v1', '/health', $route_args);
+        \FpHic\Helpers\hic_register_rest_route_fallback('hic/v1', '/health', $route_args);
     }
     
     /**

--- a/includes/helpers-scheduling.php
+++ b/includes/helpers-scheduling.php
@@ -22,8 +22,7 @@ function hic_should_schedule_retry_event() {
  * Determine if there are failed requests waiting to be retried
  */
 function hic_has_failed_requests_to_retry() {
-    global $wpdb;
-
+    $wpdb = hic_get_wpdb_instance(['get_var']);
     if (!$wpdb) {
         return false;
     }
@@ -111,7 +110,7 @@ function hic_schedule_failed_request_retry() {
 }
 
 function hic_retry_failed_requests() {
-    global $wpdb;
+    $wpdb = hic_get_wpdb_instance(['get_results', 'delete', 'update']);
     if (!$wpdb) {
         return;
     }
@@ -173,7 +172,7 @@ function hic_cleanup_failed_requests($days = 30) {
         return 0;
     }
 
-    global $wpdb;
+    $wpdb = hic_get_wpdb_instance(['query', 'prepare']);
     if (!$wpdb) {
         hic_log('hic_cleanup_failed_requests: wpdb is not available');
         return false;

--- a/includes/helpers-tracking.php
+++ b/includes/helpers-tracking.php
@@ -26,7 +26,7 @@ function hic_register_eraser($erasers) {
  * Export tracking data associated with an email address.
  */
 function hic_export_tracking_data($email_address, $page = 1) {
-    global $wpdb;
+    $wpdb = hic_get_wpdb_instance(['get_var', 'prepare', 'get_results']);
 
     if (!$wpdb) {
         return ['data' => [], 'done' => true];
@@ -107,7 +107,7 @@ function hic_export_tracking_data($email_address, $page = 1) {
  * Erase tracking data associated with an email address.
  */
 function hic_erase_tracking_data($email_address, $page = 1) {
-    global $wpdb;
+    $wpdb = hic_get_wpdb_instance(['get_var', 'prepare', 'get_results', 'delete']);
 
     if (!$wpdb) {
         return ['items_removed' => false, 'items_retained' => false, 'messages' => [], 'done' => true];
@@ -175,7 +175,7 @@ function hic_get_tracking_ids_by_sid($sid) {
         return $cache[$sid];
     }
 
-    global $wpdb;
+    $wpdb = hic_get_wpdb_instance(['get_var', 'prepare', 'get_row']);
     if (!$wpdb) {
         hic_log('hic_get_tracking_ids_by_sid: wpdb is not available');
         return $cache[$sid] = ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null];
@@ -237,7 +237,7 @@ function hic_get_utm_params_by_sid($sid) {
         return $cache[$sid];
     }
 
-    global $wpdb;
+    $wpdb = hic_get_wpdb_instance(['get_var', 'prepare']);
     if (!$wpdb) {
         hic_log('hic_get_utm_params_by_sid: wpdb is not available');
         return $cache[$sid] = ['utm_source' => null, 'utm_medium' => null, 'utm_campaign' => null, 'utm_content' => null, 'utm_term' => null];

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -312,7 +312,7 @@ function hic_register_gtm_rest_routes() {
         return;
     }
 
-    register_rest_route('hic/v1', '/gtm-events', [
+    $route_args = [
         'methods'             => \WP_REST_Server::READABLE,
         'callback'            => __NAMESPACE__ . '\hic_handle_gtm_events_request',
         'permission_callback' => '__return_true',
@@ -323,7 +323,10 @@ function hic_register_gtm_rest_routes() {
                 'description'       => 'Session ID associato alla prenotazione',
             ],
         ],
-    ]);
+    ];
+
+    register_rest_route('hic/v1', '/gtm-events', $route_args);
+    \FpHic\Helpers\hic_register_rest_route_fallback('hic/v1', '/gtm-events', $route_args);
 }
 
 /**


### PR DESCRIPTION
## Summary
- add a shared `hic_get_wpdb_instance` helper and reuse it across database helpers so calls short-circuit when the test stubs lack specific wpdb methods
- expose a REST route fallback registry and automatically load webhook/health endpoints when WordPress' REST server is unavailable
- ensure the default log masking filter is (re)registered even when other code clears the hook list so masking stays active

## Testing
- `composer run test` *(fails: existing suite still reports booking poller, logging, and integration regressions that require follow-up)*

------
https://chatgpt.com/codex/tasks/task_e_68d42604eddc832fa4667fbb8f821af1