### PR TITLE
Add Hotel in Cloud webhook S2S pipeline

### DIFF
--- a/docs/build/.state-hic-webhook.json
+++ b/docs/build/.state-hic-webhook.json
@@ -1,0 +1,13 @@
+{
+    "phase": 7,
+    "percent": 100,
+    "done": [
+        "phase1",
+        "phase2",
+        "phase3",
+        "phase4",
+        "phase5",
+        "phase6",
+        "phase7"
+    ]
+}

--- a/includes/bootstrap/module-loader.php
+++ b/includes/bootstrap/module-loader.php
@@ -79,6 +79,7 @@ final class ModuleLoader
         'includes/performance-monitor.php',
         'includes/performance-analytics-dashboard.php',
         'includes/health-monitor.php',
+        'src/bootstrap.php',
     ];
 
     private const ADMIN_MODULES = [

--- a/src/Admin/SettingsPage.php
+++ b/src/Admin/SettingsPage.php
@@ -1,0 +1,448 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Admin;
+
+use FpHic\HicS2S\Repository\Logs;
+use FpHic\HicS2S\Services\Ga4Service;
+use FpHic\HicS2S\Services\MetaCapiService;
+use FpHic\HicS2S\ValueObjects\BookingPayload;
+use WP_REST_Request;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class SettingsPage
+{
+    private const OPTION_NAME = 'hic_s2s_settings';
+
+    public static function bootstrap(): void
+    {
+        if (!\function_exists('add_action')) {
+            return;
+        }
+
+        \add_action('admin_menu', [self::class, 'registerMenu']);
+        \add_action('admin_init', [self::class, 'registerSettings']);
+        \add_action('admin_post_hic_s2s_test_webhook', [self::class, 'handleTestWebhook']);
+        \add_action('admin_post_hic_s2s_ping_ga4', [self::class, 'handlePingGa4']);
+        \add_action('admin_post_hic_s2s_ping_meta', [self::class, 'handlePingMeta']);
+        \add_action('admin_post_hic_s2s_export_logs', [self::class, 'handleExportLogs']);
+    }
+
+    public static function registerMenu(): void
+    {
+        if (!\function_exists('add_submenu_page')) {
+            return;
+        }
+
+        \add_submenu_page(
+            'hic-monitoring',
+            __('HIC Webhook & S2S', 'hotel-in-cloud'),
+            __('HIC Webhook & S2S', 'hotel-in-cloud'),
+            'hic_manage',
+            'hic-webhook-s2s',
+            [self::class, 'renderPage']
+        );
+    }
+
+    public static function registerSettings(): void
+    {
+        if (!\function_exists('register_setting')) {
+            return;
+        }
+
+        \register_setting(
+            'hic_s2s_settings_group',
+            self::OPTION_NAME,
+            [
+                'type' => 'array',
+                'sanitize_callback' => [self::class, 'sanitizeSettings'],
+                'default' => self::getDefaultSettings(),
+            ]
+        );
+    }
+
+    public static function sanitizeSettings($value): array
+    {
+        $value = is_array($value) ? $value : [];
+
+        $redirectorEnabled = !empty($value['redirector_enabled']);
+
+        return [
+            'token' => sanitize_text_field($value['token'] ?? ''),
+            'ga4_measurement_id' => sanitize_text_field($value['ga4_measurement_id'] ?? ''),
+            'ga4_api_secret' => sanitize_text_field($value['ga4_api_secret'] ?? ''),
+            'meta_pixel_id' => sanitize_text_field($value['meta_pixel_id'] ?? ''),
+            'meta_access_token' => sanitize_text_field($value['meta_access_token'] ?? ''),
+            'redirector_enabled' => $redirectorEnabled,
+            'redirector_engine_url' => esc_url_raw($value['redirector_engine_url'] ?? ''),
+        ];
+    }
+
+    public static function getSettings(): array
+    {
+        $settings = \get_option(self::OPTION_NAME, self::getDefaultSettings());
+
+        if (!is_array($settings)) {
+            $settings = self::getDefaultSettings();
+        }
+
+        return wp_parse_args($settings, self::getDefaultSettings());
+    }
+
+    public static function renderPage(): void
+    {
+        if (!\function_exists('current_user_can') || !\current_user_can('hic_manage')) {
+            wp_die(__('Non hai i permessi per accedere a questa pagina.', 'hotel-in-cloud'));
+        }
+
+        $settings = self::getSettings();
+        $engineUrl = $settings['redirector_engine_url'] ?? '';
+        $snippet = '';
+
+        if ($engineUrl !== '') {
+            $snippet = '/?fp_go_booking=1&target=' . rawurlencode(base64_encode($engineUrl));
+        }
+
+        $channelFilter = isset($_GET['hic_s2s_log_channel']) ? sanitize_key((string) $_GET['hic_s2s_log_channel']) : '';
+        $logsRepo = new Logs();
+        $logs = $logsRepo->latest(20, $channelFilter !== '' ? $channelFilter : null);
+
+        ?>
+        <div class="wrap">
+            <h1><?php esc_html_e('HIC Webhook & S2S', 'hotel-in-cloud'); ?></h1>
+            <?php settings_errors('hic_s2s'); ?>
+            <form method="post" action="options.php">
+                <?php
+                settings_fields('hic_s2s_settings_group');
+                ?>
+                <table class="form-table" role="presentation">
+                    <tbody>
+                    <tr>
+                        <th scope="row">
+                            <label for="hic_s2s_token"><?php esc_html_e('Token Webhook', 'hotel-in-cloud'); ?></label>
+                        </th>
+                        <td>
+                            <input type="text" class="regular-text" id="hic_s2s_token" name="<?php echo esc_attr(self::OPTION_NAME); ?>[token]" value="<?php echo esc_attr($settings['token']); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="hic_s2s_ga4_measurement_id"><?php esc_html_e('GA4 Measurement ID', 'hotel-in-cloud'); ?></label>
+                        </th>
+                        <td>
+                            <input type="text" class="regular-text" id="hic_s2s_ga4_measurement_id" name="<?php echo esc_attr(self::OPTION_NAME); ?>[ga4_measurement_id]" value="<?php echo esc_attr($settings['ga4_measurement_id']); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="hic_s2s_ga4_api_secret"><?php esc_html_e('GA4 API Secret', 'hotel-in-cloud'); ?></label>
+                        </th>
+                        <td>
+                            <input type="text" class="regular-text" id="hic_s2s_ga4_api_secret" name="<?php echo esc_attr(self::OPTION_NAME); ?>[ga4_api_secret]" value="<?php echo esc_attr($settings['ga4_api_secret']); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="hic_s2s_meta_pixel_id"><?php esc_html_e('Meta Pixel ID', 'hotel-in-cloud'); ?></label>
+                        </th>
+                        <td>
+                            <input type="text" class="regular-text" id="hic_s2s_meta_pixel_id" name="<?php echo esc_attr(self::OPTION_NAME); ?>[meta_pixel_id]" value="<?php echo esc_attr($settings['meta_pixel_id']); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="hic_s2s_meta_access_token"><?php esc_html_e('Meta Access Token', 'hotel-in-cloud'); ?></label>
+                        </th>
+                        <td>
+                            <input type="text" class="regular-text" id="hic_s2s_meta_access_token" name="<?php echo esc_attr(self::OPTION_NAME); ?>[meta_access_token]" value="<?php echo esc_attr($settings['meta_access_token']); ?>" />
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="hic_s2s_redirector_enabled"><?php esc_html_e('Abilita redirector /go/booking', 'hotel-in-cloud'); ?></label>
+                        </th>
+                        <td>
+                            <label>
+                                <input type="checkbox" id="hic_s2s_redirector_enabled" name="<?php echo esc_attr(self::OPTION_NAME); ?>[redirector_enabled]" value="1" <?php checked($settings['redirector_enabled']); ?> />
+                                <?php esc_html_e('Attiva la gestione redirector', 'hotel-in-cloud'); ?>
+                            </label>
+                        </td>
+                    </tr>
+                    <tr>
+                        <th scope="row">
+                            <label for="hic_s2s_redirector_engine_url"><?php esc_html_e('URL booking engine', 'hotel-in-cloud'); ?></label>
+                        </th>
+                        <td>
+                            <input type="url" class="regular-text" id="hic_s2s_redirector_engine_url" name="<?php echo esc_attr(self::OPTION_NAME); ?>[redirector_engine_url]" value="<?php echo esc_attr($settings['redirector_engine_url']); ?>" />
+                            <?php if ($snippet !== '') : ?>
+                                <p class="description"><?php esc_html_e('Link pronto da usare:', 'hotel-in-cloud'); ?> <code><?php echo esc_html($snippet); ?></code></p>
+                            <?php endif; ?>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+                <?php submit_button(); ?>
+            </form>
+
+            <h2><?php esc_html_e('Strumenti di test', 'hotel-in-cloud'); ?></h2>
+            <p><?php esc_html_e('Usa questi pulsanti per verificare la configurazione del webhook e delle integrazioni server-to-server.', 'hotel-in-cloud'); ?></p>
+            <div class="hic-s2s-tools">
+                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;margin-right:1em;">
+                    <?php wp_nonce_field('hic_s2s_test_webhook'); ?>
+                    <input type="hidden" name="action" value="hic_s2s_test_webhook" />
+                    <?php submit_button(__('Invia finto webhook', 'hotel-in-cloud'), 'secondary', 'submit', false); ?>
+                </form>
+                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;margin-right:1em;">
+                    <?php wp_nonce_field('hic_s2s_ping_ga4'); ?>
+                    <input type="hidden" name="action" value="hic_s2s_ping_ga4" />
+                    <?php submit_button(__('Ping GA4', 'hotel-in-cloud'), 'secondary', 'submit', false); ?>
+                </form>
+                <form method="post" action="<?php echo esc_url(admin_url('admin-post.php')); ?>" style="display:inline-block;">
+                    <?php wp_nonce_field('hic_s2s_ping_meta'); ?>
+                    <input type="hidden" name="action" value="hic_s2s_ping_meta" />
+                    <?php submit_button(__('Ping Meta', 'hotel-in-cloud'), 'secondary', 'submit', false); ?>
+                </form>
+            </div>
+
+            <h2><?php esc_html_e('Ultimi log', 'hotel-in-cloud'); ?></h2>
+            <form method="get" style="margin-bottom:1em;">
+                <input type="hidden" name="page" value="hic-webhook-s2s" />
+                <label for="hic_s2s_log_channel">
+                    <?php esc_html_e('Canale', 'hotel-in-cloud'); ?>
+                </label>
+                <input type="text" id="hic_s2s_log_channel" name="hic_s2s_log_channel" value="<?php echo esc_attr($channelFilter); ?>" />
+                <?php submit_button(__('Filtra', 'hotel-in-cloud'), 'secondary', 'submit', false); ?>
+                <?php
+                $exportUrl = wp_nonce_url(
+                    add_query_arg([
+                        'action' => 'hic_s2s_export_logs',
+                        'channel' => $channelFilter,
+                    ], admin_url('admin-post.php')),
+                    'hic_s2s_export_logs'
+                );
+                ?>
+                <a class="button" href="<?php echo esc_url($exportUrl); ?>"><?php esc_html_e('Esporta CSV', 'hotel-in-cloud'); ?></a>
+            </form>
+            <table class="widefat striped">
+                <thead>
+                <tr>
+                    <th><?php esc_html_e('ID', 'hotel-in-cloud'); ?></th>
+                    <th><?php esc_html_e('Timestamp', 'hotel-in-cloud'); ?></th>
+                    <th><?php esc_html_e('Canale', 'hotel-in-cloud'); ?></th>
+                    <th><?php esc_html_e('Livello', 'hotel-in-cloud'); ?></th>
+                    <th><?php esc_html_e('Messaggio', 'hotel-in-cloud'); ?></th>
+                    <th><?php esc_html_e('Contesto', 'hotel-in-cloud'); ?></th>
+                </tr>
+                </thead>
+                <tbody>
+                <?php if ($logs === []) : ?>
+                    <tr>
+                        <td colspan="6"><?php esc_html_e('Nessun log disponibile.', 'hotel-in-cloud'); ?></td>
+                    </tr>
+                <?php else : ?>
+                    <?php foreach ($logs as $log) :
+                        $context = '';
+                        if (!empty($log['context'])) {
+                            $decoded = json_decode((string) $log['context'], true);
+                            if (is_array($decoded)) {
+                                $context = wp_json_encode($decoded, JSON_UNESCAPED_UNICODE);
+                            } else {
+                                $context = (string) $log['context'];
+                            }
+                        }
+                    ?>
+                        <tr>
+                            <td><?php echo esc_html((string) $log['id']); ?></td>
+                            <td><?php echo esc_html((string) $log['ts']); ?></td>
+                            <td><?php echo esc_html((string) $log['channel']); ?></td>
+                            <td><?php echo esc_html((string) $log['level']); ?></td>
+                            <td><?php echo esc_html((string) $log['message']); ?></td>
+                            <td><code><?php echo esc_html($context); ?></code></td>
+                        </tr>
+                    <?php endforeach; ?>
+                <?php endif; ?>
+                </tbody>
+            </table>
+        </div>
+        <?php
+    }
+
+    public static function handleTestWebhook(): void
+    {
+        self::requireCapability();
+        check_admin_referer('hic_s2s_test_webhook');
+
+        $settings = self::getSettings();
+        $token = $settings['token'] ?? '';
+
+        $request = new WP_REST_Request('POST', '/hic/v1/conversion');
+        $request->set_body_params([
+            'token' => $token,
+            'booking_code' => 'TEST-' . wp_generate_uuid4(),
+            'status' => 'confirmed',
+            'checkin' => gmdate('Y-m-d'),
+            'checkout' => gmdate('Y-m-d', strtotime('+1 day')),
+            'currency' => 'EUR',
+            'amount' => 1,
+            'guest_email' => 'qa@example.com',
+            'guest_phone' => '+3900000000',
+        ]);
+        $request->set_param('token', $token);
+
+        $response = rest_do_request($request);
+
+        if (is_wp_error($response)) {
+            self::redirectWithMessage(__('Errore durante il test webhook.', 'hotel-in-cloud') . ' ' . $response->get_error_message(), 'error');
+        } else {
+            $data = $response->get_data();
+            $message = __('Webhook di prova inviato correttamente.', 'hotel-in-cloud');
+            if (isset($data['conversion_id'])) {
+                $message .= ' #' . sanitize_text_field((string) $data['conversion_id']);
+            }
+
+            self::redirectWithMessage($message, 'updated');
+        }
+    }
+
+    public static function handlePingGa4(): void
+    {
+        self::requireCapability();
+        check_admin_referer('hic_s2s_ping_ga4');
+
+        try {
+            $payload = BookingPayload::fromArray([
+                'booking_code' => 'GA4-' . wp_generate_uuid4(),
+                'status' => 'confirmed',
+                'checkin' => gmdate('Y-m-d'),
+                'checkout' => gmdate('Y-m-d', strtotime('+1 day')),
+                'currency' => 'EUR',
+                'amount' => 1,
+            ]);
+        } catch (\InvalidArgumentException $exception) {
+            self::redirectWithMessage(__('Impossibile costruire il payload di test GA4.', 'hotel-in-cloud'), 'error');
+            return;
+        }
+
+        $testCode = 'HIC_S2S_TEST';
+        $filter = static function (array $body) use ($testCode) {
+            $body['test_event_code'] = $testCode;
+            return $body;
+        };
+
+        add_filter('hic_s2s_ga4_payload', $filter);
+        $result = (new Ga4Service())->sendPurchase($payload, false);
+        remove_filter('hic_s2s_ga4_payload', $filter);
+
+        if (!empty($result['sent'])) {
+            self::redirectWithMessage(__('Ping GA4 completato con successo.', 'hotel-in-cloud'), 'updated');
+            return;
+        }
+
+        $code = $result['code'] ?? null;
+        $message = __('Ping GA4 fallito.', 'hotel-in-cloud');
+        if ($code !== null) {
+            $message .= ' HTTP ' . (int) $code;
+        }
+
+        self::redirectWithMessage($message, 'error');
+    }
+
+    public static function handlePingMeta(): void
+    {
+        self::requireCapability();
+        check_admin_referer('hic_s2s_ping_meta');
+
+        try {
+            $payload = BookingPayload::fromArray([
+                'booking_code' => 'META-' . wp_generate_uuid4(),
+                'status' => 'confirmed',
+                'checkin' => gmdate('Y-m-d'),
+                'checkout' => gmdate('Y-m-d', strtotime('+1 day')),
+                'currency' => 'EUR',
+                'amount' => 1,
+            ]);
+        } catch (\InvalidArgumentException $exception) {
+            self::redirectWithMessage(__('Impossibile costruire il payload di test Meta.', 'hotel-in-cloud'), 'error');
+            return;
+        }
+
+        $result = (new MetaCapiService())->sendPurchase($payload, false);
+
+        if (!empty($result['sent'])) {
+            self::redirectWithMessage(__('Ping Meta completato con successo.', 'hotel-in-cloud'), 'updated');
+            return;
+        }
+
+        $code = $result['code'] ?? null;
+        $message = __('Ping Meta fallito.', 'hotel-in-cloud');
+        if ($code !== null) {
+            $message .= ' HTTP ' . (int) $code;
+        }
+
+        self::redirectWithMessage($message, 'error');
+    }
+
+    public static function handleExportLogs(): void
+    {
+        self::requireCapability();
+        check_admin_referer('hic_s2s_export_logs');
+
+        $channel = isset($_GET['channel']) ? sanitize_key((string) $_GET['channel']) : '';
+        $logs = (new Logs())->latest(200, $channel !== '' ? $channel : null);
+
+        nocache_headers();
+        header('Content-Type: text/csv; charset=utf-8');
+        header('Content-Disposition: attachment; filename="hic-logs-' . gmdate('Ymd-His') . '.csv"');
+
+        $output = fopen('php://output', 'w');
+        if ($output === false) {
+            wp_die(__('Impossibile generare il file CSV.', 'hotel-in-cloud'));
+        }
+
+        fputcsv($output, ['id', 'timestamp', 'channel', 'level', 'message', 'context']);
+        foreach ($logs as $log) {
+            $context = (string) ($log['context'] ?? '');
+            fputcsv($output, [
+                $log['id'] ?? '',
+                $log['ts'] ?? '',
+                $log['channel'] ?? '',
+                $log['level'] ?? '',
+                $log['message'] ?? '',
+                $context,
+            ]);
+        }
+
+        fclose($output);
+        exit;
+    }
+
+    private static function getDefaultSettings(): array
+    {
+        return [
+            'token' => 'hic2025ga4',
+            'ga4_measurement_id' => '',
+            'ga4_api_secret' => '',
+            'meta_pixel_id' => '',
+            'meta_access_token' => '',
+            'redirector_enabled' => false,
+            'redirector_engine_url' => '',
+        ];
+    }
+
+    private static function requireCapability(): void
+    {
+        if (!current_user_can('hic_manage')) {
+            wp_die(__('Permessi insufficienti per eseguire questa azione.', 'hotel-in-cloud'));
+        }
+    }
+
+    private static function redirectWithMessage(string $message, string $type): void
+    {
+        add_settings_error('hic_s2s', 'hic_s2s_notice', $message, $type);
+        set_transient('settings_errors', get_settings_errors('hic_s2s'), 30);
+        wp_safe_redirect(admin_url('admin.php?page=hic-webhook-s2s'));
+        exit;
+    }
+}

--- a/src/Http/Controllers/WebhookController.php
+++ b/src/Http/Controllers/WebhookController.php
@@ -1,0 +1,313 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Http\Controllers;
+
+use FpHic\HicS2S\Admin\SettingsPage;
+use FpHic\HicS2S\Repository\BookingIntents;
+use FpHic\HicS2S\Repository\Conversions;
+use FpHic\HicS2S\Repository\Logs;
+use FpHic\HicS2S\Services\Ga4Service;
+use FpHic\HicS2S\Services\MetaCapiService;
+use FpHic\HicS2S\ValueObjects\BookingPayload;
+use WP_Error;
+use WP_REST_Request;
+use WP_REST_Response;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class WebhookController
+{
+    private Conversions $conversions;
+
+    private BookingIntents $bookingIntents;
+
+    private Logs $logs;
+
+    private Ga4Service $ga4Service;
+
+    private MetaCapiService $metaService;
+
+    public function __construct()
+    {
+        $this->conversions = new Conversions();
+        $this->bookingIntents = new BookingIntents();
+        $this->logs = new Logs();
+        $this->ga4Service = new Ga4Service();
+        $this->metaService = new MetaCapiService();
+    }
+
+    public function handleConversion(WP_REST_Request $request)
+    {
+        $settings = SettingsPage::getSettings();
+        $configuredToken = sanitize_text_field($settings['token'] ?? '');
+        $providedToken = sanitize_text_field((string) $request->get_param('token'));
+
+        if ($configuredToken === '' || !hash_equals($configuredToken, $providedToken)) {
+            return new WP_Error('hic_invalid_token', __('Token non valido', 'hotel-in-cloud'), ['status' => 401]);
+        }
+
+        try {
+            $payload = BookingPayload::fromArray($this->extractPayload($request));
+        } catch (\InvalidArgumentException $exception) {
+            $this->logs->log('webhook', 'error', 'Payload conversione non valido', [
+                'error' => $exception->getMessage(),
+            ]);
+
+            return new WP_Error('hic_invalid_payload', __('Payload non valido', 'hotel-in-cloud'), ['status' => 400]);
+        }
+
+        $bucket = $this->resolveBucket($payload);
+
+        $conversionId = $this->conversions->insert(array_merge(
+            $payload->toDatabaseArray(),
+            [
+                'bucket' => $bucket,
+                'ga4_sent' => 0,
+                'meta_sent' => 0,
+            ]
+        ));
+
+        if ($conversionId === null) {
+            $this->logs->log('webhook', 'error', 'Impossibile salvare la conversione', [
+                'booking_code' => $payload->getBookingCode(),
+            ]);
+
+            return new WP_Error('hic_persistence_error', __('Errore nel salvataggio della conversione', 'hotel-in-cloud'), ['status' => 500]);
+        }
+
+        $this->logs->log('webhook', 'info', 'Conversione salvata', [
+            'conversion_id' => $conversionId,
+            'booking_code' => $payload->getBookingCode(),
+            'bucket' => $bucket,
+        ]);
+
+        $sendUserData = $this->shouldSendUserData($payload);
+
+        if (!$sendUserData) {
+            $this->logs->log('webhook', 'info', 'User data esclusi per consenso non disponibile', [
+                'booking_code' => $payload->getBookingCode(),
+            ]);
+        }
+
+        $ga4Result = $this->ga4Service->sendPurchase($payload, $sendUserData);
+        $ga4Sent = (bool) ($ga4Result['sent'] ?? false);
+
+        if ($ga4Sent) {
+            $this->conversions->markGa4Status($conversionId, true);
+        }
+
+        $metaResult = $this->metaService->sendPurchase($payload, $sendUserData);
+        $metaSent = (bool) ($metaResult['sent'] ?? false);
+
+        if ($metaSent) {
+            $this->conversions->markMetaStatus($conversionId, true);
+        }
+
+        return new WP_REST_Response([
+            'ok' => true,
+            'conversion_id' => $conversionId,
+            'bucket' => $bucket,
+            'ga4_sent' => $ga4Sent,
+            'meta_sent' => $metaSent,
+        ]);
+    }
+
+    public function health(WP_REST_Request $request)
+    {
+        $settings = SettingsPage::getSettings();
+
+        $ga4Configured = ($settings['ga4_measurement_id'] ?? '') !== '' && ($settings['ga4_api_secret'] ?? '') !== '';
+        $metaConfigured = ($settings['meta_pixel_id'] ?? '') !== '' && ($settings['meta_access_token'] ?? '') !== '';
+
+        $ga4Reachable = $ga4Configured ? $this->pingUrl('https://www.google-analytics.com') : null;
+        $metaReachable = $metaConfigured ? $this->pingUrl('https://graph.facebook.com') : null;
+
+        $conversions = array_map(
+            static function (array $row): array {
+                return [
+                    'id' => (int) ($row['id'] ?? 0),
+                    'booking_code' => (string) ($row['booking_code'] ?? ''),
+                    'status' => (string) ($row['status'] ?? ''),
+                    'bucket' => (string) ($row['bucket'] ?? ''),
+                    'ga4_sent' => (bool) ($row['ga4_sent'] ?? false),
+                    'meta_sent' => (bool) ($row['meta_sent'] ?? false),
+                    'created_at' => (string) ($row['created_at'] ?? ''),
+                ];
+            },
+            $this->conversions->latest(10)
+        );
+
+        return new WP_REST_Response([
+            'ok' => true,
+            'settings' => [
+                'token_set' => ($settings['token'] ?? '') !== '',
+                'ga4_configured' => $ga4Configured,
+                'meta_configured' => $metaConfigured,
+            ],
+            'ga4' => [
+                'configured' => $ga4Configured,
+                'reachable' => $ga4Reachable,
+            ],
+            'meta' => [
+                'configured' => $metaConfigured,
+                'reachable' => $metaReachable,
+            ],
+            'conversions' => $conversions,
+        ]);
+    }
+
+    public function healthPermissions(): bool
+    {
+        if (!\function_exists('current_user_can')) {
+            return false;
+        }
+
+        return \current_user_can('hic_manage');
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractPayload(WP_REST_Request $request): array
+    {
+        $data = [];
+
+        $json = $request->get_json_params();
+        if (is_array($json)) {
+            $data = array_merge($data, $json);
+        }
+
+        $body = $request->get_body_params();
+        if (is_array($body)) {
+            $data = array_merge($data, $body);
+        }
+
+        $query = $request->get_query_params();
+        if (is_array($query)) {
+            $data = array_merge($data, $query);
+        }
+
+        unset($data['token']);
+
+        return $data;
+    }
+
+    private function resolveBucket(BookingPayload $payload): string
+    {
+        $bucket = $payload->getBucket();
+
+        if ($bucket !== 'unknown') {
+            return $bucket;
+        }
+
+        $intentId = $payload->getBookingIntentId();
+
+        if ($intentId === null) {
+            return $bucket;
+        }
+
+        $intent = $this->bookingIntents->findByIntentId($intentId);
+
+        if (!$intent) {
+            return $bucket;
+        }
+
+        $ids = [];
+        if (!empty($intent['ids'])) {
+            $decoded = json_decode((string) $intent['ids'], true);
+            if (is_array($decoded)) {
+                $ids = $decoded;
+            }
+        }
+
+        if (!empty($ids['gclid']) || !empty($ids['gbraid']) || !empty($ids['wbraid'])) {
+            return 'gads';
+        }
+
+        if (!empty($ids['fbclid'])) {
+            return 'fbads';
+        }
+
+        return $bucket;
+    }
+
+    private function shouldSendUserData(BookingPayload $payload): bool
+    {
+        $raw = $payload->getRaw();
+        $consentKeys = ['consent', 'marketing_consent', 'analytics_consent', 'privacy_consent', 'tcf_consent', 'cmode'];
+
+        $consent = null;
+
+        foreach ($consentKeys as $key) {
+            if (!array_key_exists($key, $raw)) {
+                continue;
+            }
+
+            $value = $raw[$key];
+
+            if (is_string($value)) {
+                $value = strtolower(trim($value));
+            }
+
+            if ($value === true || $value === 'granted' || $value === 'yes' || $value === 'true' || $value === '1' || $value === 1) {
+                $consent = true;
+                // Continue checking in case a more specific key (e.g. analytics_consent) denies consent.
+                continue;
+            }
+
+            if ($value === false || $value === 'denied' || $value === 'no' || $value === 'false' || $value === '0' || $value === 0) {
+                $consent = false;
+                break;
+            }
+
+            if ($value !== null && $value !== '') {
+                // An explicit value that we do not recognise is treated as a denial to stay on the safe side.
+                $consent = false;
+                break;
+            }
+        }
+
+        $filtered = apply_filters('hic_s2s_user_data_consent', $consent, $raw, $payload);
+
+        if ($filtered !== null) {
+            return (bool) $filtered;
+        }
+
+        if ($consent !== null) {
+            return (bool) $consent;
+        }
+
+        return true;
+    }
+
+    private function pingUrl(string $url): ?bool
+    {
+        $response = wp_remote_head($url, ['timeout' => 5]);
+
+        if (is_wp_error($response)) {
+            $response = wp_remote_get($url, ['timeout' => 5]);
+        }
+
+        if (is_wp_error($response)) {
+            return false;
+        }
+
+        $code = wp_remote_retrieve_response_code($response);
+
+        if ($code === 0) {
+            return null;
+        }
+
+        if ($code >= 200 && $code < 400) {
+            return true;
+        }
+
+        if (in_array($code, [401, 403, 405], true)) {
+            return true;
+        }
+
+        return false;
+    }
+}

--- a/src/Http/Routes.php
+++ b/src/Http/Routes.php
@@ -1,0 +1,50 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Http;
+
+use FpHic\HicS2S\Http\Controllers\WebhookController;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Routes
+{
+    public static function bootstrap(): void
+    {
+        if (!\function_exists('add_action')) {
+            return;
+        }
+
+        \add_action('rest_api_init', [self::class, 'registerRoutes']);
+    }
+
+    public static function registerRoutes(): void
+    {
+        if (!\function_exists('register_rest_route')) {
+            return;
+        }
+
+        $controller = new WebhookController();
+
+        \register_rest_route(
+            'hic/v1',
+            '/conversion',
+            [
+                'methods'             => ['GET', 'POST'],
+                'callback'            => [$controller, 'handleConversion'],
+                'permission_callback' => '__return_true',
+            ]
+        );
+
+        \register_rest_route(
+            'hic/v1',
+            '/health',
+            [
+                'methods'             => ['GET'],
+                'callback'            => [$controller, 'health'],
+                'permission_callback' => [$controller, 'healthPermissions'],
+            ]
+        );
+    }
+}

--- a/src/Repository/BookingIntents.php
+++ b/src/Repository/BookingIntents.php
@@ -1,0 +1,156 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Repository;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use wpdb;
+
+final class BookingIntents
+{
+    private const TABLE = 'hic_booking_intents';
+
+    public function maybeMigrate(): void
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return;
+        }
+
+        $charset = $wpdb->get_charset_collate();
+        $table = $this->getTableName();
+
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            intent_id CHAR(36) NOT NULL,
+            sid VARCHAR(191) NOT NULL,
+            utms LONGTEXT NULL,
+            ids LONGTEXT NULL,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            PRIMARY KEY (id),
+            UNIQUE KEY intent_id (intent_id),
+            KEY sid (sid(100)),
+            KEY created_at (created_at)
+        ) {$charset};";
+
+        $this->runDbDelta($sql);
+    }
+
+    public function record(string $intentId, string $sid, array $utmParams, array $ids): ?int
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return null;
+        }
+
+        $data = [
+            'intent_id' => sanitize_text_field($intentId),
+            'sid' => sanitize_text_field($sid),
+            'utms' => wp_json_encode($this->filterEmpty($utmParams), JSON_UNESCAPED_UNICODE),
+            'ids' => wp_json_encode($this->filterEmpty($ids), JSON_UNESCAPED_UNICODE),
+        ];
+
+        $formats = ['%s', '%s', '%s', '%s'];
+
+        $result = $wpdb->insert($this->getTableName(), $data, $formats);
+
+        if ($result === false) {
+            return null;
+        }
+
+        return (int) $wpdb->insert_id;
+    }
+
+    public function findByIntentId(string $intentId): ?array
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return null;
+        }
+
+        $table = $this->getTableName();
+        $query = $wpdb->prepare("SELECT * FROM {$table} WHERE intent_id = %s LIMIT 1", $intentId);
+        $row = $wpdb->get_row($query, ARRAY_A);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return $row;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function latest(int $limit = 20): array
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return [];
+        }
+
+        $limit = max(1, min(200, $limit));
+
+        $table = $this->getTableName();
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $sql = $wpdb->prepare("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT %d", $limit);
+        $results = $wpdb->get_results($sql, ARRAY_A);
+
+        return is_array($results) ? $results : [];
+    }
+
+    private function filterEmpty(array $data): array
+    {
+        return array_filter(
+            $data,
+            static function ($value): bool {
+                if (is_string($value)) {
+                    return trim($value) !== '';
+                }
+
+                return !empty($value);
+            }
+        );
+    }
+
+    private function getTableName(): string
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return self::TABLE;
+        }
+
+        return $wpdb->prefix . self::TABLE;
+    }
+
+    private function runDbDelta(string $sql): void
+    {
+        if (!defined('ABSPATH')) {
+            return;
+        }
+
+        $upgradeFile = ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        if (!function_exists('dbDelta') && is_readable($upgradeFile)) {
+            require_once $upgradeFile;
+        }
+
+        if (function_exists('dbDelta')) {
+            dbDelta($sql);
+        }
+    }
+
+    private function getWpdb(): ?wpdb
+    {
+        global $wpdb;
+
+        return $wpdb instanceof wpdb ? $wpdb : null;
+    }
+}

--- a/src/Repository/Conversions.php
+++ b/src/Repository/Conversions.php
@@ -1,0 +1,244 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Repository;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use wpdb;
+
+final class Conversions
+{
+    private const TABLE = 'hic_conversions';
+
+    public function maybeMigrate(): void
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return;
+        }
+
+        $tableName = $this->getTableName();
+        $charset = $wpdb->get_charset_collate();
+
+        $sql = "CREATE TABLE {$tableName} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            booking_code VARCHAR(191) NOT NULL,
+            status VARCHAR(50) NOT NULL DEFAULT 'confirmed',
+            checkin DATE NULL,
+            checkout DATE NULL,
+            currency CHAR(3) NOT NULL DEFAULT '',
+            amount DECIMAL(18,2) NOT NULL DEFAULT 0,
+            guest_email_hash CHAR(64) NOT NULL DEFAULT '',
+            guest_phone_hash CHAR(64) NOT NULL DEFAULT '',
+            bucket VARCHAR(50) NOT NULL DEFAULT 'unknown',
+            ga4_sent TINYINT(1) NOT NULL DEFAULT 0,
+            meta_sent TINYINT(1) NOT NULL DEFAULT 0,
+            raw_json LONGTEXT NULL,
+            PRIMARY KEY  (id),
+            KEY booking_code (booking_code),
+            KEY bucket (bucket),
+            KEY created_at (created_at)
+        ) {$charset};";
+
+        $this->runDbDelta($sql);
+    }
+
+    public function insert(array $data): ?int
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return null;
+        }
+
+        $defaults = [
+            'booking_code' => '',
+            'status' => 'confirmed',
+            'checkin' => null,
+            'checkout' => null,
+            'currency' => '',
+            'amount' => 0.0,
+            'guest_email_hash' => '',
+            'guest_phone_hash' => '',
+            'bucket' => 'unknown',
+            'ga4_sent' => 0,
+            'meta_sent' => 0,
+            'raw_json' => null,
+        ];
+
+        $payload = wp_parse_args($data, $defaults);
+
+        $inserted = $wpdb->insert(
+            $this->getTableName(),
+            [
+                'booking_code' => sanitize_text_field((string) $payload['booking_code']),
+                'status' => sanitize_text_field((string) $payload['status']),
+                'checkin' => $this->sanitizeDate($payload['checkin']),
+                'checkout' => $this->sanitizeDate($payload['checkout']),
+                'currency' => strtoupper(sanitize_text_field((string) $payload['currency'])),
+                'amount' => (float) $payload['amount'],
+                'guest_email_hash' => sanitize_text_field((string) $payload['guest_email_hash']),
+                'guest_phone_hash' => sanitize_text_field((string) $payload['guest_phone_hash']),
+                'bucket' => sanitize_text_field((string) $payload['bucket']),
+                'ga4_sent' => (int) $payload['ga4_sent'],
+                'meta_sent' => (int) $payload['meta_sent'],
+                'raw_json' => is_null($payload['raw_json']) ? null : wp_json_encode($payload['raw_json'], JSON_UNESCAPED_UNICODE),
+            ],
+            [
+                '%s', '%s', '%s', '%s', '%s', '%f', '%s', '%s', '%s', '%d', '%d', '%s',
+            ]
+        );
+
+        if ($inserted === false) {
+            return null;
+        }
+
+        return (int) $wpdb->insert_id;
+    }
+
+    public function markGa4Status(int $conversionId, bool $sent): bool
+    {
+        return $this->updateFlags($conversionId, ['ga4_sent' => $sent ? 1 : 0]);
+    }
+
+    public function markMetaStatus(int $conversionId, bool $sent): bool
+    {
+        return $this->updateFlags($conversionId, ['meta_sent' => $sent ? 1 : 0]);
+    }
+
+    public function updateFlags(int $conversionId, array $flags): bool
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb || $conversionId <= 0) {
+            return false;
+        }
+
+        $allowed = ['ga4_sent', 'meta_sent', 'bucket'];
+        $data = [];
+
+        foreach ($flags as $key => $value) {
+            if (!in_array($key, $allowed, true)) {
+                continue;
+            }
+
+            if ($key === 'bucket') {
+                $data['bucket'] = sanitize_text_field((string) $value);
+                continue;
+            }
+
+            $data[$key] = $value ? 1 : 0;
+        }
+
+        if ($data === []) {
+            return false;
+        }
+
+        $updated = $wpdb->update(
+            $this->getTableName(),
+            $data,
+            ['id' => $conversionId],
+            null,
+            ['%d']
+        );
+
+        return $updated !== false;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function latest(int $limit = 10): array
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return [];
+        }
+
+        $limit = max(1, min(100, $limit));
+
+        $table = $this->getTableName();
+        // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+        $sql = $wpdb->prepare("SELECT * FROM {$table} ORDER BY created_at DESC LIMIT %d", $limit);
+
+        $results = $wpdb->get_results($sql, ARRAY_A);
+
+        return is_array($results) ? $results : [];
+    }
+
+    public function findByBookingCode(string $code): ?array
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return null;
+        }
+
+        $table = $this->getTableName();
+        $query = $wpdb->prepare("SELECT * FROM {$table} WHERE booking_code = %s ORDER BY id DESC LIMIT 1", $code);
+        $row = $wpdb->get_row($query, ARRAY_A);
+
+        if (!is_array($row)) {
+            return null;
+        }
+
+        return $row;
+    }
+
+    private function getTableName(): string
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return self::TABLE;
+        }
+
+        return $wpdb->prefix . self::TABLE;
+    }
+
+    private function runDbDelta(string $sql): void
+    {
+        if (!defined('ABSPATH')) {
+            return;
+        }
+
+        $upgradeFile = ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        if (!function_exists('dbDelta')) {
+            if (is_readable($upgradeFile)) {
+                require_once $upgradeFile;
+            }
+        }
+
+        if (function_exists('dbDelta')) {
+            dbDelta($sql);
+        }
+    }
+
+    private function sanitizeDate($value): ?string
+    {
+        if (!is_string($value) || $value === '') {
+            return null;
+        }
+
+        $date = date_create($value);
+
+        if (!$date) {
+            return null;
+        }
+
+        return $date->format('Y-m-d');
+    }
+
+    private function getWpdb(): ?wpdb
+    {
+        global $wpdb;
+
+        return $wpdb instanceof wpdb ? $wpdb : null;
+    }
+}

--- a/src/Repository/Logs.php
+++ b/src/Repository/Logs.php
@@ -1,0 +1,132 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Repository;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use wpdb;
+
+final class Logs
+{
+    private const TABLE = 'hic_logs';
+
+    public function maybeMigrate(): void
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return;
+        }
+
+        $charset = $wpdb->get_charset_collate();
+        $table = $this->getTableName();
+
+        $sql = "CREATE TABLE {$table} (
+            id BIGINT UNSIGNED NOT NULL AUTO_INCREMENT,
+            ts DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+            channel VARCHAR(50) NOT NULL,
+            level VARCHAR(20) NOT NULL,
+            message TEXT NOT NULL,
+            context LONGTEXT NULL,
+            PRIMARY KEY (id),
+            KEY channel (channel),
+            KEY ts (ts)
+        ) {$charset};";
+
+        $this->runDbDelta($sql);
+    }
+
+    public function log(string $channel, string $level, string $message, array $context = []): ?int
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return null;
+        }
+
+        $result = $wpdb->insert(
+            $this->getTableName(),
+            [
+                'channel' => sanitize_key($channel),
+                'level' => sanitize_text_field($level),
+                'message' => wp_kses_post($message),
+                'context' => wp_json_encode($context, JSON_UNESCAPED_UNICODE),
+            ],
+            ['%s', '%s', '%s', '%s']
+        );
+
+        if ($result === false) {
+            return null;
+        }
+
+        return (int) $wpdb->insert_id;
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    public function latest(int $limit = 50, ?string $channel = null): array
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return [];
+        }
+
+        $limit = max(1, min(200, $limit));
+        $table = $this->getTableName();
+
+        if ($channel !== null && $channel !== '') {
+            $channel = sanitize_key($channel);
+            $sql = $wpdb->prepare(
+                "SELECT * FROM {$table} WHERE channel = %s ORDER BY ts DESC LIMIT %d",
+                $channel,
+                $limit
+            );
+        } else {
+            // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+            $sql = $wpdb->prepare("SELECT * FROM {$table} ORDER BY ts DESC LIMIT %d", $limit);
+        }
+
+        $rows = $wpdb->get_results($sql, ARRAY_A);
+
+        return is_array($rows) ? $rows : [];
+    }
+
+    private function getTableName(): string
+    {
+        $wpdb = $this->getWpdb();
+
+        if (!$wpdb) {
+            return self::TABLE;
+        }
+
+        return $wpdb->prefix . self::TABLE;
+    }
+
+    private function runDbDelta(string $sql): void
+    {
+        if (!defined('ABSPATH')) {
+            return;
+        }
+
+        $upgradeFile = ABSPATH . 'wp-admin/includes/upgrade.php';
+
+        if (!function_exists('dbDelta') && is_readable($upgradeFile)) {
+            require_once $upgradeFile;
+        }
+
+        if (function_exists('dbDelta')) {
+            dbDelta($sql);
+        }
+    }
+
+    private function getWpdb(): ?wpdb
+    {
+        global $wpdb;
+
+        return $wpdb instanceof wpdb ? $wpdb : null;
+    }
+}

--- a/src/Services/Ga4Service.php
+++ b/src/Services/Ga4Service.php
@@ -1,0 +1,144 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Services;
+
+use FpHic\HicS2S\Admin\SettingsPage;
+use FpHic\HicS2S\Repository\Logs;
+use FpHic\HicS2S\Support\Http;
+use FpHic\HicS2S\ValueObjects\BookingPayload;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Ga4Service
+{
+    private Logs $logs;
+
+    public function __construct()
+    {
+        $this->logs = new Logs();
+    }
+
+    /**
+     * @return array{sent:bool,code:int|null,body:string|null,attempts:int,reason?:string}
+     */
+    public function sendPurchase(BookingPayload $payload, bool $includeUserData = true): array
+    {
+        $settings = SettingsPage::getSettings();
+        $measurementId = trim((string) ($settings['ga4_measurement_id'] ?? ''));
+        $apiSecret = trim((string) ($settings['ga4_api_secret'] ?? ''));
+
+        if ($measurementId === '' || $apiSecret === '') {
+            $this->logs->log('ga4', 'warning', 'Credenziali GA4 mancanti', [
+                'measurement_id' => $measurementId,
+                'api_secret' => $apiSecret !== '' ? 'set' : 'missing',
+            ]);
+
+            return [
+                'sent' => false,
+                'code' => null,
+                'body' => null,
+                'attempts' => 0,
+                'reason' => 'missing_credentials',
+            ];
+        }
+
+        $endpoint = sprintf(
+            'https://www.google-analytics.com/mp/collect?measurement_id=%s&api_secret=%s',
+            rawurlencode($measurementId),
+            rawurlencode($apiSecret)
+        );
+
+        $event = [
+            'name' => 'purchase',
+            'params' => [
+                'currency' => $payload->getCurrency() ?: 'EUR',
+                'value' => $payload->getAmount(),
+                'transaction_id' => $payload->getBookingCode(),
+                'items' => [
+                    [
+                        'item_id' => $payload->getBookingCode(),
+                        'item_name' => 'Room Booking',
+                        'quantity' => 1,
+                        'price' => $payload->getAmount(),
+                    ],
+                ],
+            ],
+        ];
+
+        $body = [
+            'client_id' => $this->determineClientId($payload),
+            'timestamp_micros' => (int) round(microtime(true) * 1000000),
+            'events' => [$event],
+        ];
+
+        if ($includeUserData) {
+            $userData = [];
+
+            if ($payload->getGuestEmailHash() !== '') {
+                $userData['email'] = $payload->getGuestEmailHash();
+            }
+
+            if ($payload->getGuestPhoneHash() !== '') {
+                $userData['phone_number'] = $payload->getGuestPhoneHash();
+            }
+
+            if ($userData !== []) {
+                $body['user_data'] = $userData;
+            }
+        }
+
+        /** @var array<string,mixed> $body */
+        $body = apply_filters('hic_s2s_ga4_payload', $body, $payload);
+
+        $result = Http::postWithRetry(static function () use ($endpoint, $body): array {
+            return [
+                'url' => $endpoint,
+                'args' => [
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                    'body' => wp_json_encode($body, JSON_UNESCAPED_UNICODE),
+                    'timeout' => 10,
+                ],
+            ];
+        });
+
+        $responseBody = null;
+        if (is_array($result['response'])) {
+            $responseBody = wp_remote_retrieve_body($result['response']);
+        }
+
+        $this->logs->log($result['success'] ? 'ga4' : 'error', $result['success'] ? 'info' : 'error', 'Richiesta GA4 eseguita', [
+            'endpoint' => $endpoint,
+            'code' => $result['code'],
+            'attempts' => $result['attempts'],
+            'response' => $responseBody,
+            'payload' => $body,
+        ]);
+
+        return [
+            'sent' => $result['success'],
+            'code' => $result['code'],
+            'body' => $responseBody,
+            'attempts' => $result['attempts'],
+        ];
+    }
+
+    private function determineClientId(BookingPayload $payload): string
+    {
+        $sid = $payload->getSid();
+
+        if (is_string($sid) && $sid !== '') {
+            return $sid;
+        }
+
+        $hash = hash('sha256', $payload->getBookingCode());
+
+        $part1 = substr($hash, 0, 10);
+        $part2 = substr($hash, 10, 10);
+
+        return sprintf('%s.%s', $part1, $part2);
+    }
+}

--- a/src/Services/MetaCapiService.php
+++ b/src/Services/MetaCapiService.php
@@ -1,0 +1,147 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Services;
+
+use FpHic\HicS2S\Admin\SettingsPage;
+use FpHic\HicS2S\Repository\Logs;
+use FpHic\HicS2S\Support\Http;
+use FpHic\HicS2S\ValueObjects\BookingPayload;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class MetaCapiService
+{
+    private Logs $logs;
+
+    public function __construct()
+    {
+        $this->logs = new Logs();
+    }
+
+    /**
+     * @return array{sent:bool,code:int|null,body:string|null,attempts:int,reason?:string}
+     */
+    public function sendPurchase(BookingPayload $payload, bool $includeUserData = true): array
+    {
+        $settings = SettingsPage::getSettings();
+        $pixelId = trim((string) ($settings['meta_pixel_id'] ?? ''));
+        $accessToken = trim((string) ($settings['meta_access_token'] ?? ''));
+
+        if ($pixelId === '' || $accessToken === '') {
+            $this->logs->log('meta', 'warning', 'Credenziali Meta CAPI mancanti', [
+                'pixel_id' => $pixelId,
+                'access_token' => $accessToken !== '' ? 'set' : 'missing',
+            ]);
+
+            return [
+                'sent' => false,
+                'code' => null,
+                'body' => null,
+                'attempts' => 0,
+                'reason' => 'missing_credentials',
+            ];
+        }
+
+        $endpoint = sprintf(
+            'https://graph.facebook.com/v17.0/%s/events?access_token=%s',
+            rawurlencode($pixelId),
+            rawurlencode($accessToken)
+        );
+
+        $userData = [];
+        if ($includeUserData) {
+            if ($payload->getGuestEmailHash() !== '') {
+                $userData['em'] = $payload->getGuestEmailHash();
+            }
+
+            if ($payload->getGuestPhoneHash() !== '') {
+                $userData['ph'] = $payload->getGuestPhoneHash();
+            }
+
+            $ipAddress = isset($_SERVER['REMOTE_ADDR']) ? sanitize_text_field((string) $_SERVER['REMOTE_ADDR']) : '';
+            $userAgent = isset($_SERVER['HTTP_USER_AGENT']) ? sanitize_text_field((string) $_SERVER['HTTP_USER_AGENT']) : '';
+
+            if ($ipAddress !== '') {
+                $userData['client_ip_address'] = $ipAddress;
+            }
+
+            if ($userAgent !== '') {
+                $userData['client_user_agent'] = $userAgent;
+            }
+        }
+
+        $event = [
+            'event_name' => 'Purchase',
+            'event_time' => time(),
+            'event_source_url' => home_url('/'),
+            'action_source' => 'website',
+            'event_id' => $this->buildEventId($payload),
+            'custom_data' => [
+                'currency' => $payload->getCurrency() ?: 'EUR',
+                'value' => $payload->getAmount(),
+                'booking_code' => $payload->getBookingCode(),
+            ],
+        ];
+
+        if ($userData !== []) {
+            $event['user_data'] = $userData;
+        }
+
+        /** @var array<string,mixed> $event */
+        $event = apply_filters('hic_s2s_meta_event', $event, $payload);
+
+        $body = [
+            'data' => [$event],
+        ];
+
+        /** @var array<string,mixed> $body */
+        $body = apply_filters('hic_s2s_meta_payload', $body, $payload);
+
+        $result = Http::postWithRetry(static function () use ($endpoint, $body): array {
+            return [
+                'url' => $endpoint,
+                'args' => [
+                    'headers' => [
+                        'Content-Type' => 'application/json',
+                    ],
+                    'body' => wp_json_encode($body, JSON_UNESCAPED_UNICODE),
+                    'timeout' => 10,
+                ],
+            ];
+        });
+
+        $responseBody = null;
+        if (is_array($result['response'])) {
+            $responseBody = wp_remote_retrieve_body($result['response']);
+        }
+
+        $this->logs->log($result['success'] ? 'meta' : 'error', $result['success'] ? 'info' : 'error', 'Richiesta Meta CAPI eseguita', [
+            'endpoint' => $endpoint,
+            'code' => $result['code'],
+            'attempts' => $result['attempts'],
+            'response' => $responseBody,
+            'payload' => $body,
+        ]);
+
+        return [
+            'sent' => $result['success'],
+            'code' => $result['code'],
+            'body' => $responseBody,
+            'attempts' => $result['attempts'],
+        ];
+    }
+
+    private function buildEventId(BookingPayload $payload): string
+    {
+        $parts = [
+            $payload->getBookingCode(),
+            (string) $payload->getAmount(),
+            (string) $payload->getCheckin(),
+            (string) $payload->getCheckout(),
+        ];
+
+        return hash('sha256', implode('|', $parts));
+    }
+}

--- a/src/Services/Redirector.php
+++ b/src/Services/Redirector.php
@@ -1,0 +1,135 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Services;
+
+use FpHic\HicS2S\Admin\SettingsPage;
+use FpHic\HicS2S\Repository\BookingIntents;
+use FpHic\HicS2S\Repository\Logs;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Redirector
+{
+    private const COOKIE_NAME = 'hic_sid';
+
+    public static function bootstrap(): void
+    {
+        if (!\function_exists('add_action')) {
+            return;
+        }
+
+        \add_action('template_redirect', [self::class, 'maybeHandleRedirect'], 0);
+    }
+
+    public static function maybeHandleRedirect(): void
+    {
+        if (!isset($_GET['fp_go_booking'])) {
+            return;
+        }
+
+        $settings = SettingsPage::getSettings();
+
+        if (empty($settings['redirector_enabled'])) {
+            return;
+        }
+
+        $targetParam = isset($_GET['target']) ? (string) $_GET['target'] : '';
+        $decodedTarget = base64_decode($targetParam, true);
+
+        if (!is_string($decodedTarget) || $decodedTarget === '' || !wp_http_validate_url($decodedTarget)) {
+            wp_die(__('URL di destinazione non valido.', 'hotel-in-cloud'));
+        }
+
+        $sid = self::ensureSid();
+
+        $utmParams = self::collectPrefixedParams('utm_');
+        $ids = self::collectIdentifiers();
+
+        $intentId = wp_generate_uuid4();
+        $repo = new BookingIntents();
+        $logs = new Logs();
+
+        $saved = $repo->record($intentId, $sid, $utmParams, $ids);
+
+        if ($saved === null) {
+            $logs->log('webhook', 'error', 'Impossibile salvare booking intent', [
+                'intent_id' => $intentId,
+                'sid' => $sid,
+                'utm' => $utmParams,
+                'ids' => $ids,
+            ]);
+        } else {
+            $logs->log('webhook', 'info', 'Booking intent registrato', [
+                'intent_id' => $intentId,
+                'sid' => $sid,
+            ]);
+        }
+
+        wp_safe_redirect($decodedTarget, 302);
+        exit;
+    }
+
+    private static function ensureSid(): string
+    {
+        $sid = isset($_COOKIE[self::COOKIE_NAME]) ? (string) $_COOKIE[self::COOKIE_NAME] : '';
+
+        if ($sid === '') {
+            $sid = wp_generate_uuid4();
+            $secure = isset($_SERVER['HTTPS']) && strtolower((string) $_SERVER['HTTPS']) === 'on';
+            $path = defined('COOKIEPATH') ? COOKIEPATH : '/';
+            $domain = defined('COOKIE_DOMAIN') ? COOKIE_DOMAIN : '';
+            setcookie(self::COOKIE_NAME, $sid, time() + YEAR_IN_SECONDS, $path, $domain, $secure, true);
+            $_COOKIE[self::COOKIE_NAME] = $sid;
+        }
+
+        return $sid;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private static function collectPrefixedParams(string $prefix): array
+    {
+        $params = [];
+
+        foreach ($_GET as $key => $value) {
+            if (!is_string($key) || strpos($key, $prefix) !== 0) {
+                continue;
+            }
+
+            if (!is_string($value) || trim($value) === '') {
+                continue;
+            }
+
+            $params[$key] = sanitize_text_field($value);
+        }
+
+        return $params;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private static function collectIdentifiers(): array
+    {
+        $keys = ['gclid', 'fbclid', 'gbraid', 'wbraid', 'msclkid', 'ttclid'];
+        $ids = [];
+
+        foreach ($keys as $key) {
+            if (!isset($_GET[$key]) || !is_string($_GET[$key])) {
+                continue;
+            }
+
+            $value = sanitize_text_field((string) $_GET[$key]);
+            if ($value === '') {
+                continue;
+            }
+
+            $ids[$key] = $value;
+        }
+
+        return $ids;
+    }
+}

--- a/src/Support/Hasher.php
+++ b/src/Support/Hasher.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Support;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Hasher
+{
+    public static function hash(?string $value): string
+    {
+        $value = is_string($value) ? trim(strtolower($value)) : '';
+
+        if ($value === '') {
+            return '';
+        }
+
+        return hash('sha256', $value);
+    }
+}

--- a/src/Support/Http.php
+++ b/src/Support/Http.php
@@ -1,0 +1,68 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\Support;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+final class Http
+{
+    /**
+     * @param callable():array{url:string,args?:array<string,mixed>} $requestFactory
+     * @return array{success:bool,code:int|null,attempts:int,response:mixed,error:mixed}
+     */
+    public static function postWithRetry(callable $requestFactory, int $maxAttempts = 3, int $initialDelay = 1): array
+    {
+        $attempt = 0;
+        $lastResponse = null;
+        $lastError = null;
+        $code = null;
+
+        while ($attempt < $maxAttempts) {
+            $attempt++;
+
+            $request = $requestFactory();
+            $url = isset($request['url']) ? (string) $request['url'] : '';
+            $args = isset($request['args']) && is_array($request['args']) ? $request['args'] : [];
+
+            if ($url === '') {
+                $lastError = new \WP_Error('invalid_url', 'URL non valido');
+                break;
+            }
+
+            $response = \wp_remote_post($url, $args);
+
+            if (is_wp_error($response)) {
+                $lastError = $response;
+                break;
+            }
+
+            $code = \wp_remote_retrieve_response_code($response);
+
+            if ($code >= 500 && $code < 600 && $attempt < $maxAttempts) {
+                $lastResponse = $response;
+                \sleep($initialDelay * $attempt);
+                continue;
+            }
+
+            $success = $code >= 200 && $code < 300;
+
+            return [
+                'success' => $success,
+                'code' => $code,
+                'attempts' => $attempt,
+                'response' => $response,
+                'error' => null,
+            ];
+        }
+
+        return [
+            'success' => false,
+            'code' => $code,
+            'attempts' => $attempt,
+            'response' => $lastResponse,
+            'error' => $lastError,
+        ];
+    }
+}

--- a/src/ValueObjects/BookingPayload.php
+++ b/src/ValueObjects/BookingPayload.php
@@ -1,0 +1,354 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S\ValueObjects;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+use FpHic\HicS2S\Support\Hasher;
+
+final class BookingPayload
+{
+    private string $bookingCode;
+
+    private string $status;
+
+    private ?string $checkin;
+
+    private ?string $checkout;
+
+    private string $currency;
+
+    private float $amount;
+
+    private ?string $guestEmail;
+
+    private ?string $guestPhone;
+
+    private ?int $rooms;
+
+    private ?int $adults;
+
+    private ?int $children;
+
+    private string $bucket;
+
+    /** @var array<string,mixed> */
+    private array $raw;
+
+    /** @var array<string,string> */
+    private array $identifiers;
+
+    private ?string $bookingIntentId;
+
+    private ?string $sid;
+
+    /** @param array<string,mixed> $data */
+    private function __construct(array $data)
+    {
+        $this->bookingCode = $data['booking_code'];
+        $this->status = $data['status'];
+        $this->checkin = $data['checkin'];
+        $this->checkout = $data['checkout'];
+        $this->currency = $data['currency'];
+        $this->amount = $data['amount'];
+        $this->guestEmail = $data['guest_email'];
+        $this->guestPhone = $data['guest_phone'];
+        $this->rooms = $data['rooms'];
+        $this->adults = $data['adults'];
+        $this->children = $data['children'];
+        $this->bucket = $data['bucket'];
+        $this->raw = $data['raw'];
+        $this->identifiers = $data['identifiers'];
+        $this->bookingIntentId = $data['booking_intent_id'];
+        $this->sid = $data['sid'];
+    }
+
+    /**
+     * @param array<string,mixed> $input
+     */
+    public static function fromArray(array $input): self
+    {
+        $bookingCode = self::cleanString($input['booking_code'] ?? '');
+
+        if ($bookingCode === '') {
+            throw new \InvalidArgumentException('Missing booking_code');
+        }
+
+        $status = self::cleanString($input['status'] ?? 'confirmed');
+
+        if ($status === '') {
+            $status = 'confirmed';
+        }
+
+        $checkin = self::cleanDate($input['checkin'] ?? null);
+        $checkout = self::cleanDate($input['checkout'] ?? null);
+        $currency = strtoupper(substr(self::cleanString($input['currency'] ?? ''), 0, 3));
+        $amount = self::cleanAmount($input['amount'] ?? 0);
+        $guestEmail = self::cleanEmail($input['guest_email'] ?? null);
+        $guestPhone = self::cleanPhone($input['guest_phone'] ?? null);
+
+        $rooms = self::cleanInt($input['rooms'] ?? null);
+        $adults = self::cleanInt($input['adults'] ?? null);
+        $children = self::cleanInt($input['children'] ?? null);
+
+        $identifiers = self::extractIdentifiers($input);
+
+        $bucket = self::determineBucket($identifiers, $input);
+
+        return new self([
+            'booking_code' => $bookingCode,
+            'status' => $status,
+            'checkin' => $checkin,
+            'checkout' => $checkout,
+            'currency' => $currency,
+            'amount' => $amount,
+            'guest_email' => $guestEmail,
+            'guest_phone' => $guestPhone,
+            'rooms' => $rooms,
+            'adults' => $adults,
+            'children' => $children,
+            'bucket' => $bucket,
+            'raw' => $input,
+            'identifiers' => $identifiers,
+            'booking_intent_id' => self::cleanString($input['booking_intent_id'] ?? ($input['intent_id'] ?? '')) ?: null,
+            'sid' => self::cleanString($input['sid'] ?? ($input['hic_sid'] ?? '')) ?: null,
+        ]);
+    }
+
+    public function getBookingCode(): string
+    {
+        return $this->bookingCode;
+    }
+
+    public function getStatus(): string
+    {
+        return $this->status;
+    }
+
+    public function getCheckin(): ?string
+    {
+        return $this->checkin;
+    }
+
+    public function getCheckout(): ?string
+    {
+        return $this->checkout;
+    }
+
+    public function getCurrency(): string
+    {
+        return $this->currency;
+    }
+
+    public function getAmount(): float
+    {
+        return $this->amount;
+    }
+
+    public function getGuestEmail(): ?string
+    {
+        return $this->guestEmail;
+    }
+
+    public function getGuestPhone(): ?string
+    {
+        return $this->guestPhone;
+    }
+
+    public function getRooms(): ?int
+    {
+        return $this->rooms;
+    }
+
+    public function getAdults(): ?int
+    {
+        return $this->adults;
+    }
+
+    public function getChildren(): ?int
+    {
+        return $this->children;
+    }
+
+    public function getBucket(): string
+    {
+        return $this->bucket;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function getRaw(): array
+    {
+        return $this->raw;
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    public function getIdentifiers(): array
+    {
+        return $this->identifiers;
+    }
+
+    public function getBookingIntentId(): ?string
+    {
+        return $this->bookingIntentId;
+    }
+
+    public function getSid(): ?string
+    {
+        return $this->sid;
+    }
+
+    public function getGuestEmailHash(): string
+    {
+        return Hasher::hash($this->guestEmail);
+    }
+
+    public function getGuestPhoneHash(): string
+    {
+        return Hasher::hash($this->guestPhone);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function toDatabaseArray(): array
+    {
+        return [
+            'booking_code' => $this->bookingCode,
+            'status' => $this->status,
+            'checkin' => $this->checkin,
+            'checkout' => $this->checkout,
+            'currency' => $this->currency,
+            'amount' => $this->amount,
+            'guest_email_hash' => $this->getGuestEmailHash(),
+            'guest_phone_hash' => $this->getGuestPhoneHash(),
+            'bucket' => $this->bucket,
+            'raw_json' => $this->raw,
+        ];
+    }
+
+    /**
+     * @param array<string,string> $identifiers
+     * @param array<string,mixed>  $input
+     */
+    private static function determineBucket(array $identifiers, array $input): string
+    {
+        if (!empty($identifiers['gclid']) || !empty($identifiers['gbraid']) || !empty($identifiers['wbraid'])) {
+            return 'gads';
+        }
+
+        if (!empty($identifiers['fbclid'])) {
+            return 'fbads';
+        }
+
+        if (!empty($input['source']) && is_string($input['source'])) {
+            $source = strtolower(trim($input['source']));
+            if ($source === 'organic') {
+                return 'organic';
+            }
+        }
+
+        return 'unknown';
+    }
+
+    /**
+     * @param array<string,mixed> $input
+     * @return array<string,string>
+     */
+    private static function extractIdentifiers(array $input): array
+    {
+        $keys = ['gclid', 'gbraid', 'wbraid', 'fbclid', 'msclkid', 'ttclid'];
+        $identifiers = [];
+
+        foreach ($keys as $key) {
+            $value = $input[$key] ?? null;
+
+            if (!is_string($value) || trim($value) === '') {
+                continue;
+            }
+
+            $identifiers[$key] = self::cleanString($value);
+        }
+
+        return $identifiers;
+    }
+
+    private static function cleanString($value): string
+    {
+        if (!is_string($value)) {
+            return '';
+        }
+
+        $value = trim($value);
+
+        return $value;
+    }
+
+    private static function cleanDate($value): ?string
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $date = date_create($value);
+
+        if (!$date) {
+            return null;
+        }
+
+        return $date->format('Y-m-d');
+    }
+
+    private static function cleanAmount($value): float
+    {
+        if (is_numeric($value)) {
+            return round((float) $value, 2);
+        }
+
+        return 0.0;
+    }
+
+    private static function cleanEmail($value): ?string
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = strtolower(trim($value));
+
+        return is_email($value) ? $value : null;
+    }
+
+    private static function cleanPhone($value): ?string
+    {
+        if (!is_string($value) || trim($value) === '') {
+            return null;
+        }
+
+        $value = preg_replace('/[^0-9+]/', '', $value ?? '') ?? '';
+
+        if ($value === '') {
+            return null;
+        }
+
+        return $value;
+    }
+
+    private static function cleanInt($value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        if (is_numeric($value)) {
+            return (int) $value;
+        }
+
+        return null;
+    }
+}

--- a/src/bootstrap.php
+++ b/src/bootstrap.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace FpHic\HicS2S;
+
+require_once __DIR__ . '/Http/Routes.php';
+require_once __DIR__ . '/Http/Controllers/WebhookController.php';
+require_once __DIR__ . '/Services/Ga4Service.php';
+require_once __DIR__ . '/Services/MetaCapiService.php';
+require_once __DIR__ . '/Services/Redirector.php';
+require_once __DIR__ . '/Repository/Conversions.php';
+require_once __DIR__ . '/Repository/BookingIntents.php';
+require_once __DIR__ . '/Repository/Logs.php';
+require_once __DIR__ . '/Support/Hasher.php';
+require_once __DIR__ . '/Support/Http.php';
+require_once __DIR__ . '/ValueObjects/BookingPayload.php';
+require_once __DIR__ . '/Admin/SettingsPage.php';
+
+use FpHic\HicS2S\Repository\BookingIntents;
+use FpHic\HicS2S\Repository\Conversions;
+use FpHic\HicS2S\Repository\Logs;
+
+use FpHic\HicS2S\Admin\SettingsPage;
+use FpHic\HicS2S\Http\Routes;
+use FpHic\HicS2S\Services\Redirector;
+
+if (!defined('ABSPATH')) {
+    exit;
+}
+
+Routes::bootstrap();
+SettingsPage::bootstrap();
+Redirector::bootstrap();
+
+if (\function_exists('add_action')) {
+    \add_action('plugins_loaded', static function (): void {
+        (new Conversions())->maybeMigrate();
+        (new BookingIntents())->maybeMigrate();
+        (new Logs())->maybeMigrate();
+    }, 50);
+}


### PR DESCRIPTION
## Summary
- add REST conversion endpoint with persistent storage, logging and health reporting
- wire Measurement Protocol and Meta CAPI services with hashed identifiers, retry support, and consent-aware user data gating
- implement /go/booking redirector, S2S settings UI, QA tools, and updated documentation

## Testing
- `composer lint:syntax` *(fails: vendor/bin/parallel-lint not found)*

------
https://chatgpt.com/codex/tasks/task_e_68dbf48e3208832fbc73c58f6fa9ce23