### PR TITLE
Normalize bucket attribution for Google braid identifiers

### DIFF
--- a/demo-without-enhanced.php
+++ b/demo-without-enhanced.php
@@ -42,7 +42,7 @@ namespace FpHic\Helpers {
     function hic_get_tracking_mode() { return \get_option('hic_tracking_mode', 'ga4_only'); }
     function hic_is_valid_email($email) { return filter_var($email, FILTER_VALIDATE_EMAIL) !== false; }
     function hic_normalize_price($price) { return (float) str_replace([',', ' '], ['', ''], $price); }
-    function hic_get_tracking_ids_by_sid($sid) { return ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null]; }
+    function hic_get_tracking_ids_by_sid($sid) { return ['gclid' => null, 'fbclid' => null, 'msclkid' => null, 'ttclid' => null, 'gbraid' => null, 'wbraid' => null]; }
     function hic_refund_tracking_enabled() { return false; }
     function hic_get_measurement_id() { return \get_option('hic_measurement_id', ''); }
     function hic_get_api_secret() { return \get_option('hic_api_secret', ''); }

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -1825,8 +1825,39 @@ function hic_send_admin_email($data, $gclid, $fbclid, $sid){
     hic_log('hic_send_admin_email: data is not an array');
     return false;
   }
-  
-  $bucket = fp_normalize_bucket($gclid, $fbclid);
+
+  $gbraid = '';
+  $wbraid = '';
+  $normalized_sid = '';
+
+  if (!empty($sid) && (is_string($sid) || is_numeric($sid))) {
+    $normalized_sid = sanitize_text_field((string) $sid);
+  }
+
+  if ($normalized_sid !== '') {
+    $tracking = \FpHic\Helpers\hic_get_tracking_ids_by_sid($normalized_sid);
+    if (empty($gclid) && !empty($tracking['gclid'])) {
+      $gclid = $tracking['gclid'];
+    }
+    if (empty($fbclid) && !empty($tracking['fbclid'])) {
+      $fbclid = $tracking['fbclid'];
+    }
+    if (!empty($tracking['gbraid'])) {
+      $gbraid = $tracking['gbraid'];
+    }
+    if (!empty($tracking['wbraid'])) {
+      $wbraid = $tracking['wbraid'];
+    }
+  }
+
+  if ($gbraid === '' && isset($data['gbraid']) && is_scalar($data['gbraid'])) {
+    $gbraid = sanitize_text_field((string) $data['gbraid']);
+  }
+  if ($wbraid === '' && isset($data['wbraid']) && is_scalar($data['wbraid'])) {
+    $wbraid = sanitize_text_field((string) $data['wbraid']);
+  }
+
+  $bucket = fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
   $to = hic_get_admin_email();
   
   // Enhanced email validation with detailed logging
@@ -2780,8 +2811,8 @@ namespace {
     function hic_mask_sensitive_data($message) { return \FpHic\Helpers\hic_mask_sensitive_data($message); }
     function hic_default_log_message_filter($message, $level) { return \FpHic\Helpers\hic_default_log_message_filter($message, $level); }
     function hic_log($msg, $level = HIC_LOG_LEVEL_INFO, $context = []) { return \FpHic\Helpers\hic_log($msg, $level, $context); }
-    function fp_normalize_bucket($gclid, $fbclid) { return \FpHic\Helpers\fp_normalize_bucket($gclid, $fbclid); }
-    function hic_get_bucket($gclid, $fbclid) { return \FpHic\Helpers\hic_get_bucket($gclid, $fbclid); }
+    function fp_normalize_bucket($gclid, $fbclid, $gbraid = null, $wbraid = null) { return \FpHic\Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid); }
+    function hic_get_bucket($gclid, $fbclid, $gbraid = null, $wbraid = null) { return \FpHic\Helpers\hic_get_bucket($gclid, $fbclid, $gbraid, $wbraid); }
     function hic_send_admin_email($data, $gclid, $fbclid, $sid) { return \FpHic\Helpers\hic_send_admin_email($data, $gclid, $fbclid, $sid); }
     function hic_test_email_configuration($recipient_email = null) { return \FpHic\Helpers\hic_test_email_configuration($recipient_email); }
     function hic_diagnose_email_issues() { return \FpHic\Helpers\hic_diagnose_email_issues(); }

--- a/includes/helpers-tracking.php
+++ b/includes/helpers-tracking.php
@@ -283,15 +283,31 @@ function hic_get_utm_params_by_sid($sid) {
 }
 
 /**
- * Normalize bucket attribution according to priority: gclid > fbclid > organic
+ * Normalize bucket attribution according to priority: gclid > gbraid/wbraid > fbclid > organic
  *
- * @param string|null $gclid Google Click ID from Google Ads
+ * @param string|null $gclid  Google Click ID from Google Ads
  * @param string|null $fbclid Facebook Click ID from Meta Ads
+ * @param string|null $gbraid Google Ads GBRAID identifier
+ * @param string|null $wbraid Google Ads WBRAID identifier
  * @return string One of: 'gads', 'fbads', 'organic'
  */
-function fp_normalize_bucket($gclid, $fbclid){
-  if (!empty($gclid) && trim($gclid) !== '')  return 'gads';
-  if (!empty($fbclid) && trim($fbclid) !== '') return 'fbads';
+function fp_normalize_bucket($gclid, $fbclid, $gbraid = null, $wbraid = null){
+  foreach ([$gclid, $gbraid, $wbraid] as $google_identifier) {
+    if (is_string($google_identifier) || is_numeric($google_identifier)) {
+      $normalized = trim((string) $google_identifier);
+      if ($normalized !== '') {
+        return 'gads';
+      }
+    }
+  }
+
+  if (is_string($fbclid) || is_numeric($fbclid)) {
+    $facebook_identifier = trim((string) $fbclid);
+    if ($facebook_identifier !== '') {
+      return 'fbads';
+    }
+  }
+
   return 'organic';
 }
 
@@ -299,7 +315,7 @@ function fp_normalize_bucket($gclid, $fbclid){
  * Legacy function name for backward compatibility
  * @deprecated Use fp_normalize_bucket() instead
  */
-function hic_get_bucket($gclid, $fbclid){
-  return fp_normalize_bucket($gclid, $fbclid);
+function hic_get_bucket($gclid, $fbclid, $gbraid = null, $wbraid = null){
+  return fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
 }
 

--- a/includes/integrations/brevo.php
+++ b/includes/integrations/brevo.php
@@ -119,7 +119,7 @@ function hic_send_brevo_contact($data, $gclid, $fbclid, $msclkid = '', $ttclid =
 /* ============ Brevo: evento personalizzato (purchase + bucket) ============ */
 function hic_send_brevo_event($reservation, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gbraid = '', $wbraid = ''){
   if (!Helpers\hic_get_brevo_api_key()) { return; }
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
 
   $amount = 0;
   $amount_source = null;
@@ -197,7 +197,7 @@ function hic_send_brevo_event($reservation, $gclid, $fbclid, $msclkid = '', $ttc
  */
 function hic_send_brevo_refund_event($reservation, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gbraid = '', $wbraid = ''){
   if (!Helpers\hic_get_brevo_api_key()) { return false; }
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
 
   $amount = 0;
   $amount_source = null;
@@ -625,7 +625,7 @@ function hic_send_brevo_reservation_created_event($data, $gclid = '', $fbclid = 
   $data['phone'] = $phone_data['phone'] ?? ($data['phone'] ?? '');
   $data['language'] = $phone_data['language'] ?? ($data['language'] ?? '');
 
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
   $currency_code = Helpers\hic_normalize_currency_code($data['currency'] ?? null);
 
   $body = array(

--- a/includes/integrations/facebook.php
+++ b/includes/integrations/facebook.php
@@ -24,7 +24,7 @@ function hic_send_to_fb($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $gb
     return false;
   }
   
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid); // gads | fbads | organic
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid); // gads | fbads | organic
   
   // Generate event ID using consistent extraction
   $event_id = Helpers\hic_extract_reservation_id($data);
@@ -195,7 +195,7 @@ function hic_send_fb_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = '',
     return false;
   }
 
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
 
   $event_id = Helpers\hic_extract_reservation_id($data);
   if (empty($event_id)) {
@@ -395,7 +395,7 @@ function hic_dispatch_pixel_reservation($data, $sid = '') {
     $wbraid = $tracking['wbraid'] ?? '';
   }
 
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
 
   $user_data = [
     'em' => [hash('sha256', strtolower(trim($data['email'])))]

--- a/includes/integrations/ga4.php
+++ b/includes/integrations/ga4.php
@@ -202,7 +202,7 @@ function hic_send_to_ga4($data, $gclid, $fbclid, $msclkid = '', $ttclid = '', $g
     return false;
   }
 
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid); // gads | fbads | organic
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid); // gads | fbads | organic
   $client_id = $gclid ?: ($fbclid ?: (string) wp_generate_uuid4());
   $sid = (is_string($sid) || is_numeric($sid)) ? sanitize_text_field((string) $sid) : '';
 
@@ -330,7 +330,7 @@ function hic_send_ga4_refund($data, $gclid, $fbclid, $msclkid = '', $ttclid = ''
     return false;
   }
 
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
   $client_id = $gclid ?: ($fbclid ?: (string) wp_generate_uuid4());
   $sid = (is_string($sid) || is_numeric($sid)) ? sanitize_text_field((string) $sid) : '';
 
@@ -509,7 +509,7 @@ function hic_dispatch_ga4_reservation($data, $sid = '') {
     $wbraid = $tracking['wbraid'] ?? '';
   }
 
-  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+  $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
 
   $params = [
     'transaction_id' => $transaction_id,

--- a/includes/integrations/gtm.php
+++ b/includes/integrations/gtm.php
@@ -22,7 +22,7 @@ function hic_send_to_gtm_datalayer($data, $gclid, $fbclid, $msclkid = '', $ttcli
         return false;
     }
 
-    $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid); // gads | fbads | organic
+    $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid); // gads | fbads | organic
     $sid = !empty($sid) ? sanitize_text_field($sid) : '';
 
     // Validate and normalize amount
@@ -413,7 +413,7 @@ function hic_dispatch_gtm_reservation($data, $sid = '') {
         $wbraid = $tracking['wbraid'] ?? '';
     }
 
-    $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid);
+    $bucket = Helpers\fp_normalize_bucket($gclid, $fbclid, $gbraid, $wbraid);
 
     // Prepare GTM ecommerce data
     $gtm_data = [

--- a/tests/CoreFunctionsTest.php
+++ b/tests/CoreFunctionsTest.php
@@ -21,6 +21,9 @@ final class CoreFunctionsTest extends TestCase
         self::assertSame('gads', Helpers\fp_normalize_bucket('CL123456', null));
         self::assertSame('fbads', Helpers\fp_normalize_bucket(null, 'FB123456'));
         self::assertSame('gads', Helpers\fp_normalize_bucket('CL123456', 'FB123456'));
+        self::assertSame('gads', Helpers\fp_normalize_bucket(null, null, 'GBRAID-123', null));
+        self::assertSame('gads', Helpers\fp_normalize_bucket(null, null, null, 'WBRAID-987'));
+        self::assertSame('gads', Helpers\hic_get_bucket(null, null, 'GBRAID-123', 'WBRAID-987'));
         self::assertSame('organic', Helpers\fp_normalize_bucket(null, null));
         self::assertSame('organic', Helpers\fp_normalize_bucket('', ''));
     }


### PR DESCRIPTION
## Summary
- treat Google Ads GBRAID/WBRAID identifiers as first-class signals in bucket normalization
- surface braid identifiers when dispatching events and in admin email fallback logic
- extend core tests to cover braid-based attribution handling

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d68cce7ce4832f95ad2fccdcac1566