### PR TITLE
Add health check token management tools

### DIFF
--- a/assets/css/admin-settings.css
+++ b/assets/css/admin-settings.css
@@ -13,3 +13,19 @@
     visibility: visible;
 }
 
+.hic-health-token-control {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    margin-top: 10px;
+}
+
+.hic-health-token-control input[type="text"] {
+    max-width: 320px;
+}
+
+#hic-health-token-status {
+    margin-top: 8px;
+    font-style: italic;
+}
+

--- a/assets/js/admin-settings.js
+++ b/assets/js/admin-settings.js
@@ -81,4 +81,36 @@ jQuery(function($){
             resultDiv.html('<div style="color: red;">Errore nella richiesta: ' + error + '</div>');
         });
     });
+
+    $('#hic-generate-health-token').on('click', function(){
+        var $button = $(this);
+        var $input = $('#hic_health_token');
+        var $status = $('#hic-health-token-status');
+
+        $button.prop('disabled', true);
+        $status.text('Generazione token in corso...');
+
+        var data = {
+            action: 'hic_generate_health_token',
+            nonce: hicAdminSettings.health_nonce
+        };
+
+        $.post(ajaxurl, data, function(response){
+            var message = 'Impossibile generare un nuovo token.';
+            if (response && response.success && response.data) {
+                if (response.data.token) {
+                    $input.val(response.data.token);
+                }
+                message = response.data.message || 'Nuovo token generato. Ricorda di salvare le impostazioni.';
+            } else if (response && response.data && response.data.message) {
+                message = response.data.message;
+            }
+
+            $status.text(message);
+        }, 'json').fail(function(){
+            $status.text('Errore durante la generazione del token. Riprova.');
+        }).always(function(){
+            $button.prop('disabled', false);
+        });
+    });
 });

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -255,6 +255,7 @@ function hic_get_brevo_list_default() { return hic_get_option('brevo_list_defaul
 function hic_get_brevo_optin_default() { return hic_get_option('brevo_optin_default', '0') === '1'; }
 function hic_is_brevo_enabled() { return hic_get_option('brevo_enabled', '0') === '1'; }
 function hic_is_debug_verbose() { return hic_get_option('debug_verbose', '0') === '1'; }
+function hic_get_health_token() { return hic_get_option('health_token', ''); }
 
 // New email enrichment settings
 function hic_updates_enrich_contacts() { return hic_get_option('updates_enrich_contacts', '1') === '1'; }
@@ -2673,6 +2674,7 @@ namespace {
     function hic_get_brevo_optin_default() { return \FpHic\Helpers\hic_get_brevo_optin_default(); }
     function hic_is_brevo_enabled() { return \FpHic\Helpers\hic_is_brevo_enabled(); }
     function hic_is_debug_verbose() { return \FpHic\Helpers\hic_is_debug_verbose(); }
+    function hic_get_health_token() { return \FpHic\Helpers\hic_get_health_token(); }
     function hic_updates_enrich_contacts() { return \FpHic\Helpers\hic_updates_enrich_contacts(); }
     function hic_get_brevo_list_alias() { return \FpHic\Helpers\hic_get_brevo_list_alias(); }
     function hic_brevo_double_optin_on_enrich() { return \FpHic\Helpers\hic_brevo_double_optin_on_enrich(); }

--- a/includes/health-monitor.php
+++ b/includes/health-monitor.php
@@ -453,7 +453,7 @@ class HIC_Health_Monitor {
      * Validate public health check token
      */
     private function validate_health_token($token) {
-        $saved = get_option('hic_health_token');
+        $saved = \FpHic\Helpers\hic_get_health_token();
         return !empty($token) && !empty($saved) && hash_equals($saved, $token);
     }
 

--- a/includes/site-health.php
+++ b/includes/site-health.php
@@ -56,7 +56,7 @@ function hic_site_health_webhook_ping(array $result): array
 {
     $result['label'] = __('Ping Webhook', 'hotel-in-cloud');
 
-    $token = get_option('hic_health_token');
+    $token = Helpers\hic_get_health_token();
     if (empty($token)) {
         $result['status']      = 'recommended';
         $result['description'] = __('Token health non configurato.', 'hotel-in-cloud');

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -189,6 +189,26 @@ if (!function_exists('sanitize_email')) {
     }
 }
 
+if (!function_exists('wp_generate_password')) {
+    function wp_generate_password($length = 12, $special_chars = true, $extra_special_chars = false) {
+        $length = (int) $length;
+        if ($length < 1) {
+            $length = 12;
+        }
+
+        $alphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
+        $alphabet_length = strlen($alphabet);
+        $password = '';
+
+        for ($i = 0; $i < $length; $i++) {
+            $index = random_int(0, $alphabet_length - 1);
+            $password .= $alphabet[$index];
+        }
+
+        return $password;
+    }
+}
+
 if (!function_exists('wp_unslash')) {
     function wp_unslash($value) {
         if (is_array($value)) {
@@ -196,6 +216,12 @@ if (!function_exists('wp_unslash')) {
         }
 
         return is_string($value) ? stripslashes($value) : $value;
+    }
+}
+
+if (!function_exists('add_settings_error')) {
+    function add_settings_error($setting, $code, $message, $type = 'error') {
+        $GLOBALS['hic_settings_errors'][] = compact('setting', 'code', 'message', 'type');
     }
 }
 
@@ -424,6 +450,11 @@ if (!function_exists('sanitize_text_field')) {
 if (!function_exists('esc_html')) {
     function esc_html($text) {
         return htmlspecialchars($text, ENT_QUOTES, 'UTF-8');
+    }
+}
+if (!function_exists('esc_html__')) {
+    function esc_html__($text, $domain = null) {
+        return esc_html($text);
     }
 }
 


### PR DESCRIPTION
## Summary
- add a secure admin control to view and regenerate the health-check token with AJAX handling and UI feedback
- expose helpers so health monitoring code consistently loads the stored token
- extend automated tests and stubs to cover the new sanitization, generation logic, and AJAX handler

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d44a2bbdb0832f98a22698d14bf5dd