### PR TITLE
Add FP Experience frontend bindings and assets

### DIFF
--- a/.rebuild-state.json
+++ b/.rebuild-state.json
@@ -1,0 +1,1 @@
+{"verify_current":"FRONT-BINDING","ok":true}

--- a/assets/css/front.css
+++ b/assets/css/front.css
@@ -1,0 +1,99 @@
+.fp-exp-page,
+.fp-exp-widget {
+    font-family: inherit;
+    background: #ffffff;
+    border: 1px solid rgba(0, 0, 0, 0.08);
+    border-radius: 8px;
+    padding: 24px;
+    box-shadow: 0 8px 24px rgba(15, 23, 42, 0.04);
+}
+
+.fp-exp-header {
+    margin-bottom: 24px;
+}
+
+.fp-exp-title,
+.fp-exp-widget__title {
+    margin: 0 0 8px;
+    font-size: 1.5rem;
+    line-height: 1.3;
+}
+
+.fp-exp-widget__summary {
+    margin: 0 0 12px;
+    color: #2563eb;
+    font-weight: 600;
+}
+
+.fp-exp-excerpt {
+    margin: 0;
+    color: #475569;
+}
+
+.fp-exp-section {
+    margin-bottom: 24px;
+}
+
+.fp-exp-section__title {
+    margin: 0 0 12px;
+    font-size: 1.125rem;
+}
+
+.fp-exp-section__list,
+.fp-exp-section__tickets,
+.fp-exp-widget__tickets {
+    margin: 0;
+    padding-left: 20px;
+    color: #1f2937;
+}
+
+.fp-exp-section__list li,
+.fp-exp-section__tickets li,
+.fp-exp-widget__tickets li {
+    margin-bottom: 6px;
+}
+
+.fp-exp-ticket__label {
+    font-weight: 600;
+}
+
+.fp-exp-ticket__description {
+    display: block;
+    color: #475569;
+}
+
+.fp-exp-ticket__price,
+.fp-exp-widget__ticket-price {
+    float: right;
+    font-weight: 600;
+}
+
+.fp-exp-pricing {
+    width: 100%;
+    border-collapse: collapse;
+    margin-bottom: 12px;
+}
+
+.fp-exp-pricing th,
+.fp-exp-pricing td {
+    padding: 8px 12px;
+    border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.fp-exp-section__maps {
+    display: inline-block;
+    margin-top: 8px;
+    color: #2563eb;
+    text-decoration: none;
+}
+
+.fp-exp-section__maps:hover,
+.fp-exp-section__maps:focus {
+    text-decoration: underline;
+}
+
+.fp-exp-widget__notice {
+    margin: 0;
+    color: #475569;
+    font-style: italic;
+}

--- a/assets/js/front.js
+++ b/assets/js/front.js
@@ -1,0 +1,63 @@
+(function () {
+    var i18n = window.wp && window.wp.i18n ? window.wp.i18n : null;
+    var __ = i18n && typeof i18n.__ === 'function' ? i18n.__ : function (text) { return text; };
+
+    function parsePricing(element) {
+        var raw = element.getAttribute('data-pricing') || '[]';
+        try {
+            var data = JSON.parse(raw);
+            return Array.isArray(data) ? data : [];
+        } catch (e) {
+            return [];
+        }
+    }
+
+    function updateWidget(widget) {
+        var summary = widget.querySelector('[data-role="fp-exp-summary"]');
+        if (!summary) {
+            return;
+        }
+
+        var version = widget.getAttribute('data-pricing-version') || '';
+        if (summary.dataset.renderedVersion === version) {
+            return;
+        }
+
+        var pricing = parsePricing(widget);
+        if (!pricing.length) {
+            summary.textContent = __('Contattaci per un preventivo', 'hotel-in-cloud');
+            summary.dataset.renderedVersion = version;
+            return;
+        }
+
+        var firstPrice = '';
+        for (var i = 0; i < pricing.length; i++) {
+            if (pricing[i] && pricing[i].price) {
+                firstPrice = pricing[i].price;
+                break;
+            }
+        }
+
+        if (!firstPrice) {
+            summary.textContent = __('Contattaci per un preventivo', 'hotel-in-cloud');
+            summary.dataset.renderedVersion = version;
+            return;
+        }
+
+        summary.textContent = __('A partire da', 'hotel-in-cloud') + ' ' + firstPrice;
+        summary.dataset.renderedVersion = version;
+    }
+
+    function init() {
+        var widgets = document.querySelectorAll('.fp-exp-widget');
+        for (var i = 0; i < widgets.length; i++) {
+            updateWidget(widgets[i]);
+        }
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init, { once: true });
+    } else {
+        init();
+    }
+})();

--- a/docs/VERIFY-FRONT-BINDING.md
+++ b/docs/VERIFY-FRONT-BINDING.md
@@ -1,0 +1,24 @@
+# Verifica binding front-end FP Experience
+
+## Problemi trovati
+- Nessun shortcode registrato per `[fp_exp_page]` o `[fp_exp_widget]`, quindi il front-end non reagiva ai salvataggi né caricava i metadati delle esperienze.
+- I template mancavano di una normalizzazione condivisa dei metadati (`_fp_highlights`, `_fp_pricing`, `_fp_ticket_types`, ecc.), con il rischio di array/stringhe incoerenti e dati obsoleti in cache del browser.
+- Gli asset front-end non venivano caricati né versionati, e mancava la disabilitazione mirata della cache per le pagine che usano i nostri shortcode.
+
+## Fix applicati
+- Creato modulo `includes/experience/` caricato in fase `init` (`ModuleLoader`) con:
+  - Helper `FP_Exp\Utils\Helpers::get_meta_array()` per restituire sempre array e loggare in debug i meta mancanti.
+  - Gestione asset (`FP_Exp\Frontend\Assets`) con enqueue condizionale e versionamento via `filemtime` per `assets/css/front.css` e `assets/js/front.js`.
+  - Nuove funzioni di rendering shortcode (`render_page_shortcode`, `render_widget_shortcode`) che:
+    - Convalidano `id`, eseguono fallback solo su `fp_experience`, disattivano cache (`Cache-Control: no-store`) e invalidano transients su `save_post_fp_experience`.
+    - Leggono i meta `_fp_highlights`, `_fp_inclusions`, `_fp_ticket_types`, `_fp_pricing`, `_fp_meeting_point_*` usando l'helper e degradano correttamente il meeting point se dati mancanti.
+    - Espongono dati pricing normalizzati al widget con versione aggiornata per la logica JS.
+- Aggiunti nuovi asset:
+  - `assets/css/front.css` per la presentazione delle sezioni/page/widget.
+  - `assets/js/front.js` per il riepilogo prezzo “live” basato sui meta normalizzati.
+
+## Cosa testare manualmente
+1. Creare/modificare un post `fp_experience` e aggiornare highlights/inclusions → visitando una pagina con `[fp_exp_page id="<ID>"]` le modifiche devono apparire subito dopo il refresh.
+2. Aggiornare meta di pricing/ticket → ricaricare la pagina con `[fp_exp_widget id="<ID>"]` e verificare che la tabella e il riepilogo “A partire da …” riflettano i nuovi valori.
+3. Lasciare vuoto `_fp_meeting_point_id` ma compilare l’alternativo: la sezione meeting point deve mostrare solo il testo disponibile senza errori e senza link Maps se non ci sono coordinate/indirizzo.
+4. Abilitare il livello di log “debug” dalle impostazioni e rendere mancante un meta atteso → verificare nel log che venga scritto un messaggio `[FP_Exp]` mascherato.

--- a/includes/bootstrap/module-loader.php
+++ b/includes/bootstrap/module-loader.php
@@ -67,6 +67,9 @@ final class ModuleLoader
         'includes/performance-monitor.php',
         'includes/performance-analytics-dashboard.php',
         'includes/health-monitor.php',
+        'includes/experience/helpers.php',
+        'includes/experience/assets.php',
+        'includes/experience/shortcodes.php',
     ];
 
     private const ADMIN_MODULES = [

--- a/includes/experience/assets.php
+++ b/includes/experience/assets.php
@@ -1,0 +1,73 @@
+<?php declare(strict_types=1);
+
+namespace FP_Exp\Frontend;
+
+use function FpHic\Helpers\hic_safe_add_hook;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Assets
+{
+    private static $enqueueRequested = false;
+    private static $hooked = false;
+
+    public static function bootstrap(): void
+    {
+        if (self::$hooked) {
+            return;
+        }
+
+        self::$hooked = true;
+        hic_safe_add_hook('action', 'wp_enqueue_scripts', [__CLASS__, 'maybe_enqueue'], 20);
+    }
+
+    public static function request_enqueue(): void
+    {
+        self::$enqueueRequested = true;
+
+        if (did_action('wp_enqueue_scripts')) {
+            self::enqueue();
+        }
+    }
+
+    public static function maybe_enqueue(): void
+    {
+        if (!self::$enqueueRequested) {
+            return;
+        }
+
+        self::enqueue();
+    }
+
+    private static function enqueue(): void
+    {
+        $plugin_main_file = dirname(__DIR__, 2) . '/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php';
+        $style_path       = dirname(__DIR__, 2) . '/assets/css/front.css';
+        $script_path      = dirname(__DIR__, 2) . '/assets/js/front.js';
+
+        $style_version  = file_exists($style_path) ? (string) filemtime($style_path) : HIC_PLUGIN_VERSION;
+        $script_version = file_exists($script_path) ? (string) filemtime($script_path) : HIC_PLUGIN_VERSION;
+
+        wp_register_style(
+            'fp-exp-front',
+            plugin_dir_url($plugin_main_file) . 'assets/css/front.css',
+            [],
+            $style_version
+        );
+
+        wp_register_script(
+            'fp-exp-front',
+            plugin_dir_url($plugin_main_file) . 'assets/js/front.js',
+            ['wp-i18n'],
+            $script_version,
+            true
+        );
+
+        wp_enqueue_style('fp-exp-front');
+        wp_enqueue_script('fp-exp-front');
+    }
+}
+
+Assets::bootstrap();

--- a/includes/experience/helpers.php
+++ b/includes/experience/helpers.php
@@ -1,0 +1,108 @@
+<?php declare(strict_types=1);
+
+namespace FP_Exp\Utils;
+
+use function FpHic\Helpers\hic_is_debug_verbose;
+use function FpHic\Helpers\hic_log;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+/**
+ * Helper utilities for the FP Experience front-end bindings.
+ */
+final class Helpers
+{
+    /** @var array<int, array<string, bool>> */
+    private static $missingMetaLogged = [];
+
+    /**
+     * Retrieve a post meta value and guarantee an array output.
+     *
+     * The helper normalises scalar strings, JSON blobs and mixed arrays
+     * returning a clean list that templates can consume safely.
+     */
+    public static function get_meta_array(int $postId, string $key): array
+    {
+        if ($postId <= 0 || $key === '') {
+            return [];
+        }
+
+        $value = get_post_meta($postId, $key, true);
+
+        if (empty($value)) {
+            self::log_missing_meta($postId, $key);
+            return [];
+        }
+
+        if (is_string($value)) {
+            $decoded = json_decode($value, true);
+            if (json_last_error() === JSON_ERROR_NONE && is_array($decoded)) {
+                $value = $decoded;
+            } else {
+                $lines = preg_split('/\r\n|\r|\n/', $value);
+                if (is_array($lines)) {
+                    $value = array_filter(array_map('trim', $lines), static function ($item): bool {
+                        return $item !== '';
+                    });
+                }
+            }
+        }
+
+        if ($value instanceof \Traversable) {
+            $value = iterator_to_array($value, true);
+        }
+
+        if (is_scalar($value)) {
+            $value = [$value];
+        }
+
+        if (!is_array($value)) {
+            return [];
+        }
+
+        $normalised = [];
+
+        foreach ($value as $item) {
+            if ($item === null || $item === '') {
+                continue;
+            }
+
+            if (is_scalar($item)) {
+                $normalised[] = (string) $item;
+                continue;
+            }
+
+            if (is_array($item)) {
+                $normalised[] = $item;
+            }
+        }
+
+        if (empty($normalised)) {
+            self::log_missing_meta($postId, $key);
+        }
+
+        return $normalised;
+    }
+
+    private static function log_missing_meta(int $postId, string $key): void
+    {
+        if (!hic_is_debug_verbose()) {
+            return;
+        }
+
+        if (!isset(self::$missingMetaLogged[$postId][$key])) {
+            hic_log(
+                sprintf('[FP_Exp] Meta "%s" non trovato per esperienza #%d', $key, $postId),
+                HIC_LOG_LEVEL_DEBUG,
+                [
+                    'post_id' => $postId,
+                    'meta_key' => $key,
+                ]
+            );
+
+            self::$missingMetaLogged[$postId][$key] = true;
+        }
+    }
+}

--- a/includes/experience/shortcodes.php
+++ b/includes/experience/shortcodes.php
@@ -1,0 +1,436 @@
+<?php declare(strict_types=1);
+
+namespace FP_Exp;
+
+use FP_Exp\Frontend\Assets;
+use FP_Exp\Utils\Helpers as MetaHelpers;
+use WP_Post;
+use function FpHic\Helpers\hic_log;
+use function FpHic\Helpers\hic_safe_add_hook;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+const SHORTCODE_PAGE   = 'fp_exp_page';
+const SHORTCODE_WIDGET = 'fp_exp_widget';
+
+hic_safe_add_hook('action', 'init', __NAMESPACE__ . '\\register_shortcodes');
+hic_safe_add_hook('action', 'save_post_fp_experience', __NAMESPACE__ . '\\handle_experience_save', 20, 3);
+
+function register_shortcodes(): void
+{
+    add_shortcode(SHORTCODE_PAGE, __NAMESPACE__ . '\\render_page_shortcode');
+    add_shortcode(SHORTCODE_WIDGET, __NAMESPACE__ . '\\render_widget_shortcode');
+}
+
+function render_page_shortcode($atts = [], $content = '', $shortcode = ''): string
+{
+    $post = resolve_experience_post((array) $atts);
+
+    if (!$post) {
+        return '';
+    }
+
+    Assets::request_enqueue();
+    maybe_send_no_store_header();
+
+    $sections = parse_sections($atts['sections'] ?? '');
+
+    $highlights   = MetaHelpers::get_meta_array($post->ID, '_fp_highlights');
+    $inclusions   = MetaHelpers::get_meta_array($post->ID, '_fp_inclusions');
+    $ticketTypes  = MetaHelpers::get_meta_array($post->ID, '_fp_ticket_types');
+    $pricingRows  = MetaHelpers::get_meta_array($post->ID, '_fp_pricing');
+    $meetingPoint = get_meeting_point_data($post->ID);
+
+    $sectionsMap = [
+        'highlights'    => $highlights,
+        'inclusions'    => $inclusions,
+        'ticket_types'  => $ticketTypes,
+        'pricing'       => $pricingRows,
+        'meeting_point' => $meetingPoint,
+    ];
+
+    if (empty($sections)) {
+        $sections = array_keys($sectionsMap);
+    }
+
+    $sections = array_values(array_intersect(array_keys($sectionsMap), $sections));
+
+    ob_start();
+    ?>
+    <div class="fp-exp-page" data-exp-id="<?php echo esc_attr((string) $post->ID); ?>" data-version="<?php echo esc_attr(get_post_modified_time('U', true, $post)); ?>">
+        <div class="fp-exp-header">
+            <h2 class="fp-exp-title"><?php echo esc_html(get_the_title($post)); ?></h2>
+            <?php if ($excerpt = get_the_excerpt($post)) : ?>
+                <p class="fp-exp-excerpt"><?php echo esc_html($excerpt); ?></p>
+            <?php endif; ?>
+        </div>
+        <?php foreach ($sections as $sectionKey) : ?>
+            <?php $data = $sectionsMap[$sectionKey]; ?>
+            <?php if (empty($data)) { continue; } ?>
+            <?php echo render_section($sectionKey, $data, $post); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+        <?php endforeach; ?>
+    </div>
+    <?php
+
+    return (string) ob_get_clean();
+}
+
+function render_widget_shortcode($atts = [], $content = '', $shortcode = ''): string
+{
+    $post = resolve_experience_post((array) $atts);
+
+    if (!$post) {
+        return '';
+    }
+
+    Assets::request_enqueue();
+    maybe_send_no_store_header();
+
+    $pricingRows = MetaHelpers::get_meta_array($post->ID, '_fp_pricing');
+    $ticketTypes = MetaHelpers::get_meta_array($post->ID, '_fp_ticket_types');
+
+    $pricingData = prepare_pricing_payload($pricingRows, $post->ID);
+
+    ob_start();
+    ?>
+    <aside class="fp-exp-widget" data-exp-id="<?php echo esc_attr((string) $post->ID); ?>"
+        data-pricing="<?php echo esc_attr(wp_json_encode($pricingData)); ?>"
+        data-pricing-version="<?php echo esc_attr(get_post_modified_time('U', true, $post)); ?>">
+        <h3 class="fp-exp-widget__title"><?php echo esc_html(get_the_title($post)); ?></h3>
+        <p class="fp-exp-widget__summary" data-role="fp-exp-summary"></p>
+        <div class="fp-exp-widget__body">
+            <?php if (!empty($pricingRows)) : ?>
+                <?php echo render_pricing_table($pricingRows, $post); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>
+            <?php else : ?>
+                <p class="fp-exp-widget__notice"><?php esc_html_e('Tariffe disponibili su richiesta.', 'hotel-in-cloud'); ?></p>
+            <?php endif; ?>
+        </div>
+        <?php if (!empty($ticketTypes)) : ?>
+            <ul class="fp-exp-widget__tickets">
+                <?php foreach ($ticketTypes as $ticket) : ?>
+                    <?php $ticketRow = normalise_ticket_row($ticket); ?>
+                    <li>
+                        <span class="fp-exp-widget__ticket-label"><?php echo esc_html($ticketRow['label']); ?></span>
+                        <?php if ($ticketRow['price'] !== '') : ?>
+                            <span class="fp-exp-widget__ticket-price"><?php echo esc_html($ticketRow['price']); ?></span>
+                        <?php endif; ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+        <?php endif; ?>
+    </aside>
+    <?php
+
+    return (string) ob_get_clean();
+}
+
+function resolve_experience_post(array $atts): ?WP_Post
+{
+    $id = isset($atts['id']) ? absint($atts['id']) : 0;
+
+    if ($id <= 0) {
+        $currentId = get_the_ID();
+        if ($currentId && get_post_type($currentId) === 'fp_experience') {
+            $id = (int) $currentId;
+        } else {
+            hic_log('[FP_Exp] Shortcode senza attributo id e nessun contesto fp_experience valido.', HIC_LOG_LEVEL_DEBUG);
+            return null;
+        }
+    }
+
+    $post = get_post($id);
+
+    if (!$post instanceof WP_Post || $post->post_type !== 'fp_experience') {
+        hic_log('[FP_Exp] Esperienza non trovata per ID fornito: ' . $id, HIC_LOG_LEVEL_WARNING, ['post_id' => $id]);
+        return null;
+    }
+
+    if ($post->post_status !== 'publish') {
+        hic_log('[FP_Exp] Esperienza con stato non pubblicato esclusa dal render.', HIC_LOG_LEVEL_DEBUG, ['post_id' => $id, 'status' => $post->post_status]);
+        return null;
+    }
+
+    return $post;
+}
+
+function parse_sections($sections): array
+{
+    if (empty($sections)) {
+        return [];
+    }
+
+    if (is_string($sections)) {
+        $sections = preg_split('/\s*,\s*/', $sections);
+    }
+
+    if (!is_array($sections)) {
+        return [];
+    }
+
+    $sections = array_map(static function ($section) {
+        return sanitize_key((string) $section);
+    }, $sections);
+
+    return array_filter($sections);
+}
+
+function render_section(string $sectionKey, $data, WP_Post $post): string
+{
+    switch ($sectionKey) {
+        case 'highlights':
+            return render_list_section(__('In evidenza', 'hotel-in-cloud'), (array) $data, 'fp-exp-section--highlights');
+        case 'inclusions':
+            return render_list_section(__('Cosa è incluso', 'hotel-in-cloud'), (array) $data, 'fp-exp-section--inclusions');
+        case 'ticket_types':
+            return render_ticket_types($data);
+        case 'pricing':
+            return render_pricing_table($data, $post);
+        case 'meeting_point':
+            return render_meeting_point($data);
+    }
+
+    return '';
+}
+
+function render_list_section(string $title, array $items, string $class): string
+{
+    if (empty($items)) {
+        return '';
+    }
+
+    ob_start();
+    ?>
+    <section class="fp-exp-section <?php echo esc_attr($class); ?>">
+        <h3 class="fp-exp-section__title"><?php echo esc_html($title); ?></h3>
+        <ul class="fp-exp-section__list">
+            <?php foreach ($items as $item) : ?>
+                <li><?php echo esc_html(is_scalar($item) ? (string) $item : wp_json_encode($item)); ?></li>
+            <?php endforeach; ?>
+        </ul>
+    </section>
+    <?php
+
+    return (string) ob_get_clean();
+}
+
+function render_ticket_types(array $ticketTypes): string
+{
+    if (empty($ticketTypes)) {
+        return '';
+    }
+
+    ob_start();
+    ?>
+    <section class="fp-exp-section fp-exp-section--tickets">
+        <h3 class="fp-exp-section__title"><?php esc_html_e('Tipologie di biglietto', 'hotel-in-cloud'); ?></h3>
+        <ul class="fp-exp-section__tickets">
+            <?php foreach ($ticketTypes as $ticket) : ?>
+                <?php $row = normalise_ticket_row($ticket); ?>
+                <?php if ($row['label'] === '' && $row['description'] === '' && $row['price'] === '') { continue; } ?>
+                <li class="fp-exp-ticket">
+                    <span class="fp-exp-ticket__label"><?php echo esc_html($row['label']); ?></span>
+                    <?php if ($row['description'] !== '') : ?>
+                        <span class="fp-exp-ticket__description"><?php echo esc_html($row['description']); ?></span>
+                    <?php endif; ?>
+                    <?php if ($row['price'] !== '') : ?>
+                        <span class="fp-exp-ticket__price"><?php echo esc_html($row['price']); ?></span>
+                    <?php endif; ?>
+                </li>
+            <?php endforeach; ?>
+        </ul>
+    </section>
+    <?php
+
+    return (string) ob_get_clean();
+}
+
+function normalise_ticket_row($ticket): array
+{
+    $label       = '';
+    $description = '';
+    $price       = '';
+
+    if (is_array($ticket)) {
+        $label = trim((string) ($ticket['label'] ?? $ticket['name'] ?? ''));
+        $description = trim((string) ($ticket['description'] ?? ''));
+        $priceValue  = $ticket['price'] ?? $ticket['amount'] ?? '';
+        $currency    = $ticket['currency'] ?? '';
+
+        if (is_numeric($priceValue)) {
+            $priceValue = number_format_i18n((float) $priceValue, 2);
+        }
+
+        if ($priceValue !== '') {
+            $price = trim($priceValue . ' ' . (string) $currency);
+        }
+    } elseif (is_scalar($ticket)) {
+        $label = trim((string) $ticket);
+    }
+
+    return [
+        'label'       => $label,
+        'description' => $description,
+        'price'       => $price,
+    ];
+}
+
+function render_pricing_table(array $pricingRows, WP_Post $post): string
+{
+    if (empty($pricingRows)) {
+        return '';
+    }
+
+    ob_start();
+    ?>
+    <table class="fp-exp-pricing">
+        <thead>
+            <tr>
+                <th scope="col"><?php esc_html_e('Opzione', 'hotel-in-cloud'); ?></th>
+                <th scope="col"><?php esc_html_e('Prezzo', 'hotel-in-cloud'); ?></th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($pricingRows as $row) : ?>
+                <?php $normalised = normalise_pricing_row($row, $post->ID); ?>
+                <?php if ($normalised['label'] === '' && $normalised['price'] === '') { continue; } ?>
+                <tr>
+                    <td><?php echo esc_html($normalised['label']); ?></td>
+                    <td><?php echo esc_html($normalised['price']); ?></td>
+                </tr>
+            <?php endforeach; ?>
+        </tbody>
+    </table>
+    <?php
+
+    return (string) ob_get_clean();
+}
+
+function normalise_pricing_row($row, int $postId): array
+{
+    $label = '';
+    $price = '';
+
+    if (is_array($row)) {
+        $label = trim((string) ($row['label'] ?? $row['name'] ?? ''));
+        $amount = $row['amount'] ?? $row['price'] ?? '';
+        $currency = $row['currency'] ?? get_post_meta($postId, '_fp_currency', true);
+
+        if (is_numeric($amount)) {
+            $amount = number_format_i18n((float) $amount, 2);
+        }
+
+        if ($amount !== '') {
+            $price = trim($amount . ' ' . (string) $currency);
+        }
+    } elseif (is_scalar($row)) {
+        $label = trim((string) $row);
+    }
+
+    return [
+        'label' => $label,
+        'price' => $price,
+    ];
+}
+
+function get_meeting_point_data(int $postId): array
+{
+    $pointId   = (string) get_post_meta($postId, '_fp_meeting_point_id', true);
+    $alt       = (string) get_post_meta($postId, '_fp_meeting_point_alt', true);
+    $address   = (string) get_post_meta($postId, '_fp_meeting_point_address', true);
+    $latitude  = get_post_meta($postId, '_fp_meeting_point_lat', true);
+    $longitude = get_post_meta($postId, '_fp_meeting_point_lng', true);
+
+    if ($pointId === '' && $alt === '' && $address === '' && $latitude === '' && $longitude === '') {
+        return [];
+    }
+
+    return [
+        'id'        => $pointId,
+        'alt'       => $alt,
+        'address'   => $address,
+        'latitude'  => is_numeric($latitude) ? (float) $latitude : null,
+        'longitude' => is_numeric($longitude) ? (float) $longitude : null,
+    ];
+}
+
+function render_meeting_point(array $data): string
+{
+    if (empty($data)) {
+        return '';
+    }
+
+    $label = $data['alt'] ?: $data['address'];
+
+    if ($label === '' && $data['id'] !== '') {
+        $label = sprintf(__('Punto d\'incontro #%s', 'hotel-in-cloud'), $data['id']);
+    }
+
+    if ($label === '') {
+        return '';
+    }
+
+    $mapLink = '';
+    if (is_numeric($data['latitude']) && is_numeric($data['longitude'])) {
+        $mapLink = sprintf('https://www.google.com/maps?q=%s,%s', rawurlencode((string) $data['latitude']), rawurlencode((string) $data['longitude']));
+    } elseif ($data['address'] !== '') {
+        $mapLink = sprintf('https://www.google.com/maps/search/?api=1&query=%s', rawurlencode($data['address']));
+    }
+
+    ob_start();
+    ?>
+    <section class="fp-exp-section fp-exp-section--meeting-point">
+        <h3 class="fp-exp-section__title"><?php esc_html_e('Punto di incontro', 'hotel-in-cloud'); ?></h3>
+        <p class="fp-exp-section__content"><?php echo esc_html($label); ?></p>
+        <?php if ($mapLink !== '') : ?>
+            <a class="fp-exp-section__maps" href="<?php echo esc_url($mapLink); ?>" target="_blank" rel="noopener noreferrer"><?php esc_html_e('Apri in Maps', 'hotel-in-cloud'); ?></a>
+        <?php endif; ?>
+    </section>
+    <?php
+
+    return (string) ob_get_clean();
+}
+
+function prepare_pricing_payload(array $rows, int $postId): array
+{
+    $payload = [];
+
+    foreach ($rows as $row) {
+        $normalised = normalise_pricing_row($row, $postId);
+        if ($normalised['label'] === '' && $normalised['price'] === '') {
+            continue;
+        }
+
+        $payload[] = $normalised;
+    }
+
+    return $payload;
+}
+
+function maybe_send_no_store_header(): void
+{
+    static $sent = false;
+
+    if ($sent || headers_sent()) {
+        return;
+    }
+
+    header('Cache-Control: no-store, no-cache, must-revalidate, max-age=0');
+    header('Pragma: no-cache');
+    $sent = true;
+}
+
+function handle_experience_save(int $postId, $post, bool $update): void
+{
+    if ($postId <= 0 || (defined('DOING_AUTOSAVE') && DOING_AUTOSAVE)) {
+        return;
+    }
+
+    if (wp_is_post_revision($postId)) {
+        return;
+    }
+
+    delete_transient('fp_exp_page_' . $postId);
+    delete_transient('fp_exp_widget_' . $postId);
+}


### PR DESCRIPTION
## Summary
- register the new fp_experience shortcodes with strict attribute validation and meta normalization helpers
- add conditional asset loader with versioned front.css/front.js and disable caching when rendering shortcodes
- document the verification steps and update the rebuild state marker

## Testing
- php -l includes/experience/helpers.php
- php -l includes/experience/shortcodes.php
- php -l includes/experience/assets.php

------
https://chatgpt.com/codex/tasks/task_e_68da760f7268832fb17c11fd402dd0a8