### PR TITLE
Restore reliable admin page detection

### DIFF
--- a/includes/admin/diagnostics.php
+++ b/includes/admin/diagnostics.php
@@ -22,9 +22,16 @@ if (!defined('ABSPATH')) exit;
     'action',
     'admin_enqueue_scripts',
     function ($hook) {
-        $diagnostics_hook = 'hic-monitoring_page_hic-diagnostics';
-
-        if (is_string($hook) && strpos($hook, $diagnostics_hook) === 0) {
+        if (function_exists('hic_admin_hook_matches_page') && hic_admin_hook_matches_page(
+            $hook,
+            'hic-diagnostics',
+            array(
+                'hic-monitoring_page_hic-diagnostics',
+                'hic-monitoring-network_page_hic-diagnostics',
+                'hic-monitoring-user_page_hic-diagnostics',
+                'hotel-in-cloud_page_hic-diagnostics'
+            )
+        )) {
             wp_set_script_translations(
                 'hic-diagnostics',
                 'hotel-in-cloud',
@@ -1350,7 +1357,7 @@ function hic_diagnostics_page() {
                         <span class="dashicons dashicons-admin-generic"></span>
                         <?php esc_html_e('Apri Impostazioni', 'hotel-in-cloud'); ?>
                     </a>
-                    <a class="hic-button hic-button--ghost hic-button--inverted" href="<?php echo esc_url(admin_url('admin.php?page=hic-realtime-dashboard')); ?>">
+                    <a class="hic-button hic-button--ghost hic-button--inverted" href="<?php echo esc_url(admin_url('admin.php?page=hic-monitoring')); ?>">
                         <span class="dashicons dashicons-chart-line"></span>
                         <?php esc_html_e('Dashboard Real-Time', 'hotel-in-cloud'); ?>
                     </a>


### PR DESCRIPTION
## Summary
- replace the slug normalization helpers with a simpler matcher that accepts explicit hook prefixes and the current `page` query
- update the admin asset loader to check both hook strings and the request slug for settings and diagnostics screens so the Real-Time styling only loads where expected
- adjust the diagnostics translations loader to use the new matcher when determining whether to run

## Testing
- composer lint:syntax *(fails: vendor/bin/parallel-lint not installed in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d54694d360832fbc064c990dc07236