### PR TITLE
Fix trend calculations and modernize reflection usage

### DIFF
--- a/includes/performance-monitor.php
+++ b/includes/performance-monitor.php
@@ -583,8 +583,6 @@ class HIC_Performance_Monitor {
                 ? ($operationBucket['success']['total'] / $operationBucket['total']) * 100
                 : 0.0;
 
-            $operationBucket['trend'] = $this->calculate_trend($operationBucket['days']);
-
             foreach ($operationBucket['days'] as $date => &$dayBucket) {
                 sort($dayBucket['durations']);
                 $successTotal = $dayBucket['success']['total'];
@@ -605,6 +603,8 @@ class HIC_Performance_Monitor {
                 ];
             }
             unset($dayBucket);
+
+            $operationBucket['trend'] = $this->calculate_trend($operationBucket['days']);
 
             unset($operationBucket['durations']);
         }

--- a/tests/AdminMenuRegistrationTest.php
+++ b/tests/AdminMenuRegistrationTest.php
@@ -16,7 +16,7 @@ final class AdminMenuRegistrationTest extends WP_UnitTestCase
         if (class_exists(\FpHic\AutomatedReporting\AutomatedReportingManager::class)) {
             $instanceProperty = new ReflectionProperty(\FpHic\AutomatedReporting\AutomatedReportingManager::class, 'instance');
             $instanceProperty->setAccessible(true);
-            $instanceProperty->setValue(null);
+            $instanceProperty->setValue(null, null);
         }
     }
 
@@ -67,7 +67,7 @@ final class AdminMenuRegistrationTest extends WP_UnitTestCase
     {
         $reflection = new ReflectionProperty(\FpHic\AutomatedReporting\AutomatedReportingManager::class, 'instance');
         $reflection->setAccessible(true);
-        $reflection->setValue(null);
+        $reflection->setValue(null, null);
 
         $reports = \FpHic\AutomatedReporting\AutomatedReportingManager::instance();
         $reports->add_reports_menu();


### PR DESCRIPTION
## Summary
- compute aggregated trend data after daily buckets are normalized to avoid undefined indexes
- update admin menu registration tests to use the two-argument ReflectionProperty::setValue signature and silence PHP 8.4 deprecations

## Testing
- `composer test -- --display-deprecations --display-warnings`


------
https://chatgpt.com/codex/tasks/task_e_68d68b5dc6c4832fa58d295e35c0cfff