### PR TITLE
Fix deactivation cleanup database table resolution

### DIFF
--- a/includes/booking-poller.php
+++ b/includes/booking-poller.php
@@ -1675,13 +1675,22 @@ function hic_deactivate(): void {
         delete_transient($transient);
     }
 
-    global $wpdb;
-    if (isset($wpdb)) {
-        // Clear all hic_* transients including processing locks
-        $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE '_transient_hic_%' OR option_name LIKE '_transient_timeout_hic_%'");
+    $wpdb = Helpers\hic_get_wpdb_instance(['query']);
 
-        // Remove temporary options related to polling and locks
-        $wpdb->query("DELETE FROM {$wpdb->options} WHERE option_name LIKE 'hic_last_%' OR option_name LIKE 'hic_%_lock'");
+    if ($wpdb) {
+        $options_table = Helpers\hic_get_options_table_name($wpdb);
+
+        if (is_string($options_table) && $options_table !== '') {
+            if (function_exists('esc_sql')) {
+                $options_table = esc_sql($options_table);
+            }
+
+            // Clear all hic_* transients including processing locks
+            $wpdb->query("DELETE FROM {$options_table} WHERE option_name LIKE '_transient_hic_%' OR option_name LIKE '_transient_timeout_hic_%'");
+
+            // Remove temporary options related to polling and locks
+            $wpdb->query("DELETE FROM {$options_table} WHERE option_name LIKE 'hic_last_%' OR option_name LIKE 'hic_%_lock'");
+        }
     }
 
     delete_option('hic_api_calls_today');

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -36,6 +36,59 @@ function hic_get_wpdb_instance(array $required_methods = [])
     return $wpdb;
 }
 
+/**
+ * Determine the options table name for a wpdb instance without triggering
+ * dynamic property notices on custom test doubles.
+ *
+ * @param object $wpdb The wpdb-like instance.
+ * @return string|null Fully qualified table name or null when unavailable.
+ */
+function hic_get_options_table_name($wpdb)
+{
+    if (!is_object($wpdb)) {
+        return null;
+    }
+
+    $candidates = [];
+
+    if (property_exists($wpdb, 'options')) {
+        $options_table = $wpdb->options;
+        if (is_string($options_table) && $options_table !== '') {
+            $candidates[] = $options_table;
+        }
+    }
+
+    if (property_exists($wpdb, 'prefix')) {
+        $prefix = $wpdb->prefix;
+        if (is_string($prefix) && $prefix !== '') {
+            $candidates[] = $prefix . 'options';
+        }
+    }
+
+    if (property_exists($wpdb, 'base_prefix')) {
+        $base_prefix = $wpdb->base_prefix;
+        if (is_string($base_prefix) && $base_prefix !== '') {
+            $candidates[] = $base_prefix . 'options';
+        }
+    }
+
+    if (method_exists($wpdb, 'get_blog_prefix')) {
+        $blog_prefix = $wpdb->get_blog_prefix();
+        if (is_string($blog_prefix) && $blog_prefix !== '') {
+            $candidates[] = $blog_prefix . 'options';
+        }
+    }
+
+    foreach ($candidates as $candidate) {
+        $candidate = trim((string) $candidate);
+        if ($candidate !== '') {
+            return $candidate;
+        }
+    }
+
+    return null;
+}
+
 /* ================= CONFIG FUNCTIONS ================= */
 function &hic_option_cache() {
     static $cache = [];


### PR DESCRIPTION
## Summary
- add a helper to resolve the wp_options table name without triggering dynamic property warnings
- update the deactivation cleanup to use the helper and guard queries when wpdb is unavailable

## Testing
- composer test -- --display-warnings
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68d45e84a05c832f89cf17794c6194d6