### PR TITLE
Prevent duplicate hook registration in helper

### DIFF
--- a/tests/SafeHookRegistrationTest.php
+++ b/tests/SafeHookRegistrationTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\TestCase;
+
+use function FpHic\Helpers\hic_safe_add_hook;
+
+require_once __DIR__ . '/bootstrap.php';
+
+if (!function_exists('hic_test_sample_action_callback')) {
+    function hic_test_sample_action_callback(): void {}
+}
+
+if (!function_exists('hic_test_sample_filter_callback')) {
+    function hic_test_sample_filter_callback($value = null) {
+        return $value;
+    }
+}
+
+final class SafeHookRegistrationTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $GLOBALS['hic_test_hooks'] = [];
+        $GLOBALS['hic_test_filters'] = [];
+    }
+
+    public function test_duplicate_action_registration_is_prevented(): void
+    {
+        hic_safe_add_hook('action', 'hic_test_action', 'hic_test_sample_action_callback');
+        hic_safe_add_hook('action', 'hic_test_action', 'hic_test_sample_action_callback');
+
+        $this->assertArrayHasKey('hic_test_action', $GLOBALS['hic_test_hooks']);
+        $this->assertArrayHasKey(10, $GLOBALS['hic_test_hooks']['hic_test_action']);
+        $this->assertCount(1, $GLOBALS['hic_test_hooks']['hic_test_action'][10]);
+    }
+
+    public function test_duplicate_filter_registration_is_prevented(): void
+    {
+        hic_safe_add_hook('filter', 'hic_test_filter', 'hic_test_sample_filter_callback');
+        hic_safe_add_hook('filter', 'hic_test_filter', 'hic_test_sample_filter_callback');
+
+        $this->assertArrayHasKey('hic_test_filter', $GLOBALS['hic_test_filters']);
+        $this->assertArrayHasKey(10, $GLOBALS['hic_test_filters']['hic_test_filter']);
+        $this->assertCount(1, $GLOBALS['hic_test_filters']['hic_test_filter'][10]);
+    }
+
+    public function test_duplicate_closure_registration_is_prevented(): void
+    {
+        $closure = static function (): void {};
+
+        hic_safe_add_hook('action', 'hic_test_closure', $closure);
+        hic_safe_add_hook('action', 'hic_test_closure', $closure);
+
+        $this->assertArrayHasKey('hic_test_closure', $GLOBALS['hic_test_hooks']);
+        $this->assertArrayHasKey(10, $GLOBALS['hic_test_hooks']['hic_test_closure']);
+        $this->assertCount(1, $GLOBALS['hic_test_hooks']['hic_test_closure'][10]);
+    }
+}

--- a/tests/preload.php
+++ b/tests/preload.php
@@ -27,6 +27,27 @@ if (!function_exists('add_filter')) {
         ];
     }
 }
+if (!function_exists('has_filter')) {
+    function has_filter($hook, $callback = false) {
+        if (empty($GLOBALS['hic_test_filters'][$hook])) {
+            return false;
+        }
+
+        if ($callback === false) {
+            return true;
+        }
+
+        foreach ($GLOBALS['hic_test_filters'][$hook] as $priority => $callbacks) {
+            foreach ($callbacks as $registered) {
+                if ($registered['function'] === $callback) {
+                    return $priority;
+                }
+            }
+        }
+
+        return false;
+    }
+}
 if (!function_exists('remove_filter')) {
     function remove_filter($hook, $callback, $priority = 10) {
         if (empty($GLOBALS['hic_test_filters'][$hook][$priority])) {
@@ -66,6 +87,27 @@ if (!function_exists('apply_filters')) {
         }
 
         return $value;
+    }
+}
+if (!function_exists('has_action')) {
+    function has_action($hook, $callback = false) {
+        if (empty($GLOBALS['hic_test_hooks'][$hook])) {
+            return false;
+        }
+
+        if ($callback === false) {
+            return true;
+        }
+
+        foreach ($GLOBALS['hic_test_hooks'][$hook] as $priority => $callbacks) {
+            foreach ($callbacks as $registered) {
+                if ($registered['function'] === $callback) {
+                    return $priority;
+                }
+            }
+        }
+
+        return false;
     }
 }
 if (!function_exists('register_activation_hook')) { function register_activation_hook(...$args) {} }


### PR DESCRIPTION
## Summary
- avoid duplicate registrations by tracking hook signatures and checking existing callbacks before attaching
- extend the test bootstrap with `has_filter`/`has_action` helpers used by the new guard logic
- add unit coverage ensuring `hic_safe_add_hook` only registers actions, filters and closures once

## Testing
- composer test

------
https://chatgpt.com/codex/tasks/task_e_68d6918d061c832fbc82b94225ba0565