### PR TITLE
Handle secure HTTP 400 as timestamp error

### DIFF
--- a/tests/ApiPollingHandleResponseTest.php
+++ b/tests/ApiPollingHandleResponseTest.php
@@ -1,0 +1,44 @@
+<?php declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+final class ApiPollingHandleResponseTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        require_once __DIR__ . '/../includes/constants.php';
+        require_once __DIR__ . '/../includes/functions.php';
+        require_once __DIR__ . '/../includes/helpers-logging.php';
+        require_once __DIR__ . '/../includes/api/polling.php';
+    }
+
+    public function testHttpError400FromSecureWrapperMapsToTimestampError(): void
+    {
+        $body = 'Il timestamp cannot be older than seven days';
+        $error = new WP_Error('http_error', 'Errore HTTP 400', [
+            'status' => 400,
+            'body' => $body,
+        ]);
+
+        $result = \FpHic\hic_handle_api_response($error, 'HIC updates fetch');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('hic_timestamp_too_old', $result->get_error_code());
+    }
+
+    public function testHttpError400FromSecureWrapperReturnsGenericErrorWhenNotTimestamp(): void
+    {
+        $body = 'Parametro mancante: date_type';
+        $error = new WP_Error('http_error', 'Errore HTTP 400', [
+            'status' => 400,
+            'body' => $body,
+        ]);
+
+        $result = \FpHic\hic_handle_api_response($error, 'HIC reservations fetch');
+
+        $this->assertInstanceOf(WP_Error::class, $result);
+        $this->assertSame('hic_http', $result->get_error_code());
+    }
+}


### PR DESCRIPTION
## Summary
- detect HTTP 400 errors coming from the secure HTTP wrapper and map timestamp failures to the hic_timestamp_too_old error so recovery logic can reset polling windows
- return a consistent hic_http error for other 400 responses and log trimmed body details for diagnostics
- add PHPUnit coverage that exercises both the timestamp and generic HTTP 400 paths in hic_handle_api_response

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d564b0f768832faa50979f21dd36bf