### PR TITLE
Handle non-string reservation IDs during normalization

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1360,9 +1360,15 @@ function hic_booking_uid($reservation) {
 
 /**
  * Normalize reservation identifiers for consistent storage and comparisons.
+ *
+ * @param string|int|float|bool $value
  */
-function hic_normalize_reservation_id(string $value): string {
-    $sanitized = sanitize_text_field($value);
+function hic_normalize_reservation_id($value): string {
+    if (!is_scalar($value)) {
+        return '';
+    }
+
+    $sanitized = sanitize_text_field((string) $value);
     $sanitized = trim($sanitized);
     if ($sanitized === '') {
         return '';


### PR DESCRIPTION
## Summary
- allow `hic_normalize_reservation_id` to accept scalar reservation identifiers and return early for unsupported types
- ensure incoming values are string-cast before sanitization to avoid type errors when integers are provided

## Testing
- composer lint:syntax

------
https://chatgpt.com/codex/tasks/task_e_68d55faec89c832fb65621b3e459b493