### PR TITLE
Ensure redesigned admin styles load across wizard and tools

### DIFF
--- a/includes/automated-reporting.php
+++ b/includes/automated-reporting.php
@@ -1087,7 +1087,7 @@ class AutomatedReportingManager {
      * Enqueue reporting assets
      */
     public function enqueue_reporting_assets($hook) {
-        if ($hook !== 'hic-monitoring_page_hic-reports') {
+        if (!$this->is_reports_hook($hook)) {
             return;
         }
 
@@ -1112,6 +1112,19 @@ class AutomatedReportingManager {
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'hic_reporting_nonce' => wp_create_nonce('hic_reporting_nonce')
         ]);
+    }
+
+    private function is_reports_hook($hook): bool
+    {
+        if (!is_string($hook)) {
+            return false;
+        }
+
+        if (strpos($hook, '_page_hic-reports') !== false) {
+            return true;
+        }
+
+        return strpos($hook, 'hic-reports') !== false;
     }
     
     /**

--- a/includes/circuit-breaker.php
+++ b/includes/circuit-breaker.php
@@ -959,7 +959,7 @@ class CircuitBreakerManager {
      * Enqueue circuit breaker assets
      */
     public function enqueue_circuit_breaker_assets($hook) {
-        if ($hook !== 'hic-monitoring_page_hic-circuit-breakers') {
+        if (!$this->is_circuit_breaker_hook($hook)) {
             return;
         }
 
@@ -991,6 +991,19 @@ class CircuitBreakerManager {
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('hic_circuit_breaker_nonce')
         ]);
+    }
+
+    private function is_circuit_breaker_hook($hook): bool
+    {
+        if (!is_string($hook)) {
+            return false;
+        }
+
+        if (strpos($hook, '_page_hic-circuit-breakers') !== false) {
+            return true;
+        }
+
+        return strpos($hook, 'hic-circuit-breakers') !== false;
     }
     
     /**

--- a/includes/enterprise-management-suite.php
+++ b/includes/enterprise-management-suite.php
@@ -1266,18 +1266,27 @@ class EnterpriseManagementSuite {
      * Enqueue management assets
      */
     public function enqueue_management_assets($hook) {
-        if (strpos($hook, 'hic-') === false) {
+        if (!$this->is_setup_wizard_hook($hook)) {
             return;
         }
-        
+
+        $base_url = plugin_dir_url(dirname(__DIR__) . '/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php');
+
+        wp_enqueue_style(
+            'hic-admin-base',
+            $base_url . 'assets/css/hic-admin.css',
+            [],
+            HIC_PLUGIN_VERSION
+        );
+
         wp_enqueue_script('jquery');
-        
+
         // Add inline script for wizard functionality
         wp_add_inline_script('jquery', '
             function saveStepAndContinue(currentStep, nextStep) {
                 var formData = jQuery("#hic-wizard-step-" + currentStep).serialize();
                 formData += "&action=hic_setup_wizard_step&step=" + currentStep + "&nonce=' . wp_create_nonce('hic_setup_wizard') . '";
-                
+
                 jQuery.post(ajaxurl, formData, function(response) {
                     if (response.success) {
                         window.location.href = "?page=hic-setup-wizard&step=" + nextStep;
@@ -1287,6 +1296,20 @@ class EnterpriseManagementSuite {
                 });
             }
         ');
+    }
+
+    private function is_setup_wizard_hook($hook): bool
+    {
+        if (!is_string($hook)) {
+            return false;
+        }
+
+        if (strpos($hook, '_page_hic-setup-wizard') !== false) {
+            return true;
+        }
+
+        // Legacy fallback when hook names don't include the parent slug
+        return strpos($hook, 'hic-setup-wizard') !== false;
     }
     
     // ===== AJAX HANDLERS =====

--- a/includes/google-ads-enhanced.php
+++ b/includes/google-ads-enhanced.php
@@ -1658,7 +1658,7 @@ class GoogleAdsEnhancedConversions {
      * Enqueue enhanced conversions assets
      */
     public function enqueue_enhanced_conversions_assets($hook) {
-        if ($hook !== 'hic-monitoring_page_hic-enhanced-conversions') {
+        if (!$this->is_enhanced_conversions_hook($hook)) {
             return;
         }
 
@@ -1683,6 +1683,19 @@ class GoogleAdsEnhancedConversions {
             'ajaxUrl' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('hic_enhanced_conversions_nonce')
         ]);
+    }
+
+    private function is_enhanced_conversions_hook($hook): bool
+    {
+        if (!is_string($hook)) {
+            return false;
+        }
+
+        if (strpos($hook, '_page_hic-enhanced-conversions') !== false) {
+            return true;
+        }
+
+        return strpos($hook, 'hic-enhanced-conversions') !== false;
     }
     
     /**


### PR DESCRIPTION
## Summary
- load the shared admin stylesheet on the setup wizard page and guard the enqueue logic with a dedicated hook matcher
- relax the hook checks for enhanced conversions, circuit breaker and reports pages so their redesigned assets load in all admin contexts

## Testing
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68d55747e04c832f9605b254567180ed