### PR TITLE
Harden automated reporting export downloads

### DIFF
--- a/tests/AutomatedReportingDownloadTest.php
+++ b/tests/AutomatedReportingDownloadTest.php
@@ -25,6 +25,12 @@ if (!function_exists('check_ajax_referer')) {
     }
 }
 
+if (!function_exists('nocache_headers')) {
+    function nocache_headers() {
+        return true;
+    }
+}
+
 if (!function_exists('wp_die')) {
     function wp_die($message) {
         throw new \Exception($message);
@@ -35,6 +41,9 @@ require_once __DIR__ . '/../includes/automated-reporting.php';
 
 final class AutomatedReportingDownloadTest extends TestCase
 {
+    /** @var string[] */
+    private array $tempDirectories = [];
+
     protected function setUp(): void
     {
         $this->resetManagerInstance();
@@ -45,6 +54,7 @@ final class AutomatedReportingDownloadTest extends TestCase
     {
         $this->resetManagerInstance();
         $_GET = [];
+        $this->cleanupTempDirectories();
     }
 
     public function test_handle_download_export_with_missing_directory_returns_error(): void
@@ -68,6 +78,54 @@ final class AutomatedReportingDownloadTest extends TestCase
         }
     }
 
+    public function test_handle_download_export_blocks_disallowed_extension(): void
+    {
+        $_GET['file'] = 'report.txt';
+        $_GET['nonce'] = 'valid';
+
+        $manager = \FpHic\AutomatedReporting\AutomatedReportingManager::instance();
+        $exportDir = $this->createExportDirectory();
+        file_put_contents($exportDir . 'report.txt', 'demo');
+
+        $managerReflection = new \ReflectionClass($manager);
+        $exportDirProperty = $managerReflection->getProperty('export_dir');
+        $exportDirProperty->setAccessible(true);
+        $exportDirProperty->setValue($manager, $exportDir);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('File not found');
+        $manager->handle_download_export();
+    }
+
+    public function test_handle_download_export_blocks_symbolic_links(): void
+    {
+        if (!function_exists('symlink')) {
+            $this->markTestSkipped('Symlink function not available.');
+        }
+
+        $exportDir = $this->createExportDirectory();
+        $targetFile = $exportDir . 'valid.csv';
+        file_put_contents($targetFile, 'demo');
+
+        $linkFile = $exportDir . 'alias.csv';
+        if (@symlink($targetFile, $linkFile) === false) {
+            $this->markTestSkipped('Symlinks are not supported in this environment.');
+        }
+
+        $_GET['file'] = 'alias.csv';
+        $_GET['nonce'] = 'valid';
+
+        $manager = \FpHic\AutomatedReporting\AutomatedReportingManager::instance();
+        $managerReflection = new \ReflectionClass($manager);
+        $exportDirProperty = $managerReflection->getProperty('export_dir');
+        $exportDirProperty->setAccessible(true);
+        $exportDirProperty->setValue($manager, $exportDir);
+
+        $this->expectException(\Exception::class);
+        $this->expectExceptionMessage('File not found');
+        $manager->handle_download_export();
+    }
+
     private function resetManagerInstance(): void
     {
         $managerReflection = new \ReflectionClass(\FpHic\AutomatedReporting\AutomatedReportingManager::class);
@@ -76,6 +134,57 @@ final class AutomatedReportingDownloadTest extends TestCase
             $property->setAccessible(true);
             $property->setValue(null, null);
         }
+    }
+
+    private function createExportDirectory(): string
+    {
+        $directory = sys_get_temp_dir() . '/hic-export-' . uniqid('', true) . DIRECTORY_SEPARATOR;
+
+        if (!mkdir($directory, 0777, true) && !is_dir($directory)) {
+            $this->fail('Unable to create temporary export directory.');
+        }
+
+        $this->tempDirectories[] = $directory;
+
+        return $directory;
+    }
+
+    private function cleanupTempDirectories(): void
+    {
+        foreach ($this->tempDirectories as $directory) {
+            $this->removeDirectory($directory);
+        }
+
+        $this->tempDirectories = [];
+    }
+
+    private function removeDirectory(string $directory): void
+    {
+        if (!is_dir($directory)) {
+            return;
+        }
+
+        $items = scandir($directory);
+
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $directory . DIRECTORY_SEPARATOR . $item;
+
+            if (is_dir($path) && !is_link($path)) {
+                $this->removeDirectory($path);
+            } else {
+                @unlink($path);
+            }
+        }
+
+        @rmdir($directory);
     }
 }
 


### PR DESCRIPTION
## Summary
- reject automated reporting export downloads when the requested file has an unexpected extension or resolves to a symbolic link
- tighten validation for export paths and send no-cache and explicit MIME headers before streaming files
- extend automated reporting download tests to cover blocked extensions, symlinks and add fixture cleanup helpers

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d445506708832fa555f1b7e3d2294f