### PR TITLE
Add webhook HMAC signature validation

### DIFF
--- a/GUIDA_WEBHOOK_CONVERSIONI.md
+++ b/GUIDA_WEBHOOK_CONVERSIONI.md
@@ -39,12 +39,13 @@ Il sistema funziona in questo modo:
 ### 1. Configurazione in WordPress
 
 1. **Accedi a:** WordPress Admin → Impostazioni → HIC Monitoring
-2. **Imposta Modalità:** 
+2. **Imposta Modalità:**
    - `Webhook` per solo webhook
    - `Hybrid` per webhook + API polling (CONSIGLIATO per massima affidabilità)
 3. **Configura Token:** Inserisci un token sicuro (es. `hic2025ga4_TUOSITO`)
-4. **Se modalità Hybrid:** Configura anche credenziali API (URL, email, password, property ID)
-5. **Salva configurazione**
+4. **Imposta Webhook Secret:** Genera una chiave casuale (almeno 32 caratteri) che verrà condivisa solo con Hotel in Cloud per firmare ogni chiamata.
+5. **Se modalità Hybrid:** Configura anche credenziali API (URL, email, password, property ID)
+6. **Salva configurazione**
 
 ### 2. URL Webhook per Hotel in Cloud
 
@@ -65,6 +66,7 @@ https://www.villadianella.it/wp-json/hic/v1/conversion?token=hic2025ga4
 - **URL:** `https://tuosito.com/wp-json/hic/v1/conversion?token=IL_TUO_TOKEN`
 - **Metodo:** `POST`
 - **Content-Type:** `application/json`
+- **Header di sicurezza:** `X-HIC-Signature: sha256=<firma>` dove `<firma>` è la HMAC-SHA256 del corpo JSON calcolata usando il Webhook Secret condiviso (formula: `hash_hmac('sha256', $body, $secret)`)
 - **Trigger:** Su ogni nuova prenotazione confermata
 
 ## Payload Webhook
@@ -154,9 +156,10 @@ Dopo la configurazione, testa l'endpoint:
 ```bash
 curl -X POST "https://tuosito.com/wp-json/hic/v1/conversion?token=IL_TUO_TOKEN" \
   -H "Content-Type: application/json" \
+  -H "X-HIC-Signature: sha256=FIRMA_CALCOLATA" \
   -d '{
     "email": "test@example.com",
-    "reservation_id": "TEST123", 
+    "reservation_id": "TEST123",
     "amount": 100.00,
     "currency": "EUR"
   }'

--- a/README.md
+++ b/README.md
@@ -55,6 +55,12 @@ Schema campi principali:
 - `language` *(stringa)* – lingua dell'utente
 - `sid` *(stringa)* – identificatore utente opzionale per il tracciamento
 
+#### Sicurezza del Webhook
+
+- Configura un **Webhook Token** e un **Webhook Secret** dalle impostazioni del plugin. Il token protegge l'URL, mentre il secret viene utilizzato per firmare il payload.
+- Ogni chiamata deve includere l'header `X-HIC-Signature` con la firma HMAC-SHA256 del corpo raw (`sha256=<firma_esadecimale>` oppure la versione Base64 della firma).
+- Le richieste senza firma o con firma non valida vengono rifiutate con HTTP 401 e registrate nei log di sicurezza del plugin.
+
 #### 🎯 Webhook: La Soluzione per il Tracciamento Senza Redirect
 
 **Problema comune:** Il sistema di prenotazione di Hotel in Cloud non permette redirect al sito dopo la prenotazione, quindi la thank you page rimane nel dominio esterno di HIC.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -315,6 +315,17 @@ function hic_connection_uses_api($type = null) {
     return in_array($normalized, ['api', 'hybrid'], true);
 }
 function hic_get_webhook_token() { return hic_get_option('webhook_token', ''); }
+
+function hic_get_webhook_secret(): string
+{
+    $secret = hic_get_option('webhook_secret', '');
+
+    if (!is_string($secret)) {
+        return '';
+    }
+
+    return trim($secret);
+}
 function hic_get_api_url() { return hic_get_option('api_url', ''); }
 function hic_get_api_key() { return hic_get_option('api_key', ''); }
 
@@ -2679,6 +2690,7 @@ namespace {
     function hic_normalize_connection_type($type = null) { return \FpHic\Helpers\hic_normalize_connection_type($type); }
     function hic_connection_uses_api($type = null) { return \FpHic\Helpers\hic_connection_uses_api($type); }
     function hic_get_webhook_token() { return \FpHic\Helpers\hic_get_webhook_token(); }
+    function hic_get_webhook_secret(): string { return \FpHic\Helpers\hic_get_webhook_secret(); }
     function hic_get_api_url() { return \FpHic\Helpers\hic_get_api_url(); }
     function hic_get_api_key() { return \FpHic\Helpers\hic_get_api_key(); }
     function hic_get_api_email() { return \FpHic\Helpers\hic_get_api_email(); }

--- a/tests/WebhookSignatureValidationTest.php
+++ b/tests/WebhookSignatureValidationTest.php
@@ -1,0 +1,182 @@
+<?php
+require_once __DIR__ . '/../includes/api/webhook.php';
+require_once __DIR__ . '/../includes/input-validator.php';
+
+if (!class_exists('WP_REST_Request')) {
+    class WP_REST_Request {
+        private $method;
+        private $route;
+        private $params = [];
+        private $headers = [];
+
+        public function __construct($method = 'GET', $route = '', $attributes = [])
+        {
+            if (is_array($method)) {
+                $this->params = $method;
+                if (is_array($route)) {
+                    $this->headers = array_change_key_case($route, CASE_LOWER);
+                }
+                return;
+            }
+
+            $this->method = $method;
+            $this->route  = $route;
+
+            if (is_array($attributes)) {
+                $this->params = $attributes;
+            }
+        }
+
+        public function set_param($key, $value): void
+        {
+            $this->params[$key] = $value;
+        }
+
+        public function get_param($key)
+        {
+            return $this->params[$key] ?? null;
+        }
+
+        public function set_header($key, $value): void
+        {
+            $this->headers[strtolower($key)] = $value;
+        }
+
+        public function get_header($key)
+        {
+            $key = strtolower($key);
+            return $this->headers[$key] ?? '';
+        }
+    }
+}
+
+if (!class_exists('WebhookSignatureStream')) {
+    class WebhookSignatureStream {
+        public static $content = '';
+        private $offset = 0;
+
+        public function stream_open($path, $mode, $options, &$opened_path)
+        {
+            $this->offset = 0;
+            return true;
+        }
+
+        public function stream_read($count)
+        {
+            $chunk = substr(self::$content, $this->offset, $count);
+            $this->offset += strlen($chunk);
+            return $chunk;
+        }
+
+        public function stream_eof()
+        {
+            return $this->offset >= strlen(self::$content);
+        }
+
+        public function stream_stat()
+        {
+            return [];
+        }
+    }
+}
+
+final class WebhookSignatureValidationTest extends WP_UnitTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        update_option('hic_connection_type', 'webhook');
+        update_option('hic_webhook_token', 'signature_token');
+        update_option('hic_webhook_secret', 'super-secret-key');
+        \FpHic\Helpers\hic_clear_option_cache();
+    }
+
+    protected function tearDown(): void
+    {
+        delete_option('hic_webhook_secret');
+        delete_option('hic_webhook_token');
+        delete_option('hic_connection_type');
+        \FpHic\Helpers\hic_clear_option_cache();
+        parent::tearDown();
+    }
+
+    private function withWebhookBody(string $body, callable $callback)
+    {
+        stream_wrapper_unregister('php');
+        stream_wrapper_register('php', WebhookSignatureStream::class);
+        WebhookSignatureStream::$content = $body;
+
+        try {
+            return $callback();
+        } finally {
+            stream_wrapper_restore('php');
+            WebhookSignatureStream::$content = '';
+        }
+    }
+
+    private function buildPayload(): array
+    {
+        return [
+            'email' => 'mario.rossi@example.com',
+            'reservation_id' => 'HIC_SIG_123',
+            'guest_first_name' => 'Mario',
+            'guest_last_name' => 'Rossi',
+            'amount' => 120.0,
+            'currency' => 'EUR',
+            'checkin' => '2025-06-10',
+            'checkout' => '2025-06-12',
+        ];
+    }
+
+    public function test_webhook_requires_signature_when_secret_is_configured(): void
+    {
+        $payload = $this->buildPayload();
+        $json_payload = wp_json_encode($payload);
+
+        $result = $this->withWebhookBody($json_payload, function () {
+            $request = new WP_REST_Request(
+                ['token' => 'signature_token', 'email' => 'mario.rossi@example.com'],
+                ['content-type' => 'application/json']
+            );
+
+            return hic_webhook_handler($request);
+        });
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('missing_signature', $result->get_error_code());
+    }
+
+    public function test_webhook_rejects_invalid_signature(): void
+    {
+        $payload = $this->buildPayload();
+        $json_payload = wp_json_encode($payload);
+
+        $result = $this->withWebhookBody($json_payload, function () {
+            $request = new WP_REST_Request(
+                ['token' => 'signature_token', 'email' => 'mario.rossi@example.com'],
+                [
+                    'content-type' => 'application/json',
+                    HIC_WEBHOOK_SIGNATURE_HEADER => 'sha256=invalid',
+                ]
+            );
+
+            return hic_webhook_handler($request);
+        });
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('invalid_signature', $result->get_error_code());
+    }
+
+    public function test_signature_helper_accepts_hex_and_base64_formats(): void
+    {
+        $payload = wp_json_encode($this->buildPayload());
+        $secret = 'super-secret-key';
+        $hex_signature = hic_generate_webhook_signature($payload, $secret);
+        $this->assertTrue(hic_verify_webhook_signature($payload, 'sha256=' . strtoupper($hex_signature), $secret));
+
+        $binary = hex2bin($hex_signature);
+        $this->assertNotFalse($binary);
+        $base64_signature = base64_encode($binary);
+        $this->assertTrue(hic_verify_webhook_signature($payload, $base64_signature, $secret));
+    }
+}


### PR DESCRIPTION
## Summary
- add configurable webhook secret and enforce HMAC signature validation in the conversion endpoint
- expose the secret in the admin settings with sanitization and update the webhook documentation
- cover the new security flow with dedicated unit tests for signature handling

## Testing
- composer lint
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d441564358832fae223681650a2f19