### PR TITLE
Add build and packaging tooling for plugin releases

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+/tests export-ignore
+/docs export-ignore
+/.github export-ignore
+/node_modules export-ignore
+/.gitignore export-ignore
+/.gitattributes export-ignore

--- a/.github/workflows/build-plugin-zip.yml
+++ b/.github/workflows/build-plugin-zip.yml
@@ -1,0 +1,69 @@
+name: Build Plugin Zip
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.2'
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
+
+      - name: Optimize autoloader
+        run: composer dump-autoload -o --classmap-authoritative
+
+      - name: Prepare build directory
+        run: |
+          SLUG="fp-hotel-in-cloud-monitoraggio-conversioni"
+          BUILD_DIR="build/$SLUG"
+          rm -rf "$BUILD_DIR"
+          mkdir -p "$BUILD_DIR"
+          rsync -a \
+            --exclude=.git \
+            --exclude=.github \
+            --exclude=tests \
+            --exclude=docs \
+            --exclude=node_modules \
+            --exclude='*.md' \
+            --exclude=.idea \
+            --exclude=.vscode \
+            --exclude=build \
+            --exclude=.gitattributes \
+            --exclude=.gitignore \
+            --exclude=.codex-state.json \
+            --exclude=.phpunit.result.cache \
+            --exclude=build.sh \
+            --exclude=README-BUILD.md \
+            --exclude=build-plugin.sh \
+            --exclude=scripts \
+            --exclude='demo-*' \
+            --exclude=qa-runner.php \
+            --exclude='validate-*.php' \
+            ./ "$BUILD_DIR/"
+
+      - name: Create zip
+        run: |
+          SLUG="fp-hotel-in-cloud-monitoraggio-conversioni"
+          VERSION_LINE=$(grep -m1 -E '^\s*\*\s*Version:' FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php)
+          VERSION=${VERSION_LINE##*: }
+          ZIP_NAME="$SLUG-$VERSION.zip"
+          cd build
+          zip -r "$ZIP_NAME" "$SLUG"
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: plugin-zip
+          path: build/*.zip

--- a/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
+++ b/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name: FP HIC Monitor
  * Description: Monitoraggio conversioni Hotel in Cloud con tracciamento avanzato verso GA4, Meta CAPI e Brevo. Sistema sicuro enterprise-grade con cache intelligente e validazione input.
- * Version: 3.4.0
+ * Version: 3.4.1
  * Author: Francesco Passeri
  * Requires at least: 5.8
  * Requires PHP: 7.4

--- a/README-BUILD.md
+++ b/README-BUILD.md
@@ -1,0 +1,34 @@
+# Processo di Build e Packaging
+
+## Prerequisiti
+
+- PHP 8.2 con estensione `zip`
+- [Composer 2](https://getcomposer.org/)
+- Strumenti da shell disponibili: `bash`, `rsync`, `zip`
+
+## Comandi Principali
+
+### Bump automatico (patch) e build
+
+```bash
+bash build.sh --bump=patch
+```
+
+### Impostare manualmente la versione e generare lo zip
+
+```bash
+bash build.sh --set-version=1.2.3
+```
+
+Al termine lo script mostra:
+
+- Versione finale scritta nell'header del plugin
+- Percorso completo dello zip generato in `build/`
+
+## GitHub Action
+
+La workflow `Build Plugin Zip` genera automaticamente lo zip quando viene creato un tag `v*`:
+
+1. Esegui il bump locale (`bash build.sh --bump=patch`) e verifica.
+2. Crea il tag con il numero di versione, ad esempio `git tag v1.2.3 && git push origin v1.2.3`.
+3. L'azione su GitHub prepara lo zip e lo pubblica come artifact `plugin-zip`.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![QA matrix](https://github.com/francescopasseri/FP-Hotel-In-Cloud-Monitoraggio-Conversioni/actions/workflows/ci.yml/badge.svg)](https://github.com/francescopasseri/FP-Hotel-In-Cloud-Monitoraggio-Conversioni/actions/workflows/ci.yml)
 
-> **Versione plugin:** 3.4.0 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
+> **Versione plugin:** 3.4.1 · **Autore:** Francesco Passeri — [francescopasseri.com](https://francescopasseri.com) — [info@francescopasseri.com](mailto:info@francescopasseri.com)
 
 
 Plugin WordPress per il monitoraggio avanzato delle conversioni da Hotel in Cloud verso GA4, Facebook Meta e Brevo con sistema di sicurezza enterprise-grade.
@@ -17,7 +17,7 @@ Plugin WordPress per il monitoraggio avanzato delle conversioni da Hotel in Clou
 
 Le tappe principali dello sviluppo sono riepilogate nel [CHANGELOG.md](CHANGELOG.md). Ogni voce collega le funzionalità alle rispettive implementazioni nel codice per agevolare audit, debug e onboarding.
 
-## Novità della versione 3.4.0
+## Novità della versione 3.4.x
 
 - 🔐 **Hardening sicurezza webhook** con normalizzazione dei token prima di rate limiting e confronto costante, per ridurre vettori di attacco sui payload remoti.
 - 🚀 **Cache e ottimizzazioni tracking** che riutilizzano l'object cache WordPress per SID, UTM e controlli di esistenza tabelle, abbattendo query ripetute.
@@ -702,8 +702,9 @@ composer lint
 ```
 
 
-## Build & Release (CI)
-- Gli artefatti di build (zip) **non** sono versionati nel repo.
-- La CI su **Pull Request** crea lo zip e lo pubblica come **artifact**.
-- Il push di un tag `v*` crea una **GitHub Release** e allega lo zip + checksum.
-- Build locale: `bash scripts/build-plugin-zip.sh` → output in `dist/`.
+## Release process
+
+1. Esegui il bump della versione e genera lo zip locale con `bash build.sh --bump=patch` (oppure `--set-version=1.2.3`).
+2. Verifica lo zip in `build/` e testa il pacchetto su un ambiente di staging.
+3. Crea il tag `vX.Y.Z` e pubblicalo su GitHub (`git tag vX.Y.Z && git push origin vX.Y.Z`). La workflow **Build Plugin Zip** allega lo zip come artifact.
+4. Consulta [README-BUILD.md](README-BUILD.md) per dettagli e prerequisiti completi.

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,130 @@
+#!/bin/sh
+set -eu
+
+PROJECT_ROOT="$(cd "$(dirname "$0")" && pwd)"
+PLUGIN_DIR_BASENAME="$(basename "$PROJECT_ROOT")"
+SLUG="$(printf '%s' "$PLUGIN_DIR_BASENAME" | tr 'A-Z' 'a-z')"
+BUILD_DIR="$PROJECT_ROOT/build"
+STAGING_DIR="$BUILD_DIR/$SLUG"
+
+BUMP_ACTION=""
+SET_VERSION=""
+ZIP_NAME=""
+
+while [ "$#" -gt 0 ]; do
+    case "$1" in
+        --set-version=*)
+            SET_VERSION="${1#*=}"
+            ;;
+        --set-version)
+            if [ "$#" -lt 2 ]; then
+                echo "Missing value for --set-version" >&2
+                exit 1
+            fi
+            shift
+            SET_VERSION="$1"
+            ;;
+        --bump=*)
+            BUMP_ACTION="${1#*=}"
+            ;;
+        --bump)
+            BUMP_ACTION="patch"
+            ;;
+        --zip-name=*)
+            ZIP_NAME="${1#*=}"
+            ;;
+        --zip-name)
+            if [ "$#" -lt 2 ]; then
+                echo "Missing value for --zip-name" >&2
+                exit 1
+            fi
+            shift
+            ZIP_NAME="$1"
+            ;;
+        --help|-h)
+            cat <<'EOF'
+Usage: build.sh [options]
+
+Options:
+  --set-version=X.Y.Z   Set an explicit version before building.
+  --bump=TYPE           Bump the version (patch, minor, major). Default: patch.
+  --zip-name=NAME       Override the default zip name.
+  -h, --help            Show this help message.
+EOF
+            exit 0
+            ;;
+        *)
+            echo "Unknown argument: $1" >&2
+            exit 1
+            ;;
+    esac
+    shift
+done
+
+if [ -n "$SET_VERSION" ] && [ -n "$BUMP_ACTION" ]; then
+    echo "Cannot use --set-version together with --bump" >&2
+    exit 1
+fi
+
+if [ -n "$SET_VERSION" ]; then
+    php "$PROJECT_ROOT/tools/bump-version.php" --set="$SET_VERSION"
+elif [ -n "$BUMP_ACTION" ]; then
+    case "$BUMP_ACTION" in
+        major|minor|patch)
+            php "$PROJECT_ROOT/tools/bump-version.php" --"$BUMP_ACTION"
+            ;;
+        *)
+            echo "Invalid bump type: $BUMP_ACTION" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+cd "$PROJECT_ROOT"
+
+composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader
+composer dump-autoload -o --classmap-authoritative
+
+rm -rf "$STAGING_DIR"
+mkdir -p "$STAGING_DIR"
+
+rsync -a \
+    --exclude=.git \
+    --exclude=.github \
+    --exclude=tests \
+    --exclude=docs \
+    --exclude=node_modules \
+    --exclude='*.md' \
+    --exclude=.idea \
+    --exclude=.vscode \
+    --exclude=build \
+    --exclude=.gitattributes \
+    --exclude=.gitignore \
+    --exclude=.codex-state.json \
+    --exclude=.phpunit.result.cache \
+    --exclude=build.sh \
+    --exclude=README-BUILD.md \
+    --exclude=build-plugin.sh \
+    --exclude=scripts \
+    --exclude='demo-*' \
+    --exclude=qa-runner.php \
+    --exclude='validate-*.php' \
+    ./ "$STAGING_DIR/"
+
+TIMESTAMP="$(date +%Y%m%d%H%M)"
+DEFAULT_ZIP_NAME="$SLUG-$TIMESTAMP.zip"
+FINAL_ZIP_NAME="${ZIP_NAME:-$DEFAULT_ZIP_NAME}"
+FINAL_ZIP_PATH="$BUILD_DIR/$FINAL_ZIP_NAME"
+
+rm -f "$FINAL_ZIP_PATH"
+
+(
+    cd "$BUILD_DIR"
+    zip -r "$FINAL_ZIP_PATH" "$SLUG" >/dev/null
+)
+
+FINAL_VERSION="$(php -r 'preg_match("/(?:^|\\n)\\s*\\*\\s*Version:\\s*([^\\r\\n]+)/", file_get_contents($argv[1]), $m) ? print $m[1] : exit(1);' "$PROJECT_ROOT/FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php")"
+
+echo "Build completed"
+printf 'Version: %s\n' "$FINAL_VERSION"
+printf 'Zip: %s\n' "$FINAL_ZIP_PATH"

--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "description": "FP HIC Monitor - Plugin per monitoraggio conversioni Hotel in Cloud",
     "type": "wordpress-plugin",
     "license": "GPL-2.0-or-later",
+    "require": {
+        "php": ">=8.0"
+    },
     "autoload": {
         "psr-4": {
             "FpHic\\": "includes/",
@@ -49,7 +52,12 @@
         "quality:fix": [
             "@lint:fix"
         ],
-        "i18n:pot": "php tools/make-pot.php"
+        "i18n:pot": "php tools/make-pot.php",
+        "build": [
+            "rm -rf vendor",
+            "@composer install --no-dev --prefer-dist --no-interaction --optimize-autoloader",
+            "composer dump-autoload -o --classmap-authoritative"
+        ]
     },
     "archive": {
         "exclude": [
@@ -59,6 +67,11 @@
     "config": {
         "allow-plugins": {
             "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+        },
+        "platform": {
+            "php": "8.2.0"
+        },
+        "optimize-autoloader": true,
+        "sort-packages": true
     }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "59b8234c649e9d44140dcacd4a84baca",
+    "content-hash": "c7ccd7dd579b841116825dec8720c53e",
     "packages": [],
     "packages-dev": [
         {
@@ -3541,7 +3541,12 @@
     "stability-flags": {},
     "prefer-stable": false,
     "prefer-lowest": false,
-    "platform": {},
+    "platform": {
+        "php": ">=8.0"
+    },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.2.0"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/tools/bump-version.php
+++ b/tools/bump-version.php
@@ -1,0 +1,93 @@
+#!/usr/bin/env php
+<?php declare(strict_types=1);
+
+const PLUGIN_MAIN_FILE = __DIR__ . '/../FP-Hotel-In-Cloud-Monitoraggio-Conversioni.php';
+
+function error(string $message): void
+{
+    fwrite(STDERR, $message . PHP_EOL);
+    exit(1);
+}
+
+$options = getopt('', ['major', 'minor', 'patch', 'set:'], $optind);
+
+$set = $options['set'] ?? null;
+
+$bumpFlags = array_filter([
+    'major' => array_key_exists('major', $options),
+    'minor' => array_key_exists('minor', $options),
+    'patch' => array_key_exists('patch', $options),
+]);
+
+if ($set !== null && count(array_filter($bumpFlags)) > 0) {
+    error('The --set option cannot be combined with --major/--minor/--patch.');
+}
+
+if ($set === null) {
+    $selected = array_keys(array_filter($bumpFlags));
+    if (count($selected) > 1) {
+        error('Only one of --major, --minor, or --patch can be specified.');
+    }
+    $bump = $selected[0] ?? 'patch';
+} else {
+    $bump = null;
+}
+
+$mainFile = realpath(PLUGIN_MAIN_FILE);
+if ($mainFile === false || !is_readable($mainFile) || !is_writable($mainFile)) {
+    error('Unable to access plugin main file: ' . PLUGIN_MAIN_FILE);
+}
+
+$content = file_get_contents($mainFile);
+if ($content === false) {
+    error('Unable to read plugin main file.');
+}
+
+$pattern = '/^(\s*\*\s*Version:\s*)([^\r\n]+)(\r?\n)/mi';
+if (!preg_match($pattern, $content, $matches, PREG_OFFSET_CAPTURE)) {
+    error('Unable to locate plugin version header.');
+}
+
+$currentVersion = trim($matches[2][0]);
+
+if ($set !== null) {
+    if (!preg_match('/^\d+\.\d+\.\d+$/', $set)) {
+        error('The --set option requires a semantic version number (e.g. 1.2.3).');
+    }
+    $newVersion = $set;
+} else {
+    if (!preg_match('/^(\d+)\.(\d+)\.(\d+)$/', $currentVersion, $versionParts)) {
+        error('Current version is not in a semantic version format.');
+    }
+
+    $major = (int) $versionParts[1];
+    $minor = (int) $versionParts[2];
+    $patch = (int) $versionParts[3];
+
+    switch ($bump) {
+        case 'major':
+            $major++;
+            $minor = 0;
+            $patch = 0;
+            break;
+        case 'minor':
+            $minor++;
+            $patch = 0;
+            break;
+        case 'patch':
+        default:
+            $patch++;
+            break;
+    }
+
+    $newVersion = sprintf('%d.%d.%d', $major, $minor, $patch);
+}
+
+$replacement = $matches[1][0] . $newVersion . $matches[3][0];
+$content = substr_replace($content, $replacement, $matches[0][1], strlen($matches[0][0]));
+
+if (file_put_contents($mainFile, $content) === false) {
+    error('Unable to write updated plugin file.');
+}
+
+echo $newVersion . PHP_EOL;


### PR DESCRIPTION
## Summary
- enforce PHP 8 requirements in composer metadata and add a build helper script
- add a version bump utility plus release documentation updates
- create packaging workflow, .gitattributes, and GitHub Action to publish release zips

## Testing
- composer validate
- bash build.sh --bump=patch

------
https://chatgpt.com/codex/tasks/task_e_68dd36f57e18832f85b6bf121fb0eb89