### PR TITLE
chore: bump plugin documentation to v3.3.0

### DIFF
--- a/ARCHITETTURA_TECNICA.md
+++ b/ARCHITETTURA_TECNICA.md
@@ -1,6 +1,6 @@
 # Architettura Tecnica del Sistema
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Diagramma del Flusso Dati

--- a/BREVO_ATTRIBUTES.md
+++ b/BREVO_ATTRIBUTES.md
@@ -1,6 +1,6 @@
 # Attributi Brevo da Configurare
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 Questo documento elenca tutti gli attributi che devi configurare nel tuo account Brevo per ricevere correttamente i dati dal plugin Hotel in Cloud.

--- a/BREVO_QUICK_SETUP.md
+++ b/BREVO_QUICK_SETUP.md
@@ -1,6 +1,6 @@
 # Quick Reference: Attributi Brevo Essenziali
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Lista Attributi da Creare in Brevo

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Changelog
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 Tutte le modifiche degne di nota del plugin FP HIC Monitor sono documentate qui, in ordine cronologico inverso.
+
+## [3.3.0] - 2025-05-20
+### Documentazione
+- Aggiornati README, guide operative e quick start con intestazioni allineate alla nuova versione 3.3.0 e riferimenti di supporto aggiornati.
+- Aggiornato il workflow di rilascio con esempi di tagging e pacchetti coerenti con la versione 3.3.0.
+
+### Manutenzione
+- Sincronizzate costanti di versione, header del plugin e test CLI per riflettere la release 3.3.0 e prevenire falsi positivi nei controlli di health check.
 
 ## [3.2.0] - 2025-02-14
 ### Documentazione

--- a/ENHANCED_CONVERSIONS_QUICK_SETUP.md
+++ b/ENHANCED_CONVERSIONS_QUICK_SETUP.md
@@ -1,6 +1,6 @@
 # Setup Conversioni Enhanced - Quick Reference
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## 🚀 Setup in 10 Minuti

--- a/FAQ.md
+++ b/FAQ.md
@@ -1,6 +1,6 @@
 # FAQ - Domande Frequenti
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## ℹ️ Contatti e Supporto

--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: FP HIC Monitor
  * Description: Monitoraggio conversioni Hotel in Cloud con tracciamento avanzato verso GA4, Meta CAPI e Brevo. Sistema sicuro enterprise-grade con cache intelligente e validazione input.
- * Version: 3.2.0
+ * Version: 3.3.0
  * Author: Francesco Passeri
  * Requires at least: 5.8
  * Requires PHP: 7.4

--- a/GTM_VALIDATION_COMPLETE.md
+++ b/GTM_VALIDATION_COMPLETE.md
@@ -1,6 +1,6 @@
 # GTM Integration - Validation Complete ✅
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Validation Summary

--- a/GUIDA_CONFIGURAZIONE.md
+++ b/GUIDA_CONFIGURAZIONE.md
@@ -1,6 +1,6 @@
 # Guida Rapida di Configurazione
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Come Configurare il Sistema di Polling Automatico

--- a/GUIDA_CONVERSION_ENHANCED.md
+++ b/GUIDA_CONVERSION_ENHANCED.md
@@ -1,6 +1,6 @@
 # Guida Setup Conversioni Enhanced di Google Ads
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Cosa sono le Conversioni Enhanced

--- a/GUIDA_GTM_INTEGRAZIONE.md
+++ b/GUIDA_GTM_INTEGRAZIONE.md
@@ -1,6 +1,6 @@
 # Integrazione Google Tag Manager e Google Analytics 4
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Panoramica

--- a/GUIDA_MIGRAZIONE.md
+++ b/GUIDA_MIGRAZIONE.md
@@ -1,6 +1,6 @@
 # Guida Migrazione FP HIC Monitor v3.0
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## 🔄 Procedura di Aggiornamento v3.0

--- a/GUIDA_WEBHOOK_CONVERSIONI.md
+++ b/GUIDA_WEBHOOK_CONVERSIONI.md
@@ -1,6 +1,6 @@
 # Guida Webhook per Tracciamento Conversioni Senza Redirect
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Il Problema: Nessun Redirect dal Sistema di Prenotazione

--- a/IFRAME_SUPPORT.md
+++ b/IFRAME_SUPPORT.md
@@ -1,6 +1,6 @@
 # Supporto iframe - Hotel in Cloud Monitoraggio Conversioni
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Panoramica

--- a/MANUAL_POLLING_GUIDE.md
+++ b/MANUAL_POLLING_GUIDE.md
@@ -1,6 +1,6 @@
 # 🔄 Manual Polling Guide
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## New Manual Polling Feature

--- a/MIGLIORAMENTI_IMPLEMENTATI.md
+++ b/MIGLIORAMENTI_IMPLEMENTATI.md
@@ -1,6 +1,6 @@
 # Miglioramenti Implementati per HIC Plugin
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Panoramica dei Miglioramenti

--- a/MIGLIORAMENTI_SICUREZZA_PERFORMANCE.md
+++ b/MIGLIORAMENTI_SICUREZZA_PERFORMANCE.md
@@ -1,6 +1,6 @@
 # Miglioramenti di Sicurezza e Performance - FP HIC Monitor
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Panoramica delle Migliorie Implementate

--- a/PHP_STANDARDS_COMPLIANCE.md
+++ b/PHP_STANDARDS_COMPLIANCE.md
@@ -1,6 +1,6 @@
 # PHP Standards Compliance Implementation Summary
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## 🎯 Implementation Complete

--- a/PLUGIN_FUNZIONAMENTO.md
+++ b/PLUGIN_FUNZIONAMENTO.md
@@ -1,6 +1,6 @@
 # Come Funziona FP HIC Monitor
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Panoramica Generale

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FP HIC Monitor
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 Plugin WordPress per il monitoraggio avanzato delle conversioni da Hotel in Cloud verso GA4, Facebook Meta e Brevo con sistema di sicurezza enterprise-grade.

--- a/RIASSUNTO_GTM_IMPLEMENTAZIONE.md
+++ b/RIASSUNTO_GTM_IMPLEMENTAZIONE.md
@@ -1,6 +1,6 @@
 # Riassunto Implementazione GTM
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Problema Originale

--- a/SISTEMA_SENZA_ENHANCED.md
+++ b/SISTEMA_SENZA_ENHANCED.md
@@ -1,6 +1,6 @@
 # Il Sistema Funziona Senza Google Ads Enhanced?
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Risposta Breve: SÌ

--- a/VALIDATION_REPORT.md
+++ b/VALIDATION_REPORT.md
@@ -1,6 +1,6 @@
 # Comprehensive Implementation Validation Report
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## Executive Summary

--- a/WEB_TRAFFIC_MONITORING_COMPLETE.md
+++ b/WEB_TRAFFIC_MONITORING_COMPLETE.md
@@ -1,6 +1,6 @@
 # Web Traffic Monitoring Implementation - COMPLETE
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## 🎉 Implementation Successfully Completed

--- a/WEB_TRAFFIC_MONITORING_SUMMARY.md
+++ b/WEB_TRAFFIC_MONITORING_SUMMARY.md
@@ -1,6 +1,6 @@
 # Web Traffic Monitoring Enhancement - Visual Summary
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 ## 🌐 Enhanced Diagnostics Interface

--- a/docs/BUILD_WORKFLOW.md
+++ b/docs/BUILD_WORKFLOW.md
@@ -1,6 +1,6 @@
 # WordPress Plugin Build and Release Workflow
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 This document describes the automated GitHub Actions workflow for building and releasing the HIC WordPress plugin. Le motivazioni di ogni release sono documentate nel [CHANGELOG](../CHANGELOG.md).
@@ -18,7 +18,7 @@ The workflow automatically creates a production-ready ZIP file of the WordPress 
 
 The build workflow is triggered by:
 
-1. **Version Tags**: When you push a tag like `v3.2.0`, `v2.5.0`, etc.
+1. **Version Tags**: When you push a tag like `v3.3.0`, `v2.5.0`, etc.
 2. **GitHub Releases**: When you create a release through GitHub UI
 3. **Manual Trigger**: Can be manually triggered from the Actions tab
 
@@ -57,8 +57,8 @@ The workflow produces:
 
 ```bash
 # Tag the current commit with a version
-git tag v3.2.0
-git push origin v3.2.0
+git tag v3.3.0
+git push origin v3.3.0
 ```
 
 ### Method 2: Using GitHub Releases
@@ -66,7 +66,7 @@ git push origin v3.2.0
 1. Go to the repository on GitHub
 2. Click "Releases" in the right sidebar
 3. Click "Create a new release"
-4. Choose or create a tag (e.g., `v3.2.0`)
+4. Choose or create a tag (e.g., `v3.3.0`)
 5. Fill in release notes
 6. Click "Publish release"
 
@@ -98,7 +98,7 @@ rsync -av \
 
 # Create ZIP
 cd build
-zip -r fp-hotel-in-cloud-monitoraggio-conversioni-v3.2.0.zip fp-hotel-in-cloud-monitoraggio-conversioni
+zip -r fp-hotel-in-cloud-monitoraggio-conversioni-v3.3.0.zip fp-hotel-in-cloud-monitoraggio-conversioni
 ```
 
 ## Version Management
@@ -106,7 +106,7 @@ zip -r fp-hotel-in-cloud-monitoraggio-conversioni-v3.2.0.zip fp-hotel-in-cloud-m
 The workflow automatically extracts the version from the main plugin file:
 
 ```php
-* Version: 3.2.0
+* Version: 3.3.0
 ```
 
 Make sure to update this version number in `FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php` before creating releases.

--- a/docs/QUALITY_TOOLS.md
+++ b/docs/QUALITY_TOOLS.md
@@ -1,6 +1,6 @@
 # PHP Quality Assurance Tools
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 This directory contains comprehensive PHP standards compliance tools for the HIC Plugin. Gli aggiornamenti per release sono documentati nel [CHANGELOG](../CHANGELOG.md) per contestualizzare le pratiche di qualità rispetto alle feature introdotte.

--- a/includes/constants.php
+++ b/includes/constants.php
@@ -131,7 +131,7 @@ define('HIC_DIAGNOSTIC_DETAILED', 'detailed');
 define('HIC_DIAGNOSTIC_FULL', 'full');
 
 // === VERSION INFO ===
-define('HIC_PLUGIN_VERSION', '3.2.0');
+define('HIC_PLUGIN_VERSION', '3.3.0');
 define('HIC_API_VERSION', 'v1');
 define('HIC_MIN_PHP_VERSION', '7.4');
 define('HIC_MIN_WP_VERSION', '5.8');

--- a/tests/HealthCliCommandTest.php
+++ b/tests/HealthCliCommandTest.php
@@ -81,7 +81,7 @@ final class HealthCliCommandTest extends TestCase
                 return [
                     'status' => 'healthy',
                     'timestamp' => '2024-05-01 12:00:00',
-                    'version' => '3.2.0',
+                    'version' => '3.3.0',
                     'checks' => [
                         'plugin_active' => [
                             'status' => 'pass',
@@ -123,7 +123,7 @@ final class HealthCliCommandTest extends TestCase
                 return [
                     'status' => 'healthy',
                     'timestamp' => '2024-05-01 12:00:00',
-                    'version' => '3.2.0',
+                    'version' => '3.3.0',
                     'checks' => [],
                     'metrics' => ['uptime' => '100%'],
                     'alerts' => [],
@@ -150,6 +150,6 @@ final class HealthCliCommandTest extends TestCase
         $payload = json_decode($lines[0]['message'], true);
         $this->assertIsArray($payload);
         $this->assertSame('healthy', $payload['status']);
-        $this->assertSame('3.2.0', $payload['version']);
+        $this->assertSame('3.3.0', $payload['version']);
     }
 }

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,6 +1,6 @@
 # HIC Plugin Tests
 
-> **Versione plugin:** 3.2.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.3.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 This directory contains automated tests for the HIC Plugin. Le innovazioni per release sono documentate nel [CHANGELOG](../CHANGELOG.md) così da collegare i test alle funzionalità introdotte.


### PR DESCRIPTION
## Summary
- bump the plugin header and constants to version 3.3.0
- refresh changelog and documentation to reference the new release and workflow steps
- align automated health CLI tests and related docs with the new version number

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d58f0578dc832f8d62f3ab49e26a33