### PR TITLE
Normalize SID validation errors

### DIFF
--- a/includes/input-validator.php
+++ b/includes/input-validator.php
@@ -175,7 +175,17 @@ class HIC_Input_Validator {
 
         if (!empty($errors)) {
             if (count($errors) === 1 && $errors[0] instanceof \WP_Error) {
-                return $errors[0];
+                $single_error = $errors[0];
+                $error_data = $single_error->get_error_data();
+                $field = '';
+
+                if (is_array($error_data) && isset($error_data['field'])) {
+                    $field = strtolower((string) $error_data['field']);
+                }
+
+                if ($field !== 'sid') {
+                    return $single_error;
+                }
             }
 
             $messages = [];


### PR DESCRIPTION
## Summary
- keep single field validation errors reporting their original error codes unless the SID alias validation fails
- wrap SID-specific validation failures in a generic `validation_failed` response so webhook consumers receive the aggregated payload structure

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d457420c78832fb4c4d31714a77ef9