### PR TITLE
perf: resumable archiving and cron watchdog debounce

### DIFF
--- a/.codex-state.json
+++ b/.codex-state.json
@@ -1,6 +1,79 @@
 {
-  "current_phase": 10,
-  "completed": [1, 2, 3, 4, 5, 6, 7, 8, 9, 10],
-  "last_commit": "release: package version 3.4.0",
-  "notes": "Playbook complete: versione 3.4.0 pacchettizzata in /dist con checksum e documentazione aggiornata."
+    "phase": 5,
+    "tasks": [
+        {
+            "id": 0,
+            "title": "Bootstrap",
+            "status": "done",
+            "notes": "Branch created, dependencies installed, QA baseline captured (PHPUnit shows 4 pre-existing deprecations)."
+        },
+        {
+            "id": 1,
+            "title": "Capability coherence",
+            "status": "done",
+            "notes": "All admin/AJAX flows now rely on the hic_manage capability via hic_require_cap()."
+        },
+        {
+            "id": 2,
+            "title": "SQL safety & identifier sanitization",
+            "status": "done",
+            "notes": "Introduced strict identifier sanitization helper and refactored optimizer/poller queries to rely on sanitized names with prepared statements."
+        },
+        {
+            "id": 3,
+            "title": "Download log hardening",
+            "status": "done",
+            "notes": "Protezione directory log con .htaccess/web.config, sanificazione filename e streaming buffered con wp_die finale."
+        },
+        {
+            "id": 4,
+            "title": "Archiviazione progressiva via AJAX",
+            "status": "done",
+            "notes": "Archivio manuale trasformato in job AJAX riprendibile con stato persistito, rate limiting e nuova UI con barra di avanzamento."
+        },
+        {
+            "id": 5,
+            "title": "Debounce watchdog cron",
+            "status": "done",
+            "notes": "Inserito transient di debounce da 60s in ensure_scheduler_is_active() per limitare i controlli reiterati."
+        },
+        {
+            "id": 6,
+            "title": "Modularizzazione includes/functions.php",
+            "status": "pending",
+            "notes": ""
+        },
+        {
+            "id": 7,
+            "title": "Lazy loading feature flags",
+            "status": "pending",
+            "notes": ""
+        },
+        {
+            "id": 8,
+            "title": "i18n pass & UI coherence",
+            "status": "pending",
+            "notes": ""
+        },
+        {
+            "id": 9,
+            "title": "Logging hardening extra",
+            "status": "pending",
+            "notes": ""
+        },
+        {
+            "id": 10,
+            "title": "Indici & query review",
+            "status": "pending",
+            "notes": ""
+        },
+        {
+            "id": 11,
+            "title": "CI GitHub Actions",
+            "status": "pending",
+            "notes": ""
+        }
+    ],
+    "last_commit": "176125f0ebbb9cd418254a3f37df5dd4f96a5c92",
+    "resume_hint": "Proceed to Phase 6 - Modularizzazione includes/functions.php."
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@
 
 Tutte le modifiche degne di nota del plugin FP HIC Monitor sono documentate qui, in ordine cronologico inverso.
 
+## [Unreleased]
+### Sicurezza
+- Centralizzate le verifiche di capability amministrative sugli endpoint di ottimizzazione e suite enterprise tramite l'helper `hic_require_cap()` per richiedere il permesso `hic_manage` in modo coerente.【F:includes/functions.php†L21-L57】【F:includes/database-optimizer.php†L28-L36】【F:includes/enterprise-management-suite.php†L5-L6】
+- Introdotta la sanitizzazione rigorosa degli identificatori SQL con `hic_sanitize_identifier()` e applicazione nei processi di indicizzazione, archiviazione e manutenzione del database per evitare injection su nomi di tabelle, colonne e indici dinamici.【F:includes/functions.php†L59-L92】【F:includes/database-optimizer.php†L75-L520】【F:includes/booking-poller.php†L3-L36】
+- Rafforzato il download dei log con sanificazione del filename, streaming a buffer e generazione automatica dei file `.htaccess` e `web.config` per bloccare l'accesso diretto alla directory dei log.【F:includes/admin/diagnostics.php†L1893-L1985】【F:includes/helpers-logging.php†L9-L118】【F:includes/bootstrap/lifecycle.php†L210-L282】
+
+### Performance
+- L'archiviazione manuale dei dati storici ora è gestita da un job AJAX riprendibile con stato persistito, rate limiting e barra di avanzamento nell'admin: ogni step processa batch controllati e consente di fermarsi/riprendere senza bloccare l'interfaccia.【F:includes/database-optimizer.php†L324-L592】【F:includes/admin/admin-settings.php†L609-L683】【F:assets/js/admin-settings.js†L1-L430】
+- Il watchdog del cron verifica lo stato degli eventi al massimo una volta al minuto usando un transient di debounce, riducendo il carico sulle richieste mentre mantiene attivo il polling continuo.【F:includes/booking-poller.php†L18-L132】
+
 ## [3.4.0] - 2025-09-26
 ### Sicurezza
 - Normalizzazione preventiva dei token webhook prima della rate limiting e del confronto costante per evitare bypass delle difese su payload malformati.【F:includes/api/webhook.php†L40-L76】

--- a/assets/js/admin-settings.js
+++ b/assets/js/admin-settings.js
@@ -254,4 +254,381 @@ jQuery(function ($) {
                 });
         });
     }
+
+    const archiveConfig = adminSettings.archive || null;
+    const $archiveButton = $('#hic-archive-start-btn');
+    const $archiveButtonLabel = $('#hic-archive-button-label');
+    const $archiveProgress = $('#hic-archive-progress');
+    const $archiveProgressFill = $('#hic-archive-progress-fill');
+    const $archiveProgressLabel = $('#hic-archive-progress-label');
+    const $archiveProgressCount = $('#hic-archive-progress-count');
+    const $archiveStatusText = $('#hic-archive-status-text');
+    const $archiveLoader = $('#hic-archive-loader');
+    const $archiveFeedback = $('#hic-archive-feedback');
+
+    if (
+        ajaxUrl &&
+        archiveConfig &&
+        $archiveButton.length &&
+        $archiveButtonLabel.length &&
+        $archiveProgress.length &&
+        $archiveProgressFill.length
+    ) {
+        const archiveStrings = archiveConfig.i18n || {};
+        const strings = {
+            start_label: archiveStrings.start_label || 'Avvia archiviazione',
+            resume_label: archiveStrings.resume_label || 'Riprendi archiviazione',
+            running_label: archiveStrings.running_label || 'Archiviazione in corso…',
+            restart_label: archiveStrings.restart_label || 'Riesegui archiviazione',
+            completed_label: archiveStrings.completed_label || 'Archiviazione completata',
+            error_generic: archiveStrings.error_generic || 'Si è verificato un errore durante l\'archiviazione.',
+            records_progress: archiveStrings.records_progress || '%1$s di %2$s record archiviati',
+            records_remaining: archiveStrings.records_remaining || '%s record rimanenti',
+            last_batch: archiveStrings.last_batch || 'Ultimo batch: %s record',
+            resume_hint: archiveStrings.resume_hint || 'Job in pausa: riprendi per completare l\'archiviazione.',
+        };
+        const stepInterval = Number.isFinite(Number.parseInt(archiveConfig.step_interval, 10))
+            ? Number.parseInt(archiveConfig.step_interval, 10)
+            : 1500;
+        const batchSize = Number.isFinite(Number.parseInt(archiveConfig.batch_size, 10))
+            ? Number.parseInt(archiveConfig.batch_size, 10)
+            : null;
+
+        let currentState = null;
+        let jobDone = false;
+        let running = false;
+        let pollTimeout = null;
+
+        function formatNumbered(template, values) {
+            if (!template) {
+                return '';
+            }
+
+            let unnamedIndex = 0;
+
+            const withNumbered = template.replace(/%(\d+)\$[sd]/g, function (_match, index) {
+                const position = Number.parseInt(index, 10) - 1;
+                if (Number.isNaN(position) || position < 0 || position >= values.length) {
+                    return '';
+                }
+                return values[position];
+            });
+
+            return withNumbered.replace(/%[sd]/g, function () {
+                if (unnamedIndex >= values.length) {
+                    return '';
+                }
+
+                const replacement = values[unnamedIndex];
+                unnamedIndex += 1;
+                return replacement;
+            });
+        }
+
+        function toggleLoader(isVisible) {
+            if (!$archiveLoader.length) {
+                return;
+            }
+
+            if (isVisible) {
+                $archiveLoader.removeAttr('hidden');
+            } else {
+                $archiveLoader.attr('hidden', true);
+            }
+        }
+
+        function stopLoop() {
+            if (pollTimeout) {
+                window.clearTimeout(pollTimeout);
+                pollTimeout = null;
+            }
+        }
+
+        function setButtonState(mode) {
+            const labelMap = {
+                running: strings.running_label,
+                resume: strings.resume_label,
+                restart: strings.restart_label,
+                idle: strings.start_label,
+            };
+
+            const label = labelMap[mode] || strings.start_label;
+            $archiveButton.prop('disabled', mode === 'running');
+            $archiveButtonLabel.text(label);
+        }
+
+        function refreshButtonState() {
+            if (running) {
+                setButtonState('running');
+                return;
+            }
+
+            if (currentState && !jobDone) {
+                setButtonState('resume');
+                return;
+            }
+
+            if (jobDone && currentState) {
+                setButtonState('restart');
+                return;
+            }
+
+            setButtonState('idle');
+        }
+
+        function updateProgress(state) {
+            if (!state) {
+                $archiveProgress.attr('hidden', true);
+                return;
+            }
+
+            $archiveProgress.removeAttr('hidden');
+
+            const processed = Number.parseInt(state.processed, 10) || 0;
+            const total = Number.parseInt(state.total, 10) || 0;
+            const remaining = Math.max(0, total - processed);
+            const percentage = Math.min(100, Math.max(0, Math.round((Number(state.progress) || 0) * 100)));
+
+            $archiveProgressFill.css('width', `${percentage}%`);
+            $archiveProgressLabel.text(`${percentage}%`);
+            $archiveProgressCount.text(`${processed.toLocaleString()} / ${total.toLocaleString()}`);
+
+            const fragments = [];
+
+            fragments.push(
+                formatNumbered(strings.records_progress, [
+                    processed.toLocaleString(),
+                    total.toLocaleString(),
+                ])
+            );
+
+            if (remaining > 0) {
+                fragments.push(
+                    formatNumbered(strings.records_remaining, [remaining.toLocaleString()])
+                );
+            }
+
+            if (state.last_batch) {
+                const lastBatch = Number.parseInt(state.last_batch, 10) || 0;
+                if (lastBatch > 0) {
+                    fragments.push(formatNumbered(strings.last_batch, [lastBatch.toLocaleString()]));
+                }
+            }
+
+            if (batchSize && fragments.length === 1 && !running && !jobDone) {
+                fragments.push(formatNumbered(strings.last_batch, [batchSize.toLocaleString()]));
+            }
+
+            $archiveStatusText.text(fragments.filter(Boolean).join(' · '));
+        }
+
+        function assignState(data) {
+            if (!data) {
+                currentState = null;
+                jobDone = false;
+                return;
+            }
+
+            currentState = data.state || null;
+            jobDone = Boolean(data.done);
+        }
+
+        function callArchiveEndpoint(action, nonce) {
+            const params = new URLSearchParams();
+            params.append('action', action);
+            params.append('nonce', nonce);
+
+            return fetch(ajaxUrl, {
+                method: 'POST',
+                credentials: 'same-origin',
+                headers: {
+                    'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8',
+                },
+                body: params.toString(),
+            }).then((response) =>
+                response
+                    .json()
+                    .catch(() => ({}))
+                    .then((json) => ({
+                        ok: response.ok,
+                        json,
+                    }))
+            );
+        }
+
+        function parseResponse(result) {
+            const payload = result && result.json ? result.json : {};
+
+            if (payload && payload.success) {
+                return payload.data || {};
+            }
+
+            const data = payload ? payload.data : null;
+
+            if (data && typeof data === 'object' && data.message) {
+                throw new Error(data.message);
+            }
+
+            if (typeof data === 'string') {
+                throw new Error(data);
+            }
+
+            throw new Error(strings.error_generic);
+        }
+
+        function handleArchiveError(message) {
+            stopLoop();
+            running = false;
+            toggleLoader(false);
+            setFeedback($archiveFeedback, 'error', message || strings.error_generic);
+            refreshButtonState();
+        }
+
+        function finalizeSuccess(message) {
+            stopLoop();
+            running = false;
+            jobDone = true;
+            toggleLoader(false);
+            setFeedback($archiveFeedback, 'success', message || strings.completed_label);
+            refreshButtonState();
+        }
+
+        function scheduleNextStep() {
+            stopLoop();
+
+            if (!running) {
+                return;
+            }
+
+            const delay = Number.isFinite(stepInterval) && stepInterval > 0 ? stepInterval : 1500;
+            pollTimeout = window.setTimeout(runStep, delay);
+        }
+
+        function beginArchive() {
+            if (!archiveConfig.start_nonce) {
+                handleArchiveError(strings.error_generic);
+                return;
+            }
+
+            stopLoop();
+            running = true;
+            jobDone = false;
+            toggleLoader(true);
+            setButtonState('running');
+
+            callArchiveEndpoint('hic_archive_old_data_start', archiveConfig.start_nonce)
+                .then(parseResponse)
+                .then((data) => {
+                    assignState(data);
+                    updateProgress(currentState);
+
+                    if (data.message) {
+                        setFeedback($archiveFeedback, data.done ? 'success' : 'info', data.message);
+                    } else {
+                        setFeedback($archiveFeedback, 'info', strings.running_label);
+                    }
+
+                    if (jobDone) {
+                        finalizeSuccess(data.message || strings.completed_label);
+                        return;
+                    }
+
+                    scheduleNextStep();
+                })
+                .catch((error) => {
+                    handleArchiveError(error && error.message ? error.message : strings.error_generic);
+                });
+        }
+
+        function runStep() {
+            if (!running) {
+                return;
+            }
+
+            if (!archiveConfig.step_nonce) {
+                handleArchiveError(strings.error_generic);
+                return;
+            }
+
+            callArchiveEndpoint('hic_archive_old_data_step', archiveConfig.step_nonce)
+                .then(parseResponse)
+                .then((data) => {
+                    assignState(data);
+                    updateProgress(currentState);
+
+                    if (data.message) {
+                        setFeedback($archiveFeedback, data.done ? 'success' : 'info', data.message);
+                    }
+
+                    if (jobDone) {
+                        finalizeSuccess(data.message || strings.completed_label);
+                        return;
+                    }
+
+                    scheduleNextStep();
+                })
+                .catch((error) => {
+                    handleArchiveError(error && error.message ? error.message : strings.error_generic);
+                });
+        }
+
+        function resumeArchive() {
+            stopLoop();
+            running = true;
+            toggleLoader(true);
+            setFeedback($archiveFeedback, 'info', strings.running_label);
+            setButtonState('running');
+            runStep();
+        }
+
+        function fetchStatus() {
+            if (!archiveConfig.status_nonce) {
+                refreshButtonState();
+                return;
+            }
+
+            toggleLoader(true);
+
+            callArchiveEndpoint('hic_archive_old_data_status', archiveConfig.status_nonce)
+                .then(parseResponse)
+                .then((data) => {
+                    if (data && data.active && data.state) {
+                        assignState({ state: data.state, done: data.done });
+                        updateProgress(currentState);
+                        setFeedback($archiveFeedback, 'info', strings.resume_hint);
+                    } else {
+                        assignState(null);
+                        updateProgress(null);
+                        setFeedback($archiveFeedback, null, '');
+                    }
+                })
+                .catch(() => {
+                    assignState(null);
+                    updateProgress(null);
+                })
+                .finally(() => {
+                    toggleLoader(false);
+                    refreshButtonState();
+                });
+        }
+
+        $archiveButton.on('click', function () {
+            if (running) {
+                return;
+            }
+
+            setFeedback($archiveFeedback, null, '');
+
+            if (currentState && !jobDone) {
+                resumeArchive();
+            } else {
+                beginArchive();
+            }
+        });
+
+        updateProgress(null);
+        refreshButtonState();
+        toggleLoader(false);
+        fetchStatus();
+    }
 });

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,11 @@
         "analyse": "vendor/bin/phpstan analyse",
         "analyse:baseline": "vendor/bin/phpstan analyse --generate-baseline",
         "mess": "vendor/bin/phpmd includes/,FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php text phpmd.xml",
+        "qa": [
+            "@lint",
+            "@analyse",
+            "@test"
+        ],
         "quality": [
             "@lint:syntax",
             "@lint",

--- a/docs/QA-BASELINE.md
+++ b/docs/QA-BASELINE.md
@@ -1,0 +1,29 @@
+# QA Baseline
+
+- **Command:** `composer qa --no-ansi`
+- **Date:** 2025-09-30T07:39:45Z
+
+## Output
+
+```
+PHPUnit 11.5.41 by Sebastian Bergmann and contributors.
+
+Runtime:       PHP 8.4.12
+Configuration: /workspace/FP-Hotel-In-Cloud-Monitoraggio-Conversioni/phpunit.xml
+
+...............................................................  63 / 231 ( 27%)
+..............................................................S 126 / 231 ( 54%)
+............................................................... 189 / 231 ( 81%)
+..........................................                      231 / 231 (100%)
+
+Time: 00:01.142, Memory: 18.00 MB
+
+OK, but there were issues!
+Tests: 231, Assertions: 1268, PHPUnit Deprecations: 4, Skipped: 1.
+```
+
+## Notes
+
+- `vendor/bin/phpcs` produced no output (0 errors, 0 warnings).
+- `vendor/bin/phpstan analyse` produced no output (0 errors).
+- `vendor/bin/phpunit` reported 4 deprecations and 1 skipped test (pre-existing baseline).

--- a/includes/admin/admin-settings.php
+++ b/includes/admin/admin-settings.php
@@ -482,6 +482,25 @@ function hic_admin_enqueue_scripts($hook) {
                 'email_sending' => __('Invio email di test in corso...', 'hotel-in-cloud'),
                 'token_generating' => __('Generazione token in corso...', 'hotel-in-cloud'),
             ),
+            'archive' => array(
+                'start_nonce' => wp_create_nonce('hic_archive_start'),
+                'step_nonce' => wp_create_nonce('hic_archive_step'),
+                'status_nonce' => wp_create_nonce('hic_archive_status'),
+                'batch_size' => \FpHic\DatabaseOptimizer\DatabaseOptimizer::BATCH_SIZE,
+                'step_interval' => 1500,
+                'i18n' => array(
+                    'start_label' => __('Avvia archiviazione', 'hotel-in-cloud'),
+                    'resume_label' => __('Riprendi archiviazione', 'hotel-in-cloud'),
+                    'running_label' => __('Archiviazione in corso…', 'hotel-in-cloud'),
+                    'restart_label' => __('Riesegui archiviazione', 'hotel-in-cloud'),
+                    'completed_label' => __('Archiviazione completata', 'hotel-in-cloud'),
+                    'error_generic' => __('Si è verificato un errore durante l\'archiviazione.', 'hotel-in-cloud'),
+                    'records_progress' => __('%1$s di %2$s record archiviati', 'hotel-in-cloud'),
+                    'records_remaining' => __('%s record rimanenti', 'hotel-in-cloud'),
+                    'last_batch' => __('Ultimo batch: %s record', 'hotel-in-cloud'),
+                    'resume_hint' => __('Job in pausa: riprendi per completare l\'archiviazione.', 'hotel-in-cloud'),
+                ),
+            ),
         ));
     }
 
@@ -757,6 +776,44 @@ function hic_options_page() {
                 </div>
             </div>
         <?php endif; ?>
+
+        <div class="hic-card hic-archive-card">
+            <div class="hic-card__header">
+                <div>
+                    <h2 class="hic-card__title"><?php esc_html_e('Archiviazione Storica', 'hotel-in-cloud'); ?></h2>
+                    <p class="hic-card__subtitle"><?php esc_html_e('Esegui l\'archiviazione progressiva dei dati più datati senza bloccare l\'interfaccia.', 'hotel-in-cloud'); ?></p>
+                </div>
+                <div class="hic-page-actions">
+                    <button type="button" id="hic-archive-start-btn" class="button hic-button hic-button--secondary">
+                        <span class="dashicons dashicons-database-import"></span>
+                        <span id="hic-archive-button-label"><?php esc_html_e('Avvia archiviazione', 'hotel-in-cloud'); ?></span>
+                    </button>
+                </div>
+            </div>
+            <div class="hic-card__body">
+                <div id="hic-archive-progress" class="hic-wizard__progress" hidden>
+                    <div class="hic-progress-text">
+                        <span id="hic-archive-progress-label">0%</span>
+                        <span id="hic-archive-progress-count">0 / 0</span>
+                    </div>
+                    <div class="hic-progress-bar">
+                        <div id="hic-archive-progress-fill" class="hic-progress-fill" style="width:0%;"></div>
+                    </div>
+                    <p id="hic-archive-status-text" class="hic-inline-status"></p>
+                </div>
+
+                <div id="hic-archive-loader" class="hic-inline-loader" hidden>
+                    <span class="spinner is-active"></span>
+                    <span><?php esc_html_e('Archiviazione in corso...', 'hotel-in-cloud'); ?></span>
+                </div>
+
+                <div id="hic-archive-feedback" class="hic-feedback" hidden></div>
+
+                <p class="hic-secondary-text">
+                    <?php esc_html_e('Ogni passaggio elabora piccoli lotti di record (fino a 1000 per batch) e può essere ripreso in qualsiasi momento.', 'hotel-in-cloud'); ?>
+                </p>
+            </div>
+        </div>
     </div>
     <?php
 }

--- a/includes/enterprise-management-suite.php
+++ b/includes/enterprise-management-suite.php
@@ -2,6 +2,8 @@
 
 namespace FpHic\ReconAndSetup;
 
+use function FpHic\Helpers\hic_require_cap;
+
 if (!defined('ABSPATH')) exit;
 
 /**
@@ -1159,7 +1161,7 @@ class EnterpriseManagementSuite {
      * Add health dashboard widget
      */
     public function add_health_dashboard_widget() {
-        if (current_user_can('manage_options')) {
+        if (current_user_can('hic_manage')) {
             wp_add_dashboard_widget(
                 'hic_health_status',
                 'FP HIC Monitor - System Health',
@@ -1318,9 +1320,7 @@ class EnterpriseManagementSuite {
      * AJAX: Setup wizard step
      */
     public function ajax_setup_wizard_step() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
-        }
+        hic_require_cap('hic_manage');
         
         if (!check_ajax_referer('hic_setup_wizard', 'nonce', false)) {
             wp_send_json_error('Invalid nonce');
@@ -1448,9 +1448,7 @@ class EnterpriseManagementSuite {
      * AJAX: Run diagnostics
      */
     public function ajax_run_diagnostics() {
-        if (!current_user_can('manage_options')) {
-            wp_die('Insufficient permissions');
-        }
+        hic_require_cap('hic_manage');
         
         if (!check_ajax_referer('hic_health_check', 'nonce', false)) {
             wp_send_json_error('Invalid nonce');

--- a/includes/google-ads-enhanced.php
+++ b/includes/google-ads-enhanced.php
@@ -2174,7 +2174,7 @@ class GoogleAdsEnhancedConversions {
      * Handle Enhanced Conversions form submission
      */
     public function handle_enhanced_conversions_form() {
-        if (!isset($_POST['save_enhanced_settings']) || !current_user_can('manage_options')) {
+        if (!isset($_POST['save_enhanced_settings']) || !current_user_can('hic_manage')) {
             return;
         }
         

--- a/includes/runtime-dev-logger.php
+++ b/includes/runtime-dev-logger.php
@@ -194,7 +194,7 @@ function handle_shutdown(): void
  */
 function render_admin_notice(): void
 {
-    if (!function_exists('current_user_can') || !current_user_can('manage_options')) {
+    if (!function_exists('current_user_can') || !current_user_can('hic_manage')) {
         return;
     }
 
@@ -259,7 +259,7 @@ function render_admin_notice(): void
  */
 function render_frontend_overlay(): void
 {
-    if (!function_exists('current_user_can') || !current_user_can('manage_options')) {
+    if (!function_exists('current_user_can') || !current_user_can('hic_manage')) {
         return;
     }
 


### PR DESCRIPTION
## Summary
- convert the database optimizer archiving routine into a resumable job that persists state, enforces rate limits, and reuses sanitized batch helpers
- expose a progressive archiving control card in the settings UI with localized nonces and a progress driver script that can pause and resume batches
- record the phase advancement in the resumable tracker and changelog
- debounce the cron watchdog by persisting the last scheduler check for sixty seconds, reducing redundant recovery work while preserving resilience

## Testing
- composer qa

------
https://chatgpt.com/codex/tasks/task_e_68db88b725d4832f884e1df7bcbbb3ed