### PR TITLE
Enhance sensitive data masking for log messages

### DIFF
--- a/includes/helpers-logging.php
+++ b/includes/helpers-logging.php
@@ -57,11 +57,60 @@ function hic_mask_sensitive_data($message) {
  * @param string $level   Log level
  * @return string
  */
+function hic_normalize_sensitive_key($key): string
+{
+    if (!is_scalar($key)) {
+        return '';
+    }
+
+    $normalized = (string) $key;
+    $normalized = preg_replace('/([a-z])([A-Z])/', '$1_$2', $normalized);
+    $normalized = preg_replace('/[^a-zA-Z0-9_]+/', '_', $normalized ?? '');
+    $normalized = strtolower($normalized ?? '');
+
+    return trim($normalized ?? '', '_');
+}
+
 function hic_default_log_message_filter($message, $level) {
+    static $email_keys = null;
+    static $phone_keys = null;
+
+    if ($email_keys === null) {
+        $email_keys = [
+            'email',
+            'guest_email',
+            'customer_email',
+            'contact_email',
+            'user_email',
+            'primary_email',
+            'email_address',
+            'billing_email',
+            'shipping_email',
+        ];
+        $phone_keys = [
+            'phone',
+            'phone_number',
+            'guest_phone',
+            'customer_phone',
+            'contact_phone',
+            'user_phone',
+            'primary_phone',
+            'mobile',
+            'mobile_phone',
+            'mobile_number',
+        ];
+    }
+
     if (is_array($message)) {
         foreach ($message as $key => $value) {
-            if (is_string($key) && preg_match('/^(?:email)$/i', $key)) {
+            $normalized_key = hic_normalize_sensitive_key($key);
+
+            if ($normalized_key !== '' && in_array($normalized_key, $email_keys, true)) {
                 $message[$key] = '[masked-email]';
+                continue;
+            }
+            if ($normalized_key !== '' && in_array($normalized_key, $phone_keys, true)) {
+                $message[$key] = '[masked-phone]';
                 continue;
             }
             if (is_string($key) && preg_match('/(token|api[_-]?key|secret|password)/i', $key)) {
@@ -75,8 +124,14 @@ function hic_default_log_message_filter($message, $level) {
 
     if (is_object($message)) {
         foreach ($message as $key => $value) {
-            if (is_string($key) && preg_match('/^(?:email)$/i', $key)) {
+            $normalized_key = hic_normalize_sensitive_key($key);
+
+            if ($normalized_key !== '' && in_array($normalized_key, $email_keys, true)) {
                 $message->$key = '[masked-email]';
+                continue;
+            }
+            if ($normalized_key !== '' && in_array($normalized_key, $phone_keys, true)) {
+                $message->$key = '[masked-phone]';
                 continue;
             }
             if (is_string($key) && preg_match('/(token|api[_-]?key|secret|password)/i', $key)) {

--- a/tests/LogMessageFilterTest.php
+++ b/tests/LogMessageFilterTest.php
@@ -53,5 +53,30 @@ final class LogMessageFilterTest extends TestCase {
         $this->assertStringContainsString('[masked-phone]', $contents);
         $this->assertStringContainsString('[masked-number]', $contents);
     }
+
+    public function test_default_filter_masks_additional_email_and_phone_keys(): void
+    {
+        $manager = new \HIC_Log_Manager();
+        $data = [
+            'guestEmail' => 'guest@example.com',
+            'contact_phone' => '+39 123 456 7890',
+            'details' => [
+                'customerEmail' => 'customer@example.com',
+                'mobileNumber' => '555-1234',
+            ],
+        ];
+
+        $manager->info($data);
+
+        $log_file = Helpers\hic_get_log_file();
+        $this->assertFileExists($log_file);
+        $contents = file_get_contents($log_file);
+        $this->assertStringNotContainsString('guest@example.com', $contents);
+        $this->assertStringNotContainsString('customer@example.com', $contents);
+        $this->assertStringNotContainsString('+39 123 456 7890', $contents);
+        $this->assertStringNotContainsString('555-1234', $contents);
+        $this->assertSame(2, substr_count($contents, '[masked-email]'));
+        $this->assertSame(2, substr_count($contents, '[masked-phone]'));
+    }
 }
 }


### PR DESCRIPTION
## Summary
- expand the default log message filter to normalize keys and mask additional email and phone fields
- add test coverage ensuring the new keys are masked in the log output

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d68f20a76c832f86dcd8f43b1022dd