### PR TITLE
Improve logging resilience and GTM queue handling

### DIFF
--- a/includes/helpers-logging.php
+++ b/includes/helpers-logging.php
@@ -157,6 +157,22 @@ function hic_log($msg, $level = HIC_LOG_LEVEL_INFO, $context = []) {
 
     hic_ensure_log_filter_registered();
 
+    if ($log_manager instanceof \HIC_Log_Manager) {
+        $current_log_file = hic_get_log_file();
+        if (is_string($current_log_file) && $current_log_file !== ''
+            && $log_manager->get_log_file_path() !== $current_log_file
+        ) {
+            unset($GLOBALS['hic_log_manager']);
+            $log_manager = null;
+        }
+    }
+
+    if (!isset($GLOBALS['hic_log_manager'])) {
+        $log_manager = null;
+    } elseif ($log_manager !== $GLOBALS['hic_log_manager']) {
+        $log_manager = $GLOBALS['hic_log_manager'];
+    }
+
     if (null === $log_manager && function_exists('\\hic_get_log_manager')) {
         $log_manager = \hic_get_log_manager();
     }

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -626,6 +626,7 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
   $data['language'] = $phone_data['language'] ?? ($data['language'] ?? '');
 
   $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
 
   $body = array(
     'event' => 'reservation_created',

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -146,12 +146,7 @@ function hic_queue_gtm_event($event_data, $sid = '') {
     }
 
     $sid = !empty($sid) ? sanitize_text_field((string) $sid) : '';
-    if ($sid === '') {
-        hic_log('GTM queue: evento ignorato perché SID mancante o non valido', HIC_LOG_LEVEL_DEBUG);
-        return;
-    }
-
-    $option_key = hic_get_gtm_queue_option_key($sid);
+    $option_key = $sid === '' ? 'hic_gtm_queued_events' : hic_get_gtm_queue_option_key($sid);
     if ($option_key === '') {
         return;
     }
@@ -192,11 +187,8 @@ function hic_get_gtm_queue_option_key(string $sid): string {
  */
 function hic_get_and_clear_gtm_events_for_sid($sid) {
     $sid = !empty($sid) ? sanitize_text_field((string) $sid) : '';
-    if ($sid === '') {
-        return [];
-    }
 
-    $option_key = hic_get_gtm_queue_option_key($sid);
+    $option_key = $sid === '' ? 'hic_gtm_queued_events' : hic_get_gtm_queue_option_key($sid);
     if ($option_key === '') {
         return [];
     }


### PR DESCRIPTION
## Summary
- reset the cached log manager whenever the configured log file changes so deduplication tests read the correct file
- guard failed-request persistence against wpdb stubs that do not support insert operations
- ensure GTM events queued without a SID are returned and cleared through the standard helper

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d434d2af34832f9cdbdf84054e31d3