### PR TITLE
Improve plugin zip build workflow

### DIFF
--- a/.github/workflows/build-plugin.yml
+++ b/.github/workflows/build-plugin.yml
@@ -1,4 +1,4 @@
-name: Build Plugin
+name: Build WordPress Plugin ZIP
 
 on:
   push:
@@ -6,9 +6,14 @@ on:
       - 'v*.*.*'
   workflow_dispatch:
 
+env:
+  PLUGIN_SLUG: fp-hotel-in-cloud-monitoraggio-conversioni
+  MAIN_PLUGIN_FILE: FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
@@ -20,14 +25,46 @@ jobs:
           tools: composer:v2
           coverage: none
 
-      - name: Install dependencies
+      - name: Validate composer.json
+        run: composer validate --strict
+
+      - name: Install production dependencies
         run: composer install --no-dev --optimize-autoloader --prefer-dist --no-progress
 
-      - name: Run build script
+      - name: Run quality checks
+        run: php qa-runner.php
+
+      - name: Detect plugin version
+        id: version
+        run: |
+          VERSION=$(grep "Version:" "$MAIN_PLUGIN_FILE" | sed 's/.*Version: *//' | tr -d ' ')
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Detected plugin version: $VERSION"
+
+      - name: Build plugin ZIP
         run: ./build-plugin.sh
 
-      - name: Upload artifact
+      - name: Rename ZIP with version
+        id: package
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          cd build
+          OLD_ZIP="${PLUGIN_SLUG}.zip"
+          NEW_ZIP="${PLUGIN_SLUG}-v${VERSION}.zip"
+          mv "$OLD_ZIP" "$NEW_ZIP"
+          ZIP_PATH="$(pwd)/$NEW_ZIP"
+          echo "zip_path=$ZIP_PATH" >> "$GITHUB_OUTPUT"
+          echo "zip_name=$NEW_ZIP" >> "$GITHUB_OUTPUT"
+
+      - name: Upload build artifact
         uses: actions/upload-artifact@v4
         with:
-          name: plugin-zip
-          path: build/*.zip
+          name: ${{ steps.package.outputs.zip_name }}
+          path: ${{ steps.package.outputs.zip_path }}
+          retention-days: 30
+
+      - name: Publish build summary
+        run: |
+          echo "## WordPress Plugin Build" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Version: ${{ steps.version.outputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact: ${{ steps.package.outputs.zip_name }}" >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- enhance the plugin build workflow with validation, QA, and version detection
- rename the generated ZIP with the plugin version and publish a build summary

## Testing
- not run (workflow change only)


------
https://chatgpt.com/codex/tasks/task_e_68d5314689cc832f8cef926df383f975