### PR TITLE
Add gettext extraction tooling

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -42,7 +42,8 @@
         ],
         "quality:fix": [
             "@lint:fix"
-        ]
+        ],
+        "i18n:pot": "php tools/make-pot.php"
     },
     "archive": {
         "exclude": [

--- a/languages/hotel-in-cloud.pot
+++ b/languages/hotel-in-cloud.pot
@@ -1,0 +1,273 @@
+msgid ""
+msgstr ""
+"Project-Id-Version: FP HIC Monitor\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2025-09-24 20:47+0000\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"X-Generator: FP HIC make-pot.php\n"
+
+#: includes/admin/diagnostics.php:1833
+msgid "Test connettività Brevo fallito"
+msgstr ""
+
+#: includes/admin/admin-settings.php:596
+msgid "Il token protegge l'endpoint pubblico di health check. Condividilo solo con i sistemi di monitoraggio di fiducia."
+msgstr ""
+
+#: includes/admin/diagnostics.php:781
+msgid "Alcune tabelle potrebbero non essere state create."
+msgstr ""
+
+#: includes/admin/diagnostics.php:1233
+msgid "Non hai i permessi necessari per accedere a questa pagina."
+msgstr ""
+
+#: includes/admin/diagnostics.php:900
+msgid "Errore nel recupero prenotazioni: %s"
+msgstr ""
+
+#: includes/helpers-tracking.php:11
+#: includes/helpers-tracking.php:19
+#: includes/helpers-tracking.php:95
+msgid "Dati di tracciamento HIC"
+msgstr ""
+
+#: includes/realtime-dashboard.php:235
+msgid "Conversioni"
+msgstr ""
+
+#: includes/admin/diagnostics.php:689
+#: includes/admin/diagnostics.php:717
+#: includes/admin/diagnostics.php:736
+#: includes/admin/diagnostics.php:749
+#: includes/admin/diagnostics.php:804
+#: includes/admin/diagnostics.php:889
+#: includes/admin/diagnostics.php:1038
+#: includes/admin/diagnostics.php:1059
+#: includes/admin/diagnostics.php:1116
+#: includes/admin/diagnostics.php:1163
+#: includes/admin/diagnostics.php:1205
+#: includes/admin/diagnostics.php:1739
+#: includes/admin/diagnostics.php:1762
+#: includes/admin/diagnostics.php:1816
+#: includes/admin/diagnostics.php:1855
+#: includes/admin/diagnostics.php:1910
+msgid "Nonce non valido"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1923
+msgid "Errore durante recupero statistiche: %s"
+msgstr ""
+
+#: includes/realtime-dashboard.php:236
+msgid "Revenue"
+msgstr ""
+
+#: includes/admin/diagnostics.php:837
+msgid "Tipo di data non valido. Deve essere \"checkin\", \"checkout\" o \"presence\"."
+msgstr ""
+
+#: includes/admin/diagnostics.php:1773
+msgid "File di log non leggibile"
+msgstr ""
+
+#: includes/site-health.php:35
+msgid "La configurazione GA4 è completa."
+msgstr ""
+
+#: includes/admin/diagnostics.php:1897
+msgid "Errore fatale durante test traffico web: %s"
+msgstr ""
+
+#: includes/site-health.php:14
+#: includes/site-health.php:42
+msgid "Configurazione GA4"
+msgstr ""
+
+#: includes/intelligent-polling-manager.php:60
+msgid "Every 5 minutes (Intelligent)"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1192
+msgid "Errore fatale durante il reset dei timestamp: %s"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1189
+msgid "Errore durante il reset dei timestamp: %s"
+msgstr ""
+
+#: includes/admin/diagnostics.php:707
+msgid "Errore fatale durante il caricamento diagnostiche: %s"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1821
+msgid "API key Brevo mancante. Configura prima l'API key nelle impostazioni."
+msgstr ""
+
+#: includes/realtime-dashboard.php:237
+msgid "Prenotazioni"
+msgstr ""
+
+#: includes/admin/diagnostics.php:781
+msgid "Tutte le tabelle sono state create/verificate con successo."
+msgstr ""
+
+#: includes/site-health.php:19
+#: includes/site-health.php:57
+msgid "Ping Webhook"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1046
+msgid "Tracking degli invii resettato con successo. Ora puoi inviare nuovamente tutte le prenotazioni alle integrazioni."
+msgstr ""
+
+#: includes/admin/diagnostics.php:1222
+msgid "Errore nel recupero dello stato: %s"
+msgstr ""
+
+#: includes/site-health.php:62
+msgid "Token health non configurato."
+msgstr ""
+
+#: includes/admin/diagnostics.php:1181
+msgid "Timestamp reset completed successfully - all timestamps reset and scheduler restarted"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1840
+msgid "Test connettività Brevo completato"
+msgstr ""
+
+#: includes/intelligent-polling-manager.php:56
+msgid "Every 2 minutes (Intelligent)"
+msgstr ""
+
+#: includes/realtime-dashboard.php:234
+msgid "Nessun dato disponibile"
+msgstr ""
+
+#: includes/intelligent-polling-manager.php:68
+msgid "Every 30 minutes (Intelligent)"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1016
+msgid "Prenotazioni inviate alle integrazioni configurate"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1068
+msgid "Classe HIC_Booking_Poller non trovata"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1049
+msgid "Errore durante il reset: %s"
+msgstr ""
+
+#: includes/admin/diagnostics.php:907
+msgid "Nessuna prenotazione trovata nell'API"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1150
+msgid "Errore fatale durante l'esecuzione del watchdog: %s"
+msgstr ""
+
+#: includes/admin/diagnostics.php:704
+msgid "Errore durante il caricamento diagnostiche: %s"
+msgstr ""
+
+#: includes/site-health.php:74
+msgid "Webhook non raggiungibile o token non valido."
+msgstr ""
+
+#: includes/intelligent-polling-manager.php:64
+msgid "Every 15 minutes (Intelligent)"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1185
+msgid "Classe HIC_Booking_Poller non disponibile"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1147
+msgid "Errore durante l'esecuzione del watchdog: %s"
+msgstr ""
+
+#: includes/realtime-dashboard.php:233
+msgid "Errore nel caricamento dei dati"
+msgstr ""
+
+#: includes/admin/admin-settings.php:594
+msgid "Genera nuovo token"
+msgstr ""
+
+#: includes/realtime-dashboard.php:232
+msgid "Caricamento..."
+msgstr ""
+
+#: includes/admin/diagnostics.php:791
+msgid "Errore durante la creazione delle tabelle. Controlla i log per maggiori dettagli."
+msgstr ""
+
+#: includes/admin/diagnostics.php:1138
+msgid "Watchdog check completed successfully"
+msgstr ""
+
+#: includes/admin/diagnostics.php:685
+#: includes/admin/diagnostics.php:713
+#: includes/admin/diagnostics.php:732
+#: includes/admin/diagnostics.php:745
+#: includes/admin/diagnostics.php:800
+#: includes/admin/diagnostics.php:885
+#: includes/admin/diagnostics.php:1034
+#: includes/admin/diagnostics.php:1055
+#: includes/admin/diagnostics.php:1112
+#: includes/admin/diagnostics.php:1159
+#: includes/admin/diagnostics.php:1201
+#: includes/admin/diagnostics.php:1735
+#: includes/admin/diagnostics.php:1758
+#: includes/admin/diagnostics.php:1812
+#: includes/admin/diagnostics.php:1851
+#: includes/admin/diagnostics.php:1906
+msgid "Permessi insufficienti"
+msgstr ""
+
+#: includes/admin/diagnostics.php:842
+msgid "Date di inizio e fine sono obbligatorie"
+msgstr ""
+
+#: includes/admin/diagnostics.php:312
+#: includes/admin/diagnostics.php:794
+#: includes/admin/diagnostics.php:1028
+msgid "Errore: %s"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1103
+msgid "Errore durante l'esecuzione del polling: %s"
+msgstr ""
+
+#: includes/admin/diagnostics.php:910
+msgid "Tutte le ultime 5 prenotazioni sono già state inviate. Usa il bottone \"Reset Download Tracking\" per reinviarle."
+msgstr ""
+
+#: includes/intelligent-polling-manager.php:52
+msgid "Every 1 minute (Intelligent)"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1918
+msgid "Statistiche traffico web recuperate"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1879
+msgid "Test monitoraggio traffico web completato"
+msgstr ""
+
+#: includes/admin/diagnostics.php:1894
+msgid "Errore durante test traffico web: %s"
+msgstr ""
+
+#: includes/site-health.php:38
+msgid "GA4 non è configurato correttamente."
+msgstr ""
+
+#: includes/site-health.php:71
+msgid "Webhook risponde correttamente."
+msgstr ""

--- a/tools/make-pot.php
+++ b/tools/make-pot.php
@@ -1,0 +1,304 @@
+<?php declare(strict_types=1);
+
+/**
+ * Simple gettext extractor for the FP HIC Monitor plugin.
+ *
+ * The script scans the plugin PHP files for translation functions and
+ * generates a POT catalogue under the languages/ directory.
+ */
+
+$root = dirname(__DIR__);
+$output = $root . '/languages/hotel-in-cloud.pot';
+$domain = 'hotel-in-cloud';
+
+$functions = [
+    '__'              => 'simple',
+    '_e'              => 'simple',
+    'esc_html__'      => 'simple',
+    'esc_html_e'      => 'simple',
+    'esc_attr__'      => 'simple',
+    'esc_attr_e'      => 'simple',
+    '_x'              => 'context',
+    '_ex'             => 'context',
+    'esc_html_x'      => 'context',
+    'esc_attr_x'      => 'context',
+    '_n'              => 'plural',
+    '_nx'             => 'plural_context',
+    '_n_noop'         => 'noop',
+    '_nx_noop'        => 'noop_context',
+];
+
+$iterator = new RecursiveIteratorIterator(
+    new RecursiveDirectoryIterator($root, FilesystemIterator::SKIP_DOTS)
+);
+
+$entries = [];
+
+/**
+ * @param array<string, mixed> $entry
+ */
+function add_entry(array &$entries, array $entry): void
+{
+    $keyParts = [
+        $entry['context'] ?? '',
+        $entry['msgid'],
+        $entry['msgid_plural'] ?? '',
+    ];
+    $key = md5(implode("\x04", $keyParts));
+
+    if (!isset($entries[$key])) {
+        $entries[$key] = $entry;
+        $entries[$key]['references'] = [];
+    }
+
+    $entries[$key]['references'] = array_values(array_unique(array_merge(
+        $entries[$key]['references'],
+        $entry['references']
+    )));
+}
+
+function decode_php_string(string $token): string
+{
+    $quote = $token[0];
+    $inner = substr($token, 1, -1);
+
+    if ($quote === '\'') {
+        return str_replace(["\\\\", "\\'"], ["\\", "'"], $inner);
+    }
+
+    if ($quote === '"') {
+        return stripcslashes($inner);
+    }
+
+    return $inner;
+}
+
+/**
+ * @return list<array{value:string,line:int}>
+ */
+function get_function_strings(array $tokens, int $index): array
+{
+    $strings = [];
+    $foundParenthesis = false;
+    $level = 0;
+    $total = count($tokens);
+
+    for ($i = $index + 1; $i < $total; $i++) {
+        $token = $tokens[$i];
+
+        if (!$foundParenthesis) {
+            if (is_array($token)) {
+                $type = $token[0];
+                if ($type === T_WHITESPACE || $type === T_COMMENT || $type === T_DOC_COMMENT) {
+                    continue;
+                }
+            }
+
+            if ($token === '(') {
+                $foundParenthesis = true;
+                $level = 1;
+                continue;
+            }
+
+            break;
+        }
+
+        if (is_string($token)) {
+            if ($token === '(') {
+                $level++;
+                continue;
+            }
+            if ($token === ')') {
+                $level--;
+                if ($level === 0) {
+                    break;
+                }
+                continue;
+            }
+            continue;
+        }
+
+        if ($level === 1 && $token[0] === T_CONSTANT_ENCAPSED_STRING) {
+            $strings[] = [
+                'value' => decode_php_string($token[1]),
+                'line'  => $token[2],
+            ];
+        }
+    }
+
+    return $strings;
+}
+
+foreach ($iterator as $fileInfo) {
+    /** @var SplFileInfo $fileInfo */
+    if (!$fileInfo->isFile()) {
+        continue;
+    }
+
+    $path = $fileInfo->getPathname();
+    $relative = str_replace($root . DIRECTORY_SEPARATOR, '', $path);
+    $relative = str_replace('\\', '/', $relative);
+
+    // Skip vendor, node_modules, build artefacts.
+    if (preg_match('#^(vendor|node_modules|build|tests|docs)(/|$)#u', $relative)) {
+        continue;
+    }
+
+    if (substr($relative, -4) !== '.php') {
+        continue;
+    }
+
+    $code = file_get_contents($path);
+    if ($code === false) {
+        fwrite(STDERR, "Cannot read {$relative}\n");
+        continue;
+    }
+
+    $tokens = token_get_all($code);
+
+    $total = count($tokens);
+    for ($i = 0; $i < $total; $i++) {
+        $token = $tokens[$i];
+
+        if (!is_array($token)) {
+            continue;
+        }
+
+        if ($token[0] !== T_STRING) {
+            continue;
+        }
+
+        $functionName = $token[1];
+        if (!isset($functions[$functionName])) {
+            continue;
+        }
+
+        $strings = get_function_strings($tokens, $i);
+        if ($strings === []) {
+            continue;
+        }
+
+        // Ensure the plugin text domain is present somewhere in the call.
+        $hasDomain = false;
+        foreach ($strings as $stringToken) {
+            if ($stringToken['value'] === $domain) {
+                $hasDomain = true;
+                break;
+            }
+        }
+
+        if (!$hasDomain) {
+            continue;
+        }
+
+        $entry = [
+            'msgid'        => '',
+            'msgid_plural' => null,
+            'context'      => null,
+            'references'   => [str_replace(DIRECTORY_SEPARATOR, '/', $relative) . ':' . $token[2]],
+        ];
+
+        switch ($functions[$functionName]) {
+            case 'simple':
+                $entry['msgid'] = $strings[0]['value'];
+                break;
+
+            case 'context':
+                if (count($strings) < 2) {
+                    continue 2;
+                }
+                $entry['msgid'] = $strings[0]['value'];
+                $entry['context'] = $strings[1]['value'];
+                break;
+
+            case 'plural':
+                if (count($strings) < 2) {
+                    continue 2;
+                }
+                $entry['msgid'] = $strings[0]['value'];
+                $entry['msgid_plural'] = $strings[1]['value'];
+                break;
+
+            case 'plural_context':
+                if (count($strings) < 3) {
+                    continue 2;
+                }
+                $entry['msgid'] = $strings[0]['value'];
+                $entry['msgid_plural'] = $strings[1]['value'];
+                $entry['context'] = $strings[2]['value'];
+                break;
+
+            case 'noop':
+                if (count($strings) < 2) {
+                    continue 2;
+                }
+                $entry['msgid'] = $strings[0]['value'];
+                $entry['msgid_plural'] = $strings[1]['value'];
+                break;
+
+            case 'noop_context':
+                if (count($strings) < 3) {
+                    continue 2;
+                }
+                $entry['msgid'] = $strings[0]['value'];
+                $entry['msgid_plural'] = $strings[1]['value'];
+                $entry['context'] = $strings[2]['value'];
+                break;
+
+            default:
+                continue 2;
+        }
+
+        add_entry($entries, $entry);
+    }
+}
+
+ksort($entries);
+
+$potLines = [];
+$potLines[] = 'msgid ""';
+$potLines[] = 'msgstr ""';
+$potLines[] = '"Project-Id-Version: FP HIC Monitor\\n"';
+$potLines[] = '"Report-Msgid-Bugs-To: \\n"';
+$potLines[] = '"POT-Creation-Date: ' . gmdate('Y-m-d H:iO') . '\\n"';
+$potLines[] = '"MIME-Version: 1.0\\n"';
+$potLines[] = '"Content-Type: text/plain; charset=UTF-8\\n"';
+$potLines[] = '"Content-Transfer-Encoding: 8bit\\n"';
+$potLines[] = '"X-Generator: FP HIC make-pot.php\\n"';
+$potLines[] = '';
+
+foreach ($entries as $entry) {
+    foreach ($entry['references'] as $reference) {
+        $potLines[] = '#: ' . $reference;
+    }
+
+    if ($entry['context'] !== null) {
+        $potLines[] = 'msgctxt ' . format_pot_string($entry['context']);
+    }
+
+    $potLines[] = 'msgid ' . format_pot_string($entry['msgid']);
+
+    if ($entry['msgid_plural'] !== null) {
+        $potLines[] = 'msgid_plural ' . format_pot_string($entry['msgid_plural']);
+        $potLines[] = 'msgstr[0] ""';
+        $potLines[] = 'msgstr[1] ""';
+    } else {
+        $potLines[] = 'msgstr ""';
+    }
+
+    $potLines[] = '';
+}
+
+if (!is_dir(dirname($output))) {
+    mkdir(dirname($output), 0775, true);
+}
+
+file_put_contents($output, implode("\n", $potLines));
+
+echo "Generated POT file at {$output}\n";
+
+function format_pot_string(string $value): string
+{
+    $escaped = addcslashes($value, "\n\r\t\"\\");
+    return '"' . $escaped . '"';
+}


### PR DESCRIPTION
## Summary
- add a custom PHP extractor that scans plugin sources and builds the gettext catalogue
- wire the generator into composer scripts and produce the up-to-date hotel-in-cloud.pot template

## Testing
- composer i18n:pot

------
https://chatgpt.com/codex/tasks/task_e_68d457fa496c832f85806115b446b07d