### PR TITLE
Add test-safe controls for booking metrics singleton

### DIFF
--- a/includes/booking-metrics.php
+++ b/includes/booking-metrics.php
@@ -25,6 +25,16 @@ class BookingMetrics
         return self::$instance;
     }
 
+    /**
+     * Reset the singleton instance. Primarily useful for integration tests or
+     * when the booking metrics pipeline needs to be reinitialised during the
+     * same request (for example after cleaning up global state in CLI tools).
+     */
+    public static function resetInstance(): void
+    {
+        self::$instance = null;
+    }
+
     private function __construct()
     {
         if (function_exists('add_action')) {
@@ -148,6 +158,20 @@ class BookingMetrics
         }
 
         return $exists;
+    }
+
+    /**
+     * Manually override the cached table state.
+     *
+     * WordPress unit and integration tests frequently fake the database layer
+     * with doubles that do not support real table creation. When those tests
+     * exercise the booking metrics pipeline we need to skip the expensive
+     * `ensureTable()` logic. Exposing this helper keeps the production code
+     * simple while avoiding brittle reflection hacks in the tests.
+     */
+    public function overrideTableEnsuredState(bool $ensured): void
+    {
+        $this->tableEnsured = $ensured;
     }
 
     /**

--- a/tests/BookingMetricsIngestionTest.php
+++ b/tests/BookingMetricsIngestionTest.php
@@ -156,18 +156,14 @@ final class BookingMetricsIngestionTest extends TestCase
 
     private function resetBookingMetricsSingleton(): void
     {
-        $property = new ReflectionProperty(BookingMetrics::class, 'instance');
-        $property->setAccessible(true);
-        $property->setValue(null);
+        BookingMetrics::resetInstance();
     }
 
     private function bookingMetrics(): BookingMetrics
     {
         $instance = BookingMetrics::instance();
 
-        $ensured = new ReflectionProperty(BookingMetrics::class, 'tableEnsured');
-        $ensured->setAccessible(true);
-        $ensured->setValue($instance, true);
+        $instance->overrideTableEnsuredState(true);
 
         return $instance;
     }


### PR DESCRIPTION
## Summary
- add public helpers to the booking metrics singleton to allow resetting the instance and overriding the table-ensured cache
- refactor the booking metrics ingestion tests to rely on the new helpers instead of reflection, removing PHP 8.4 deprecations

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d4e71fb28c832fb72318a2ddda7698